### PR TITLE
Make the completion item much better

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,13 +3,15 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="..\:/Users/admin/StudioProjects/CodeAssist/app/src/main/res/layout/main_fragment.xml" value="0.1983695652173913" />
         <entry key="app/src/main/res/font/mono_font.xml" value="0.22708333333333333" />
+        <entry key="app/src/main/res/layout/completion_result_item.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/default_completion_result_item.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/text_compose_panel.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/text_compose_popup_window.xml" value="0.33" />
       </map>
     </option>
   </component>
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/tyron/code/util/AndroidUtilities.java
+++ b/app/src/main/java/com/tyron/code/util/AndroidUtilities.java
@@ -11,6 +11,16 @@ public class AndroidUtilities {
         return Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX,
                 px, ApplicationLoader.applicationContext.getResources().getDisplayMetrics()));
     }
+
+	/**
+	 * Converts a dp value into px that can be applied on margins, paddings etc
+	 * @param dp The dp value that will be converted into px
+	 * @return The converted px value from the dp argument given
+	 */
+	public static int dpToPx(float dp) {
+		return Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
+				dp, ApplicationLoader.applicationContext.getResources().getDisplayMetrics()));
+	}
 	
 	public static int getHeight(ViewGroup viewGroup) {
 

--- a/app/src/main/java/io/github/rosemoe/editor/widget/EditorAutoCompleteWindow.java
+++ b/app/src/main/java/io/github/rosemoe/editor/widget/EditorAutoCompleteWindow.java
@@ -134,7 +134,12 @@ public class EditorAutoCompleteWindow extends EditorBasePopupWindow {
 		};
         mListView.setLayoutManager(mLayoutManager);
         mListView.setAdapter(mAdapter);
-        layout.addView(mListView , new LinearLayout.LayoutParams(-1, -2));
+
+        LinearLayout.LayoutParams mListViewLP = new LinearLayout.LayoutParams(-1, -2);
+        int margin = AndroidUtilities.dpToPx(6);
+        mListViewLP.setMargins(margin, margin, margin, margin);
+
+        layout.addView(mListView, mListViewLP);
         
         layout.setLayoutParams(new ViewGroup.LayoutParams(-1, -2));
 		

--- a/app/src/main/res/layout/completion_result_item.xml
+++ b/app/src/main/res/layout/completion_result_item.xml
@@ -1,59 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="fill_parent"
 	android:layout_height="wrap_content"
 	android:gravity="center_vertical"
 	android:orientation="horizontal"
-	android:paddingStart="8dp"
 	android:paddingTop="4dp"
 	android:paddingBottom="4dp">
 
 	<ImageView
-		android:layout_height="24dp"
+		android:id="@+id/result_item_image"
 		android:layout_width="24dp"
-		android:layout_marginLeft="4dp"
-		android:layout_marginRight="4dp"
-		android:id="@+id/result_item_image"/>
+		android:layout_height="24dp"
+		android:layout_marginStart="4dp"
+		android:layout_marginEnd="4dp" />
 
-	<LinearLayout
+	<TextView
+		android:id="@+id/result_item_label"
+		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
-		android:layout_width="match_parent"
-		android:orientation="horizontal"
-		android:gravity="center_vertical"
-		android:paddingLeft="4dp"
-		android:paddingRight="4dp">
+		android:fontFamily="@font/mono_font"
+		android:layout_marginStart="4dp"
+		android:singleLine="true"
+		android:text="THIS IS A REALLY LONG TEXT THAT SHOULS"
+		android:textColor="#FFFEFEFE"
+		android:textSize="14sp" />
 
-		<LinearLayout
-			android:layout_width="0dp"
-			android:layout_height="wrap_content"
-			android:layout_weight="9">
-
-			<TextView
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:text="THIS IS A REALLY LONG TEXT THAT SHOULS"
-				android:textColor="#FFFEFEFE"
-				android:id="@+id/result_item_label"
-				android:textSize="14sp"
-				android:fontFamily="@font/mono_font"
-				android:singleLine="false"/>
-
-		</LinearLayout>
-
-		<TextView
-			android:gravity="center_vertical"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:text="Small Text"
-			android:id="@+id/result_item_desc"
-			android:textSize="12sp"
-			android:textColor="#FFC9C9C9"
-			android:fontFamily="@font/mono_font"
-			android:layout_marginLeft="8dp"        
-			android:singleLine="false"/>
-
-	</LinearLayout>
+	<TextView
+		android:id="@+id/result_item_desc"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center_vertical"
+		android:layout_marginEnd="8dp"
+		android:layout_marginStart="4dp"
+		android:fontFamily="@font/mono_font"
+		android:singleLine="true"
+		android:ellipsize="end"
+		android:text="Small Text"
+		android:textColor="#808080"
+		android:textSize="12sp" />
 
 </LinearLayout>
 


### PR DESCRIPTION
Made the completion item layout to be a lot better:
 - Removed some unnecessary paddings
 - Moved the package name / small text to be after the completion text
 - Made the package name / small text to be a bit darker
 - Added padding around the list
 - Added padding between the image and the completion text

All of these changes were talked about on discord :hels:

Before:
![image](https://user-images.githubusercontent.com/31884435/131079171-8c80b1d8-0db1-45f9-b230-9aa16a8d6bd4.png)

After:
![image](https://user-images.githubusercontent.com/31884435/131079185-bf9f5ef4-84eb-4d89-b389-7f70897ffcd0.png)
