### PR TITLE
Omit the brackets if the suggested lambda has a single parameter

### DIFF
--- a/app/src/main/java/com/tyron/code/completion/CompletionProvider.java
+++ b/app/src/main/java/com/tyron/code/completion/CompletionProvider.java
@@ -503,7 +503,9 @@ public class CompletionProvider {
                         label.append((label.length() == 0) ? "" : ", ").append(param.getSimpleName());
                     }
 
-                    item.label = "(" + label + ")" + " -> ";
+                    item.label = (sam.getParameters().size() == 1)
+                            ? label + " -> "
+                            : "(" + label + ")" + " -> ";
                     item.commitText = item.label;
                     item.detail = simpleName(sam.getReturnType().toString()).toString();
                     item.cursorOffset = item.label.length();


### PR DESCRIPTION
Auto completion now suggests **"arg0 ->"** instead of **"(arg0) ->"** when there is a single parameter in the lambda.