### PR TITLE
Remove excess app/ from the google-services.json path

### DIFF
--- a/build-logic/src/main/java/com/tyron/builder/compiler/firebase/GenerateFirebaseConfigTask.java
+++ b/build-logic/src/main/java/com/tyron/builder/compiler/firebase/GenerateFirebaseConfigTask.java
@@ -39,7 +39,7 @@ public class GenerateFirebaseConfigTask extends Task<AndroidModule> {
 
     @Override
     public void prepare(BuildType type) throws IOException {
-        mConfigFile = new File(getModule().getRootFile(), "app/google-services.json");
+        mConfigFile = new File(getModule().getRootFile(), "google-services.json");
     }
 
     /**


### PR DESCRIPTION
Remove excess `app/` from the path where `GenerateFirebaseConfigTask` searches for `google-services.json`.