### PR TITLE
feat: Use unique tab titles for files with same names

### DIFF
--- a/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
+++ b/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
@@ -34,6 +34,7 @@ import com.tyron.code.ui.editor.impl.xml.LayoutTextEditorFragment;
 import com.tyron.code.ui.main.MainFragment;
 import com.tyron.code.ui.main.MainViewModel;
 import com.tyron.code.ui.project.ProjectManager;
+import com.tyron.common.util.UniqueNameBuilder;
 import com.tyron.completion.progress.ProgressManager;
 import com.tyron.fileeditor.api.FileEditor;
 import com.tyron.fileeditor.api.FileEditorManager;
@@ -170,17 +171,35 @@ public class EditorContainerFragment extends Fragment implements FileListener,
     }
 
     private void updateTab(TabLayout.Tab tab, int pos) {
-        FileEditor currentEditor = Objects.requireNonNull(mMainViewModel.getFiles()
-                                                                  .getValue())
-                .get(pos);
+        FileEditor currentEditor =
+                Objects.requireNonNull(mMainViewModel.getFiles().getValue()).get(pos);
         File current = currentEditor.getFile();
 
-        String text = current != null ? current.getName() : "Unknown";
+        String text = current != null ? getUniqueTabTitle(current) : "Unknown";
         if (currentEditor.isModified()) {
             text = "*" + text;
         }
 
         tab.setText(text);
+    }
+
+    private String getUniqueTabTitle(@NonNull File currentFile) {
+        int sameFileNameCount = 0;
+        UniqueNameBuilder<File> builder = new UniqueNameBuilder<>("", "/");
+
+        for (FileEditor fileEditor : Objects.requireNonNull(mMainViewModel.getFiles().getValue())) {
+            File openFile = fileEditor.getFile();
+            if (openFile.getName().equals(currentFile.getName())) {
+                sameFileNameCount++;
+            }
+            builder.addPath(openFile, openFile.getPath());
+        }
+
+        if (sameFileNameCount > 1) {
+            return builder.getShortPath(currentFile);
+        } else {
+            return currentFile.getName();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
+++ b/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
@@ -334,13 +334,25 @@ public class EditorContainerFragment extends Fragment implements FileListener,
         updateTab(tab, found);
     }
 
-    @SuppressLint("NotifyDataSetChanged")
+    private boolean requestedToRefreshTabs = false;
+
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         switch (key) {
             case SharedPreferenceKeys.EDITOR_TAB_UNIQUE_FILE_NAME:
-                mAdapter.notifyDataSetChanged();
+                requestedToRefreshTabs = true;
                 break;
+        }
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        if (requestedToRefreshTabs) {
+            requestedToRefreshTabs = false;
+            mAdapter.notifyDataSetChanged();
         }
     }
 }

--- a/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
+++ b/app/src/main/java/com/tyron/code/ui/editor/EditorContainerFragment.java
@@ -334,25 +334,22 @@ public class EditorContainerFragment extends Fragment implements FileListener,
         updateTab(tab, found);
     }
 
-    private boolean requestedToRefreshTabs = false;
-
+    @SuppressLint("NotifyDataSetChanged")
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         switch (key) {
             case SharedPreferenceKeys.EDITOR_TAB_UNIQUE_FILE_NAME:
-                requestedToRefreshTabs = true;
+                if (mAdapter != null) {
+                    mAdapter.notifyDataSetChanged();
+                }
                 break;
         }
     }
 
-    @SuppressLint("NotifyDataSetChanged")
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onDestroy() {
+        super.onDestroy();
 
-        if (requestedToRefreshTabs) {
-            requestedToRefreshTabs = false;
-            mAdapter.notifyDataSetChanged();
-        }
+        ApplicationLoader.getDefaultPreferences().unregisterOnSharedPreferenceChangeListener(this);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@
     <string name="completion_settings_java_title">Java</string>
     <string name="completion_java_target_version_title">Target version</string>
     <string name="completion_java_source_version_title">Source version</string>
+    <string name="editor_tabs_settings_title">Editor Tabs</string>
+    <string name="editor_tab_unique_file_name">Show directory for non-unique file names</string>
 
     <!-- about page -->
     <string name="settings_about_us_title">About Us</string>

--- a/app/src/main/res/xml/editor_preferences.xml
+++ b/app/src/main/res/xml/editor_preferences.xml
@@ -97,4 +97,17 @@
             app:title="@string/editor_scheme_title"
             app:summary="@string/editor_scheme_desc"/>
     </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        android:title="@string/editor_tabs_settings_title">
+
+        <SwitchPreference
+            app:iconSpaceReserved="false"
+            app:defaultValue="true"
+            app:title="@string/editor_tab_unique_file_name"
+            app:key="editor_tab_unique_file_name" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/common/src/main/java/com/tyron/common/SharedPreferenceKeys.java
+++ b/common/src/main/java/com/tyron/common/SharedPreferenceKeys.java
@@ -18,4 +18,5 @@ public class SharedPreferenceKeys {
     public static final String JAVA_CODE_COMPLETION = "code_editor_completion";
     public static final String SCHEME = "scheme";
     public static final String THEME = "theme";
+    public static final String EDITOR_TAB_UNIQUE_FILE_NAME = "editor_tab_unique_file_name";
 }

--- a/common/src/main/java/com/tyron/common/util/UniqueNameBuilder.java
+++ b/common/src/main/java/com/tyron/common/util/UniqueNameBuilder.java
@@ -1,0 +1,179 @@
+package com.tyron.common.util;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Adopted from:
+ * <a href="https://github.com/JetBrains/intellij-community/blob/master/platform/util/base/src/com/intellij/filename/UniqueNameBuilder.java">UniqueNameBuilder.java</a>
+ */
+public final class UniqueNameBuilder<T> {
+    private static final String VFS_SEPARATOR = "/";
+    private final Map<T, String> myPaths = new HashMap<>();
+    private final String mySeparator;
+    private final String myRoot;
+
+    public UniqueNameBuilder(String root, String separator) {
+        myRoot = root;
+        mySeparator = separator;
+    }
+
+    public boolean contains(T file) {
+        return myPaths.containsKey(file);
+    }
+
+    public int size() {
+        return myPaths.size();
+    }
+
+    private static final class Node {
+        final String myText;
+        final HashMap<String, Node> myChildren;
+        final Node myParentNode;
+        int myNestedChildrenCount;
+
+        Node(String text, Node parentNode) {
+            myText = text;
+            myParentNode = parentNode;
+            myChildren = new HashMap<>();
+        }
+
+        Node findOrAddChild(String word) {
+            Node node = myChildren.get(word);
+            if (node == null) myChildren.put(word, node = new Node(word, this));
+            return node;
+        }
+    }
+
+    private final Node myRootNode = new Node("", null);
+
+    // Build a trie from path components starting from end
+    // E.g. following try will be build from example
+    //                                                                                   |<-------[/fabrique]  <-  [/idea]
+    // /idea/pycharm/download/index.html                                                 |
+    // /idea/fabrique/download/index.html           [RootNode] <- [/index.html] <- [/download] <- [/pycharm]  <- [/idea]
+    // /idea/pycharm/documentation/index.html                              |
+    //                                                                     |<------[/documentation] <- [/pycharm]  <- [/idea]
+    public void addPath(T key, String path) {
+        path = trimStart(path, myRoot);
+        myPaths.put(key, path);
+
+        Node current = myRootNode;
+        Iterator<String> pathComponentsIterator = new PathComponentsIterator(path);
+
+        while (pathComponentsIterator.hasNext()) {
+            String word = pathComponentsIterator.next();
+            current = current.findOrAddChild(word);
+        }
+        for (Node c = current; c != null; c = c.myParentNode) ++c.myNestedChildrenCount;
+    }
+
+    private static String trimStart(String s, String prefix) {
+        if (s.startsWith(prefix)) {
+            return s.substring(prefix.length());
+        }
+        return s;
+    }
+
+    public String getShortPath(T key) {
+        String path = myPaths.get(key);
+        if (path == null) return key.toString();
+
+        Node current = myRootNode;
+        Node firstNodeWithBranches = null;
+        Node firstNodeBeforeNodeWithBranches = null;
+        Node fileNameNode = null;
+
+        Iterator<String> pathComponentsIterator = new PathComponentsIterator(path);
+
+        while (pathComponentsIterator.hasNext()) {
+            String pathComponent = pathComponentsIterator.next();
+            current = current.findOrAddChild(pathComponent);
+
+            if (fileNameNode == null) fileNameNode = current;
+            if (firstNodeBeforeNodeWithBranches == null &&
+                firstNodeWithBranches != null &&
+                current.myChildren.size() <= 1) {
+                if (current.myParentNode.myNestedChildrenCount - current.myParentNode.myChildren.size() < 1) {
+                    firstNodeBeforeNodeWithBranches = current;
+                }
+            }
+
+            if (current.myChildren.size() != 1 && firstNodeWithBranches == null) {
+                firstNodeWithBranches = current;
+            }
+        }
+
+        StringBuilder b = new StringBuilder();
+        if (firstNodeBeforeNodeWithBranches == null) {
+            firstNodeBeforeNodeWithBranches = current;
+        }
+
+        boolean skipFirstSeparator = true;
+        for (Node c = firstNodeBeforeNodeWithBranches; c != myRootNode; c = c.myParentNode) {
+            if (c != fileNameNode && c != firstNodeBeforeNodeWithBranches && c.myParentNode.myChildren.size() == 1) {
+                b.append(mySeparator);
+                b.append("\u2026");
+
+                while (c.myParentNode != fileNameNode && c.myParentNode.myChildren.size() == 1) c = c.myParentNode;
+            }
+            else {
+                if (c.myText.startsWith(VFS_SEPARATOR)) {
+                    if (!skipFirstSeparator) b.append(mySeparator);
+                    skipFirstSeparator = false;
+                    b.append(c.myText, VFS_SEPARATOR.length(), c.myText.length());
+                }
+                else {
+                    b.append(c.myText);
+                }
+            }
+        }
+        return b.toString();
+    }
+
+    public String getSeparator() {
+        return mySeparator;
+    }
+
+    private static final class PathComponentsIterator implements Iterator<String> {
+        private final String myPath;
+        private int myLastPos;
+        private int mySeparatorPos;
+
+        PathComponentsIterator(String path) {
+            myPath = path;
+            myLastPos = path.length();
+            mySeparatorPos = path.lastIndexOf(VFS_SEPARATOR);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return myLastPos != 0;
+        }
+
+        @Override
+        public String next() {
+            if (myLastPos == 0) throw new NoSuchElementException();
+            String pathComponent;
+
+            if (mySeparatorPos != -1) {
+                pathComponent = myPath.substring(mySeparatorPos, myLastPos);
+                myLastPos = mySeparatorPos;
+                mySeparatorPos = myPath.lastIndexOf(VFS_SEPARATOR, myLastPos - 1);
+            }
+            else {
+                pathComponent = myPath.substring(0, myLastPos);
+                if (!pathComponent.startsWith(VFS_SEPARATOR)) pathComponent = VFS_SEPARATOR + pathComponent;
+                myLastPos = 0;
+            }
+            return pathComponent;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("remove");
+        }
+    }
+}


### PR DESCRIPTION
Displays unique tab titles for files with same names under different folders, using [UniqueNameBuilder.java](https://github.com/JetBrains/intellij-community/blob/master/platform/util/base/src/com/intellij/filename/UniqueNameBuilder.java) from IntelliJ. (which, FWIW, has tests [here](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-tests/testSrc/com/intellij/openapi/fileEditor/UniqueNameBuilderTest.java), I can add them as well if you want.)

Preview             |  File structure
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/45513948/158058436-6299f26a-467d-47d0-a986-aaf8c4118ebd.png" width="300">  |  <img src="https://user-images.githubusercontent.com/45513948/158058438-ae2fee59-ad55-44be-bc79-371c85bc383e.png" width="300">


