### PR TITLE
feat: Show completion window on XML attribute inserted

### DIFF
--- a/app/src/main/java/com/tyron/code/ui/editor/impl/text/rosemoe/CodeEditorView.java
+++ b/app/src/main/java/com/tyron/code/ui/editor/impl/text/rosemoe/CodeEditorView.java
@@ -79,6 +79,7 @@ public class CodeEditorView extends CodeEditor implements Editor {
     private EditorViewModel mViewModel;
 
     private final Paint mDiagnosticPaint;
+    private CodeAssistCompletionWindow mCompletionWindow;
 
     public CodeEditorView(Context context) {
         this(DataContext.wrap(context), null);
@@ -129,9 +130,9 @@ public class CodeEditorView extends CodeEditor implements Editor {
     }
 
     private void init() {
-        CodeAssistCompletionWindow window = new CodeAssistCompletionWindow(this);
-        window.setAdapter(new CodeAssistCompletionAdapter());
-        replaceComponent(EditorAutoCompletion.class, window);
+        mCompletionWindow = new CodeAssistCompletionWindow(this);
+        mCompletionWindow.setAdapter(new CodeAssistCompletionAdapter());
+        replaceComponent(EditorAutoCompletion.class, mCompletionWindow);
         replaceComponent(EditorTextActionWindow.class, new NoOpTextActionWindow(this));
     }
 
@@ -439,6 +440,11 @@ public class CodeEditorView extends CodeEditor implements Editor {
         if (mViewModel != null) {
             mViewModel.setAnalyzeState(analyzing);
         }
+    }
+
+    @Override
+    public void requireCompletion() {
+        mCompletionWindow.requireCompletion();
     }
 
     public void setViewModel(EditorViewModel editorViewModel) {

--- a/editor-api/src/main/java/com/tyron/editor/Editor.java
+++ b/editor-api/src/main/java/com/tyron/editor/Editor.java
@@ -153,4 +153,6 @@ public interface Editor {
      * @param analyzing whether to show the progress bar.
      */
     void setAnalyzing(boolean analyzing);
+
+    void requireCompletion();
 }

--- a/xml-completion/src/main/java/com/tyron/completion/xml/insert/AttributeInsertHandler.java
+++ b/xml-completion/src/main/java/com/tyron/completion/xml/insert/AttributeInsertHandler.java
@@ -1,6 +1,7 @@
 package com.tyron.completion.xml.insert;
 
 import com.tyron.completion.model.CompletionItem;
+import com.tyron.completion.progress.ProgressManager;
 import com.tyron.editor.Caret;
 import com.tyron.editor.Editor;
 
@@ -52,6 +53,10 @@ public class AttributeInsertHandler extends DefaultXmlInsertHandler {
         if (mValueToInsert != null) {
             super.insert(mValueToInsert, editor, false);
             editor.setSelection(caret.getStartLine(), caret.getStartColumn() + 1);
+        } else {
+            // show completion window for enum/flag values.
+            // the delay must be greater than DirectAccessProps.cancelCompletionNs
+            ProgressManager.getInstance().runLater(editor::requireCompletion, 120);
         }
     }
 }


### PR DESCRIPTION
Show the completion window when an attribute is inserted to list possible enum/flag values & whatnots, mimicking Android Studio's behavior. 

The delay I chose is arbitrary but as long as it's greater than `DirectAccessProps.cancelCompletionNs` (which is 70ms by default), it can be changed.