### PR TITLE
chore: use assembleDebug in github actions

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build debug apk
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: assembleRelease
+          arguments: assembleDebug
           distributions-cache-enabled: true
           dependencies-cache-enabled: true
           configuration-cache-enabled: true


### PR DESCRIPTION
![Screenshot_20220514-084728](https://user-images.githubusercontent.com/105044576/168415904-2600231f-e18d-4f15-a6bc-6979046e7303.png)


Okay I don't know for sure if I created a pull request correctly, nor do I know if this problem was applicable to GitHub, StackOverflow or the general documentation from the App itself. 

The XML file I wanted to open originated from Android Studio v2.X and it is the "main_acticity.xml.flat" (Though honestly I don't know what the ".flat" extention really is)  But there is a problem rendering that file, or any XML, created by Android Studio. It adds many different characters. Why?