### PR TITLE
fix: Convert gravity flags to String properly on XML conversion

### DIFF
--- a/layout-preview/proteus-core/build.gradle
+++ b/layout-preview/proteus-core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
 }
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -24,6 +25,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+}
+
+configurations.implementation {
+    exclude group: "org.jetbrains", module: "annotations"
 }
 
 dependencies {

--- a/layout-preview/proteus-core/build.gradle
+++ b/layout-preview/proteus-core/build.gradle
@@ -40,4 +40,6 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    testImplementation "com.google.truth:truth:1.1.3"
 }

--- a/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/util/GravityIntMapping.kt
+++ b/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/util/GravityIntMapping.kt
@@ -1,0 +1,75 @@
+package com.flipkart.android.proteus.util
+
+const val GRAVITY_CENTER_VERTICAL = 0x10
+const val GRAVITY_TOP = 0x30
+const val GRAVITY_BOTTOM = 0x50
+const val GRAVITY_FILL_VERTICAL = 0x70
+const val GRAVITY_CENTER_HORIZONTAL = 0x01
+const val GRAVITY_LEFT = 0x03
+const val GRAVITY_RIGHT = 0x05
+const val GRAVITY_FILL_HORIZONTAL = 0x07
+const val GRAVITY_CENTER = 0x11
+const val GRAVITY_FILL = 0x77
+const val GRAVITY_CLIP_HORIZONTAL = 0x08
+const val GRAVITY_CLIP_VERTICAL = 0x80
+const val GRAVITY_RTL_FLAG = 0x800000
+const val GRAVITY_START = 0x800003
+const val GRAVITY_END = 0x800005
+
+// region CodeAssist added
+const val GRAVITY_VALUE_CENTER = "center"
+const val GRAVITY_VALUE_LEFT = "left"
+const val GRAVITY_VALUE_RIGHT = "right"
+const val GRAVITY_VALUE_START = "start"
+const val GRAVITY_VALUE_END = "end"
+const val GRAVITY_VALUE_BOTTOM = "bottom"
+const val GRAVITY_VALUE_TOP = "top"
+const val GRAVITY_VALUE_FILL_HORIZONTAL = "fill_horizontal"
+const val GRAVITY_VALUE_FILL_VERTICAL = "fill_vertical"
+const val GRAVITY_VALUE_CENTER_HORIZONTAL = "center_horizontal"
+const val GRAVITY_VALUE_CENTER_VERTICAL = "center_vertical"
+const val GRAVITY_VALUE_CLIP_HORIZONTAL = "clip_horizontal"
+const val GRAVITY_VALUE_CLIP_VERTICAL = "clip_vertical"
+const val GRAVITY_VALUE_FILL = "fill"
+// endregion
+
+/**
+ * Utility for mapping an integer gravity value to a user readable string.
+ *
+ * CodeAssist: Adapted from com.android.tools.idea.layoutinspector.pipeline.legacy.GravityIntMapping
+ */
+class GravityIntMapping {
+  private val intMapping = IntFlagMapping()
+
+  fun fromIntValue(value: Int): Set<String> {
+    val values = intMapping.of(value)
+    if ((value and GRAVITY_RTL_FLAG) != 0) {
+      if (values.remove(GRAVITY_VALUE_LEFT)) {
+        values.add(GRAVITY_VALUE_START)
+      }
+      if (values.remove(GRAVITY_VALUE_RIGHT)) {
+        values.add(GRAVITY_VALUE_END)
+      }
+    }
+    return values
+  }
+
+  init {
+    intMapping.add(GRAVITY_FILL, GRAVITY_FILL, GRAVITY_VALUE_FILL)
+
+    intMapping.add(GRAVITY_FILL_VERTICAL, GRAVITY_FILL_VERTICAL, GRAVITY_VALUE_FILL_VERTICAL)
+    intMapping.add(GRAVITY_FILL_VERTICAL, GRAVITY_TOP, GRAVITY_VALUE_TOP)
+    intMapping.add(GRAVITY_FILL_VERTICAL, GRAVITY_BOTTOM, GRAVITY_VALUE_BOTTOM)
+
+    intMapping.add(GRAVITY_FILL_HORIZONTAL, GRAVITY_FILL_HORIZONTAL, GRAVITY_VALUE_FILL_HORIZONTAL)
+    intMapping.add(GRAVITY_FILL_HORIZONTAL, GRAVITY_LEFT, GRAVITY_VALUE_LEFT)
+    intMapping.add(GRAVITY_FILL_HORIZONTAL, GRAVITY_RIGHT, GRAVITY_VALUE_RIGHT)
+
+    intMapping.add(GRAVITY_FILL, GRAVITY_CENTER, GRAVITY_VALUE_CENTER)
+    intMapping.add(GRAVITY_FILL_VERTICAL, GRAVITY_CENTER_VERTICAL, GRAVITY_VALUE_CENTER_VERTICAL)
+    intMapping.add(GRAVITY_FILL_HORIZONTAL, GRAVITY_CENTER_HORIZONTAL, GRAVITY_VALUE_CENTER_HORIZONTAL)
+
+    intMapping.add(GRAVITY_CLIP_VERTICAL, GRAVITY_CLIP_VERTICAL, GRAVITY_VALUE_CLIP_VERTICAL)
+    intMapping.add(GRAVITY_CLIP_HORIZONTAL, GRAVITY_CLIP_HORIZONTAL, GRAVITY_VALUE_CLIP_HORIZONTAL)
+  }
+}

--- a/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/util/IntFlagMapping.kt
+++ b/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/util/IntFlagMapping.kt
@@ -1,0 +1,59 @@
+package com.flipkart.android.proteus.util
+
+import java.util.ArrayList
+
+/**
+ * Loose adoption of android.view.inspector.IntFlagMapping
+ *
+ * CodeAssist: Adopted from com.android.tools.idea.layoutinspector.pipeline.legacy.IntFlagMapping
+ */
+class IntFlagMapping {
+  private val flags = ArrayList<Flag>()
+
+  /**
+   * Get a set of the names of enabled flags for a given property value.
+   *
+   * @param value The value of the property
+   * @return The names of the enabled flags, empty if no flags enabled
+   */
+  fun of(value: Int): MutableSet<String> {
+    val enabledFlagNames = mutableSetOf<String>()
+    var alreadyIncluded = 0
+
+    for (flag in flags) {
+      if (flag.isEnabledFor(value) && (alreadyIncluded and flag.target != flag.target)) {
+        enabledFlagNames.add(flag.name)
+        alreadyIncluded = alreadyIncluded or flag.target
+      }
+    }
+
+    return enabledFlagNames
+  }
+
+  /**
+   * Add a flag to the map.
+   *
+   * @param mask The bit mask to compare to and with a value
+   * @param target The target value to compare the masked value with
+   * @param name The name of the flag to include if enabled
+   */
+  fun add(mask: Int, target: Int, name: String) {
+    flags.add(Flag(mask, target, name))
+  }
+
+  /**
+   * Inner class that holds the name, mask, and target value of a flag
+   */
+  private class Flag(private val mask: Int, val target: Int, val name: String) {
+
+    /**
+     * Compare the supplied property value against the mask and target.
+     *
+     * @param value The value to check
+     * @return True if this flag is enabled
+     */
+    fun isEnabledFor(value: Int): Boolean {
+      return value and mask == target
+    }
+  }
+}

--- a/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/value/Gravity.java
+++ b/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/value/Gravity.java
@@ -5,25 +5,8 @@ import androidx.annotation.NonNull;
 import com.flipkart.android.proteus.parser.ParseHelper;
 import com.flipkart.android.proteus.util.GravityIntMapping;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 public class Gravity extends Value {
-
-    private static final Map<Integer, String> GRAVITY_VALUES = new LinkedHashMap<>();
     private final GravityIntMapping gravityIntMapping = new GravityIntMapping();
-
-    static {
-        GRAVITY_VALUES.put(android.view.Gravity.LEFT, "left");
-        GRAVITY_VALUES.put(android.view.Gravity.RIGHT, "right");
-        GRAVITY_VALUES.put(android.view.Gravity.TOP, "top");
-        GRAVITY_VALUES.put(android.view.Gravity.BOTTOM, "bottom");
-        GRAVITY_VALUES.put(android.view.Gravity.START, "start");
-        GRAVITY_VALUES.put(android.view.Gravity.END, "end");
-        GRAVITY_VALUES.put(android.view.Gravity.CENTER, "center");
-        GRAVITY_VALUES.put(android.view.Gravity.CENTER_HORIZONTAL, "center_horizontal");
-        GRAVITY_VALUES.put(android.view.Gravity.CENTER_VERTICAL, "center_vertical");
-    }
 
     private final int gravity;
 

--- a/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/value/Gravity.java
+++ b/layout-preview/proteus-core/src/main/java/com/flipkart/android/proteus/value/Gravity.java
@@ -1,16 +1,17 @@
 package com.flipkart.android.proteus.value;
 
 import androidx.annotation.NonNull;
-import androidx.core.view.GravityCompat;
 
 import com.flipkart.android.proteus.parser.ParseHelper;
+import com.flipkart.android.proteus.util.GravityIntMapping;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Gravity extends Value {
 
-    private static final Map<Integer, String> GRAVITY_VALUES = new HashMap<>();
+    private static final Map<Integer, String> GRAVITY_VALUES = new LinkedHashMap<>();
+    private final GravityIntMapping gravityIntMapping = new GravityIntMapping();
 
     static {
         GRAVITY_VALUES.put(android.view.Gravity.LEFT, "left");
@@ -45,16 +46,7 @@ public class Gravity extends Value {
 
     @Override
     public String getAsString() {
-        StringBuilder sb = new StringBuilder();
-
-
-        GRAVITY_VALUES.forEach((k, v) -> {
-            if ((gravity & k) == k) {
-                sb.append(v);
-                sb.append("|");
-            }
-        });
-        return sb.substring(0, sb.length() - 1);
+        return String.join("|", gravityIntMapping.fromIntValue(gravity));
     }
 
     @Override

--- a/layout-preview/proteus-core/src/test/java/com/flipkart/GravityIntMappingTest.kt
+++ b/layout-preview/proteus-core/src/test/java/com/flipkart/GravityIntMappingTest.kt
@@ -1,0 +1,49 @@
+package com.flipkart
+
+import com.flipkart.android.proteus.util.*
+import com.flipkart.android.proteus.util.GravityIntMapping
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * CodeAssist: Adopted from com.android.tools.idea.layoutinspector.pipeline.legacy.GravityIntMappingTest
+ */
+class GravityIntMappingTest {
+  private val mapping by lazy(LazyThreadSafetyMode.NONE) { GravityIntMapping() }
+
+  @Test
+  fun testLeftOverridesCenter() {
+    assertThat(mapping.fromIntValue(GRAVITY_CENTER or GRAVITY_LEFT))
+      .containsExactly(GRAVITY_VALUE_CENTER_VERTICAL, GRAVITY_VALUE_LEFT)
+  }
+
+  @Test
+  fun testTopBottomBecomesVerticalFill() {
+    assertThat(mapping.fromIntValue(GRAVITY_TOP or GRAVITY_BOTTOM or GRAVITY_START))
+      .containsExactly(GRAVITY_VALUE_FILL_VERTICAL, GRAVITY_VALUE_START)
+  }
+
+  @Test
+  fun testLeftRightBecomesHorizontalFill() {
+    assertThat(mapping.fromIntValue(GRAVITY_TOP or GRAVITY_LEFT or GRAVITY_RIGHT))
+      .containsExactly(GRAVITY_VALUE_TOP, GRAVITY_VALUE_FILL_HORIZONTAL)
+  }
+
+  @Test
+  fun testStartEndBecomesHorizontalFill() {
+    assertThat(mapping.fromIntValue(GRAVITY_TOP or GRAVITY_START or GRAVITY_END))
+      .containsExactly(GRAVITY_VALUE_TOP, GRAVITY_VALUE_FILL_HORIZONTAL)
+  }
+
+  @Test
+  fun testTopBottomLeftRightSimplyBecomesFill() {
+    assertThat(mapping.fromIntValue(GRAVITY_TOP or GRAVITY_BOTTOM or GRAVITY_LEFT or GRAVITY_RIGHT))
+      .containsExactly(GRAVITY_VALUE_FILL)
+  }
+
+  @Test
+  fun testVerticalAndHorizontalCenterSimplyBecomesCenter() {
+    assertThat(mapping.fromIntValue(GRAVITY_CENTER_VERTICAL or GRAVITY_CENTER_HORIZONTAL))
+      .containsExactly(GRAVITY_VALUE_CENTER)
+  }
+}


### PR DESCRIPTION
Fixes a bug where when we save a layout from Layout Preview, Proteus adds unnecessary gravity fields like `center|center_horizontal|center_vertical` in the XML output.

Copied/ported over from [Android Studio's internals](https://cs.android.com/android-studio/platform/tools/adt/idea/+/mirror-goog-studio-main:layout-inspector/src/com/android/tools/idea/layoutinspector/pipeline/legacy/).

Marked as draft since Layout Preview feature is currently disabled.