### PR TITLE
F-Droid/IzzyOnDroid distribution metadata + versionName 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ docs/jdt-name-environment.md
 docs/kotlin-compiler-on-art.md
 docs/kotlin-completion-backend.md
 docs/xml-language-support.md
+docs/codeassist-layout-preview-design.md
 docs/handoff_onboarding_compose/
 docs/design/
 docs/*.png

--- a/README.md
+++ b/README.md
@@ -178,4 +178,12 @@ via the `regressionTest` tasks against committed JSON baselines.
 
 ## License
 
-CodeAssist is licensed under the **GNU General Public License v3.0**. See [LICENSE](LICENSE).
+CodeAssist is free software licensed under the **GNU General Public License v3.0 or later**
+(`GPL-3.0-or-later`). See [LICENSE](LICENSE).
+
+## Install
+
+- **Google Play** — testing track (signed via Play App Signing).
+- **F-Droid / IzzyOnDroid** — built from this repo, signed with the project's own key. See
+  [docs/fdroid-izzyondroid.md](docs/fdroid-izzyondroid.md). (The IzzyOnDroid and Play builds have
+  different signatures and cannot update across stores.)

--- a/android-support/build.gradle.kts
+++ b/android-support/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(project(":project-model-impl")) // FacetCodec / FacetCodecRegistry / ModuleTypeRegistry
     implementation(project(":language-api"))   // SyntheticClassProvider — the light `R` class for completion/analysis
     implementation(project(":index-api"))       // resource-declaration IndexExtension
+    implementation(libs.ow2.asm)                 // ClassReader — scan the classpath for custom View subclasses (no class loading)
     implementation(libs.kotlinx.coroutines.core)
 
     // D8 (r8) + apksigner (apksig) are invoked IN-PROCESS by the on-device wiring, so they're statically

--- a/android-support/src/main/kotlin/dev/ide/android/support/AndroidBuildSystem.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/AndroidBuildSystem.kt
@@ -143,7 +143,10 @@ class AndroidBuildSystem(
 
         val closure = moduleClosure(app, byId)
         val depAndroidLibs = closure.filter { it.facets.get(AndroidFacet.KEY) != null }
-        val extraPackages = depAndroidLibs.mapNotNull { it.facets.get(AndroidFacet.KEY)?.namespace }.distinct()
+        // R is generated for every dependency-lib package AND every external AAR package (so an AAR's own
+        // classes + custom-view attrs resolve against the app-linked resource table).
+        val extraPackages = (depAndroidLibs.mapNotNull { it.facets.get(AndroidFacet.KEY)?.namespace } +
+            libs.aarPackages).distinct()
 
         val mergeResInputs = depAndroidLibs.flatMap { moduleRoots(it, ContentRole.ANDROID_RES) } +
             libs.resDirs + roots(variant, ContentRole.ANDROID_RES)

--- a/android-support/src/main/kotlin/dev/ide/android/support/AndroidLibraries.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/AndroidLibraries.kt
@@ -4,6 +4,7 @@ import dev.ide.android.support.tools.AarExtractor
 import dev.ide.model.ClasspathEntryKind
 import dev.ide.model.DependencyScope
 import dev.ide.model.Module
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -14,6 +15,7 @@ class ResolvedLibraries(
     val resDirs: List<Path>,       // AAR `res/` merged by aapt2
     val assetsDirs: List<Path>,    // AAR `assets/` packaged under `assets/`
     val jniLibDirs: List<Path>,    // AAR `jni/<abi>/` packaged under `lib/`
+    val aarPackages: List<String>, // AAR manifest packages → aapt2 `--extra-packages` (their `R` + custom attrs)
 )
 
 /**
@@ -37,26 +39,36 @@ object AndroidLibraries {
         val resDirs = ArrayList<Path>()
         val assetsDirs = ArrayList<Path>()
         val jniLibDirs = ArrayList<Path>()
+        val aarPackages = ArrayList<String>()
 
         val cache = HashMap<Path, AarExtractor.Exploded>()
         fun explode(aar: Path) = cache.getOrPut(aar) { AarExtractor.explode(aar, explodeRoot.resolve(dirNameOf(aar))) }
 
+        fun addAarParts(classesJars: List<Path>, res: Path?, assets: Path?, jni: Path?, manifest: Path?) {
+            compileJars.addAll(classesJars)
+            res?.let { resDirs.add(it) }
+            assets?.let { assetsDirs.add(it) }
+            jni?.let { jniLibDirs.add(it) }
+            manifest?.let { manifestPackage(it)?.let(aarPackages::add) }
+        }
+
         for (root in compileRoots) when {
-            isAar(root) -> {
-                val e = explode(root)
-                compileJars.addAll(e.classesJars)
-                e.resDir?.let { resDirs.add(it) }
-                e.assetsDir?.let { assetsDirs.add(it) }
-                e.jniDir?.let { jniLibDirs.add(it) }
+            isAar(root) -> explode(root).let { addAarParts(it.classesJars, it.resDir, it.assetsDir, it.jniDir, it.manifest) }
+            // A Maven-resolved AAR is stored as its exploded `classes.jar`; its res/assets/jni/manifest are siblings.
+            isExplodedAar(root) -> root.parent.let { dir ->
+                addAarParts(listOf(root), dirOrNull(dir, "res"), dirOrNull(dir, "assets"), dirOrNull(dir, "jni"),
+                    dir.resolve("AndroidManifest.xml").takeIf { Files.isRegularFile(it) })
             }
             isJar(root) -> compileJars.add(root)
         }
         for (root in runtimeRoots) when {
             isAar(root) -> dexJars.addAll(explode(root).classesJars)
+            isExplodedAar(root) -> dexJars.add(root)
             isJar(root) -> dexJars.add(root)
         }
         return ResolvedLibraries(
-            compileJars.distinct(), dexJars.distinct(), resDirs.distinct(), assetsDirs.distinct(), jniLibDirs.distinct(),
+            compileJars.distinct(), dexJars.distinct(), resDirs.distinct(), assetsDirs.distinct(),
+            jniLibDirs.distinct(), aarPackages.distinct(),
         )
     }
 
@@ -68,4 +80,22 @@ object AndroidLibraries {
     private fun isAar(p: Path) = p.toString().endsWith(".aar", ignoreCase = true)
     private fun isJar(p: Path) = p.toString().endsWith(".jar", ignoreCase = true)
     private fun dirNameOf(aar: Path): String = aar.fileName.toString().substringBeforeLast('.')
+
+    /**
+     * A `classes.jar` that the dependency resolver already exploded out of an AAR — recognised by the
+     * `res/`/`assets/`/manifest siblings (or the resolver's `.extracted` marker) sitting next to it. The
+     * model stores AARs by this exploded jar (not the `.aar`), so this is the common Maven-dependency form.
+     */
+    private fun isExplodedAar(p: Path): Boolean = p.fileName?.toString() == "classes.jar" && p.parent?.let { dir ->
+        Files.isRegularFile(dir.resolve(".extracted")) || Files.isDirectory(dir.resolve("res")) ||
+            Files.isRegularFile(dir.resolve("AndroidManifest.xml"))
+    } == true
+
+    private fun dirOrNull(parent: Path, name: String): Path? = parent.resolve(name).takeIf { Files.isDirectory(it) }
+
+    /** The `package` attribute of an AAR's bundled `AndroidManifest.xml`, fed to aapt2 `--extra-packages`. */
+    private fun manifestPackage(manifest: Path): String? = runCatching {
+        val text = Files.readAllBytes(manifest).toString(Charsets.UTF_8)
+        Regex("""<manifest\b[^>]*\bpackage\s*=\s*"([^"]+)"""").find(text)?.groupValues?.get(1)
+    }.getOrNull()
 }

--- a/android-support/src/main/kotlin/dev/ide/android/support/AndroidRClassProvider.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/AndroidRClassProvider.kt
@@ -1,18 +1,25 @@
 package dev.ide.android.support
 
 import dev.ide.android.support.resources.AndroidResources
+import dev.ide.android.support.resources.RIdAssignment
 import dev.ide.android.support.resources.ResourceModel
+import dev.ide.android.support.resources.ResourceType
 import dev.ide.lang.synthetic.SyntheticClass
 import dev.ide.lang.synthetic.SyntheticClassContext
 import dev.ide.lang.synthetic.SyntheticClassProvider
 import dev.ide.lang.synthetic.SyntheticField
 
 /**
- * Contributes the light `R` class for an Android module — `<namespace>.R` with a nested class per
- * resource type (`layout`, `string`, `id`, `drawable`, …), each an `int` field per resource — generated
- * from the module's merged [dev.ide.android.support.resources.ResourceRepository] (its own `res/` plus its
- * android-lib dependencies'). So `R.layout.activity_main` resolves iff that resource actually exists. No
- * aapt2, no build: a fast, SDK-free stand-in for completion + analysis, parsed by the [ResourceModel] port.
+ * Contributes the light `R` class for an Android module — `<namespace>.R` with a nested class per resource
+ * type (`layout`, `string`, `id`, `drawable`, …), each an `int` field per resource — generated from the
+ * module's merged [dev.ide.android.support.resources.ResourceRepository] (its own `res/` plus its android-lib
+ * dependencies'). So `R.layout.activity_main` resolves iff that resource actually exists. No aapt2, no build:
+ * a fast, SDK-free stand-in for completion + analysis, parsed by the [ResourceModel] port.
+ *
+ * Fields carry **stable, deterministic int ids** ([RIdAssignment]), and `R.styleable.<Name>` is emitted as a
+ * real `int[]` (the attr ids in declaration order) plus the `<Name>_<attr>` index constants, so a custom
+ * view's `obtainStyledAttributes(attrs, R.styleable.MyChart, …)` compiles to the same ints the layout
+ * preview's bridge maps back from at runtime.
  */
 class AndroidRClassProvider(private val model: ResourceModel = ResourceModel.DEFAULT) : SyntheticClassProvider {
 
@@ -22,13 +29,37 @@ class AndroidRClassProvider(private val model: ResourceModel = ResourceModel.DEF
 
         val repo = AndroidResources.repository(context.module, context.workspace, model)
         if (repo.isEmpty()) return emptyList()
+        val ids = RIdAssignment(repo)
 
         val nested = repo.types().sortedBy { it.rClass }.map { type ->
-            SyntheticClass(
+            if (type == ResourceType.STYLEABLE) styleableClass(facet.namespace, repo, ids)
+            else SyntheticClass(
                 fqName = "${facet.namespace}.R.${type.rClass}",
-                fields = repo.names(type).sorted().map { SyntheticField(it) },
+                fields = repo.names(type).sorted().map { name ->
+                    SyntheticField(name, constant = hex(ids.id(type, name)))
+                },
             )
         }
         return listOf(SyntheticClass(fqName = "${facet.namespace}.R", nestedClasses = nested, doc = "Resource identifiers (synthetic R)"))
     }
+
+    /** `R.styleable`: each `<declare-styleable>` becomes an `int[]` of its attr ids + per-attr index constants. */
+    private fun styleableClass(namespace: String, repo: dev.ide.android.support.resources.ResourceRepository, ids: RIdAssignment): SyntheticClass {
+        val fields = ArrayList<SyntheticField>()
+        for (styleable in repo.names(ResourceType.STYLEABLE).sorted()) {
+            val attrs = repo.styleableAttrs(styleable)
+            val array = ids.styleableArray(repo, styleable)
+            fields += SyntheticField(
+                name = styleable,
+                type = "int[]",
+                constant = array.joinToString(prefix = "{ ", postfix = " }") { hex(it) }.let { if (array.isEmpty()) "{}" else it },
+            )
+            attrs.forEachIndexed { index, attr ->
+                fields += SyntheticField("${styleable}_$attr", constant = index.toString())
+            }
+        }
+        return SyntheticClass(fqName = "$namespace.R.styleable", fields = fields)
+    }
+
+    private fun hex(id: Int?): String = if (id == null) "0" else "0x%08x".format(id)
 }

--- a/android-support/src/main/kotlin/dev/ide/android/support/AndroidSupport.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/AndroidSupport.kt
@@ -2,6 +2,7 @@ package dev.ide.android.support
 
 import dev.ide.android.support.templates.AndroidAppTemplate
 import dev.ide.android.support.templates.AndroidLibraryTemplate
+import dev.ide.android.support.templates.MaterialYouAppTemplate
 import dev.ide.model.impl.FacetCodecRegistry
 import dev.ide.model.impl.FileIconRegistry
 import dev.ide.model.impl.ModuleTypeRegistry
@@ -28,9 +29,10 @@ object AndroidSupport {
         icons.register(AndroidFileIconProvider, PLUGIN)
     }
 
-    /** Contribute the Android project templates (app + library) to a host's Create-Project gallery. */
+    /** Contribute the Android project templates (app, Material You app, library) to a host's Create-Project gallery. */
     fun registerTemplates(templates: ProjectTemplateRegistry) {
         templates.register(AndroidAppTemplate, PLUGIN)
+        templates.register(MaterialYouAppTemplate, PLUGIN)
         templates.register(AndroidLibraryTemplate, PLUGIN)
     }
 }

--- a/android-support/src/main/kotlin/dev/ide/android/support/SampleAndroidProject.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/SampleAndroidProject.kt
@@ -59,10 +59,13 @@ object SampleAndroidProject {
         write(store, "app/src/main/res/values/colors.xml", APP_COLORS)
         write(store, "app/src/main/res/values/themes.xml", dev.ide.android.support.templates.AndroidAppAssets.themesXml)
         write(store, "app/src/main/res/values-night/themes.xml", dev.ide.android.support.templates.AndroidAppAssets.themesNightXml)
+        write(store, "app/src/main/res/values/attrs.xml", APP_ATTRS)
+        write(store, "app/src/main/res/layout/activity_main.xml", APP_LAYOUT)
         for ((rel, content) in dev.ide.android.support.templates.AndroidAppAssets.launcherIconResFiles) {
             write(store, "app/src/main/res/$rel", content)
         }
         write(store, "app/src/main/java/com/example/app/MainActivity.java", APP_ACTIVITY)
+        write(store, "app/src/main/java/com/example/app/MyChart.java", APP_CUSTOM_VIEW)
     }
 
     private fun write(store: ProjectModelStore, relPath: String, content: String) {
@@ -134,6 +137,81 @@ object SampleAndroidProject {
             <color name="on_primary">#FFFFFFFF</color>
             <color name="ic_launcher_background">#3DDC84</color>
         </resources>
+    """
+
+    private val APP_ATTRS = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <resources>
+            <declare-styleable name="MyChart">
+                <attr name="barColor" format="color"/>
+                <attr name="maxValue" format="integer"/>
+                <attr name="chartLabel" format="string"/>
+            </declare-styleable>
+        </resources>
+    """
+
+    private val APP_LAYOUT = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:background="@color/on_primary">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/greeting"
+                android:textColor="@color/primary"
+                android:textSize="20sp"/>
+            <com.example.app.MyChart
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                app:barColor="@color/primary"
+                app:maxValue="100"
+                app:chartLabel="Revenue"/>
+        </LinearLayout>
+    """
+
+    private val APP_CUSTOM_VIEW = """
+        package com.example.app;
+
+        import android.content.Context;
+        import android.content.res.TypedArray;
+        import android.graphics.Canvas;
+        import android.graphics.Paint;
+        import android.util.AttributeSet;
+        import android.view.View;
+
+        /** A tiny custom view with custom app: attributes — the layout-preview acceptance fixture. */
+        public class MyChart extends View {
+            private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            private int barColor = 0xFF6200EE;
+            private int maxValue = 100;
+
+            public MyChart(Context context, AttributeSet attrs) {
+                super(context, attrs);
+                TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MyChart, 0, 0);
+                barColor = a.getColor(R.styleable.MyChart_barColor, barColor);
+                maxValue = a.getInt(R.styleable.MyChart_maxValue, maxValue);
+                a.recycle();
+                paint.setColor(barColor);
+            }
+
+            @Override
+            protected void onDraw(Canvas canvas) {
+                int w = getWidth();
+                int h = getHeight();
+                int bars = 5;
+                float bw = w / (bars * 2f);
+                for (int i = 0; i < bars; i++) {
+                    float bh = h * ((i + 1) / (float) bars);
+                    float left = i * 2 * bw + bw / 2f;
+                    canvas.drawRect(left, h - bh, left + bw, h, paint);
+                }
+            }
+        }
     """
 
     private val APP_ACTIVITY = """

--- a/android-support/src/main/kotlin/dev/ide/android/support/metadata/CustomViewScanner.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/metadata/CustomViewScanner.kt
@@ -1,0 +1,143 @@
+package dev.ide.android.support.metadata
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.Opcodes
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipFile
+
+/**
+ * Discovers custom `android.view.View` subclasses on a module's compile classpath (library jars, including
+ * AAR `classes.jar`) so the XML layout editor can suggest them as element tags — e.g.
+ * `com.google.android.material.button.MaterialButton`, `androidx.appcompat.widget.AppCompatTextView`. The
+ * framework widgets (`TextView`, `LinearLayout`, …) are already offered by the bundled SDK metadata under
+ * their simple names; this fills the gap for everything else.
+ *
+ * Reads bytecode with ASM's [ClassReader] (no class loading — these jars target Android and can't be loaded
+ * on the host), building one super-name map across all jars so a subclass is recognised even when its View
+ * ancestor lives in a different jar (e.g. a Material view extending an AppCompat view extending the
+ * framework `View`). Framework / JDK / Kotlin-runtime packages are excluded: framework views are covered by
+ * the SDK metadata, and a layout must spell a non-framework view with its fully-qualified name anyway, which
+ * is exactly the [Widget.tag] emitted here.
+ */
+object CustomViewScanner {
+
+    private const val VIEW = "android/view/View"
+    private const val VIEWGROUP = "android/view/ViewGroup"
+
+    /**
+     * Scan [jars] for usable (public, concrete, non-inner) View subclasses, returning one [Widget] per class
+     * with its fully-qualified dotted name as the tag.
+     *
+     * Library views ultimately extend a *framework* base class (`android.widget.TextView`, `android.view.View`,
+     * …) that does not live in any of [jars], so the chain can't be walked all the way to `android/view/View`
+     * by bytecode alone. [frameworkWidgets] (simple class name → is-it-a-`ViewGroup`, from the bundled SDK
+     * metadata) seeds that knowledge: a class is a View as soon as an ancestor is a framework widget, and it's
+     * a `ViewGroup` if that ancestor is one (e.g. `MaterialButton → AppCompatButton → android.widget.Button`).
+     */
+    fun scan(jars: List<Path>, frameworkWidgets: Map<String, Boolean> = emptyMap()): List<Widget> {
+        val superInternal = HashMap<String, String?>() // internal name → super internal name
+        val access = HashMap<String, Int>()
+        for (jar in jars) {
+            if (!Files.isRegularFile(jar)) continue
+            runCatching {
+                ZipFile(jar.toFile()).use { zip ->
+                    val entries = zip.entries()
+                    while (entries.hasMoreElements()) {
+                        val e = entries.nextElement()
+                        if (e.isDirectory || !e.name.endsWith(".class")) continue
+                        val cr = runCatching { zip.getInputStream(e).use { ClassReader(it) } }.getOrNull() ?: continue
+                        // First jar wins for a duplicated class (matches classpath shadowing order).
+                        superInternal.putIfAbsent(cr.className, cr.superName)
+                        access.putIfAbsent(cr.className, cr.access)
+                    }
+                }
+            }
+        }
+
+        fun simpleOf(internal: String): String = internal.substringAfterLast('/').substringAfterLast('$')
+
+        // Walk the ancestry (starting at the *super* — a class's own name coinciding with a framework widget
+        // must not classify it). Returns whether the class is a View and, if so, whether it's a ViewGroup.
+        fun classify(internal: String): Pair<Boolean, Boolean>? {
+            var cur: String? = superInternal[internal]
+            val seen = HashSet<String>()
+            while (cur != null && seen.add(cur)) {
+                if (cur == VIEWGROUP) return true to true
+                if (cur == VIEW) return true to false
+                val fw = frameworkWidgets[simpleOf(cur)]
+                if (fw != null) return true to fw
+                cur = superInternal[cur]
+            }
+            return null
+        }
+
+        val out = LinkedHashMap<String, Widget>() // dedup by fqn
+        for ((internal, _) in superInternal) {
+            if ('$' in internal) continue                       // skip inner/anonymous classes
+            if (isFrameworkOrRuntime(internal)) continue
+            val acc = access[internal] ?: 0
+            val usable = acc and Opcodes.ACC_PUBLIC != 0 &&
+                acc and Opcodes.ACC_ABSTRACT == 0 &&
+                acc and Opcodes.ACC_INTERFACE == 0
+            if (!usable) continue
+            val (isView, isViewGroup) = classify(internal) ?: continue
+            if (!isView) continue
+            val fqn = internal.replace('/', '.')
+            out.putIfAbsent(fqn, Widget(fqn, isViewGroup))
+        }
+        return out.values.sortedBy { it.tag }
+    }
+
+    /**
+     * [scan] gated by a content fingerprint persisted at [cacheFile]: scanning a large dependency set is
+     * expensive, but the result only changes when a jar does, so a session reuses the previous scan unless
+     * the jar set (path + size + mtime) changed. The cache is best-effort — any I/O failure falls back to a
+     * live scan.
+     */
+    fun cached(jars: List<Path>, cacheFile: Path, frameworkWidgets: Map<String, Boolean> = emptyMap()): List<Widget> {
+        val fingerprint = fingerprintOf(jars)
+        runCatching {
+            if (Files.isRegularFile(cacheFile)) {
+                val lines = String(Files.readAllBytes(cacheFile)).split('\n')
+                if (lines.firstOrNull() == fingerprint) return parse(lines.drop(1))
+            }
+        }
+        val widgets = scan(jars, frameworkWidgets)
+        runCatching {
+            cacheFile.parent?.let { Files.createDirectories(it) }
+            Files.write(cacheFile, serialize(fingerprint, widgets).toByteArray())
+        }
+        return widgets
+    }
+
+    /** Framework, JDK, Kotlin and tooling packages that should never appear as a custom layout tag. */
+    private fun isFrameworkOrRuntime(internal: String): Boolean =
+        internal.startsWith("android/") ||   // framework views (covered by SDK metadata); NB: androidx/ is kept
+            internal.startsWith("java/") ||
+            internal.startsWith("javax/") ||
+            internal.startsWith("kotlin/") ||
+            internal.startsWith("dalvik/") ||
+            internal.startsWith("org/intellij/") ||
+            internal.startsWith("org/jetbrains/annotations/")
+
+    private fun fingerprintOf(jars: List<Path>): String =
+        jars.sortedBy { it.toString() }.joinToString(";") { p ->
+            val size = runCatching { Files.size(p) }.getOrDefault(0L)
+            val mtime = runCatching { Files.getLastModifiedTime(p).toMillis() }.getOrDefault(0L)
+            "$p:$size:$mtime"
+        }
+
+    private fun serialize(fingerprint: String, widgets: List<Widget>): String =
+        buildString {
+            append(fingerprint).append('\n')
+            widgets.forEach { append(it.tag).append('\t').append(if (it.isViewGroup) 'G' else 'V').append('\n') }
+        }
+
+    private fun parse(lines: List<String>): List<Widget> =
+        lines.filter { it.isNotBlank() }.mapNotNull { line ->
+            val tab = line.indexOf('\t')
+            if (tab <= 0) return@mapNotNull null
+            Widget(line.substring(0, tab), line.substring(tab + 1).trim() == "G")
+        }
+}

--- a/android-support/src/main/kotlin/dev/ide/android/support/resources/RIdAssignment.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/resources/RIdAssignment.kt
@@ -1,0 +1,38 @@
+package dev.ide.android.support.resources
+
+/**
+ * Deterministic, aapt-shaped resource id assignment over a [ResourceRepository]: `0x7fTTNNNN`, where `TT` is
+ * a per-type byte (present types, sorted by `R` class name) and `NNNN` is the entry index (names sorted). The
+ * synthetic `R` emits these ids as the field constants, so user code compiled against that `R` gets the same
+ * ints the preview's bridge maps back from at runtime (`R.styleable.MyChart` int[] → attr names →
+ * resolved values). Because the assignment is a pure function of the (sorted) resource set, the `R` the
+ * preview compiles against and the resolver's reverse map agree without any on-disk persistence — and it
+ * stays stable across runs as long as the resources do (the §6.1 caching goal; a persisted map can layer on
+ * later if reshuffling on add/remove becomes a problem).
+ */
+class RIdAssignment(repo: ResourceRepository) {
+
+    private val byKey = HashMap<Pair<ResourceType, String>, Int>()
+    private val byId = HashMap<Int, Pair<ResourceType, String>>()
+
+    init {
+        repo.types().sortedBy { it.rClass }.forEachIndexed { typeIndex, type ->
+            val typeId = typeIndex + 1 // 0 is reserved
+            repo.names(type).sorted().forEachIndexed { entryIndex, name ->
+                val id = (0x7f shl 24) or (typeId shl 16) or (entryIndex and 0xFFFF)
+                byKey[type to name] = id
+                byId[id] = type to name
+            }
+        }
+    }
+
+    /** The assigned id for `R.<type>.<name>`, or null if absent. */
+    fun id(type: ResourceType, name: String): Int? = byKey[type to name]
+
+    /** The (type, name) a previously assigned id maps back to — the bridge's `int → attr name` lookup. */
+    fun nameOf(id: Int): Pair<ResourceType, String>? = byId[id]
+
+    /** The `R.styleable.<name>` int[] (attr ids in declaration order; unknown attrs dropped). */
+    fun styleableArray(repo: ResourceRepository, styleableName: String): IntArray =
+        repo.styleableAttrs(styleableName).mapNotNull { id(ResourceType.ATTR, it) }.toIntArray()
+}

--- a/android-support/src/main/kotlin/dev/ide/android/support/resources/Resources.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/resources/Resources.kt
@@ -8,6 +8,9 @@ import java.nio.file.Path
  * resource (for hover), null for a file resource. The same [type]/[name] may have several items (one per
  * config); [ResourceRepository] dedups by type+name for `R` and reference resolution.
  */
+/** A parsed `<style>`/theme: its [parent] (explicit `parent="…"`, raw) and `<item name>` → value map. */
+data class StyleData(val parent: String?, val items: Map<String, String>)
+
 data class ResourceItem(
     val type: ResourceType,
     val name: String,
@@ -21,12 +24,29 @@ data class ResourceItem(
  * Built from one or more `res/` roots in overlay order (later roots win, like a
  * build's source-set/dependency merge). Backs the synthetic `R` class and XML reference resolution.
  */
-class ResourceRepository(items: List<ResourceItem>) {
+class ResourceRepository(
+    items: List<ResourceItem>,
+    /** `<declare-styleable>` name → its child `<attr>` names in declaration order. Backs `R.styleable.*` arrays. */
+    private val styleableAttrs: Map<String, List<String>> = emptyMap(),
+    /** Raw (unsanitized) `<style>`/theme name → its parent + `<item>` map. Backs theme/chrome resolution. */
+    private val styles: Map<String, StyleData> = emptyMap(),
+    /** `<attr>` name → its `format` token (color/dimension/integer/…), for typing styled-attribute lookups. */
+    private val attrFormats: Map<String, String> = emptyMap(),
+) {
+
+    /** The declared `format` of `<attr name=…>` (e.g. `color`), or null if unknown. */
+    fun attrFormat(name: String): String? = attrFormats[name]
     private val items: List<ResourceItem> = items
     private val byType: Map<ResourceType, List<ResourceItem>> = items.groupBy { it.type }
 
     fun all(): List<ResourceItem> = items
     fun types(): Set<ResourceType> = byType.keys
+
+    /** The attr names of `<declare-styleable name=[styleableName]>`, in declaration order (empty if unknown). */
+    fun styleableAttrs(styleableName: String): List<String> = styleableAttrs[styleableName] ?: emptyList()
+
+    /** The `<style name=[styleName]>` definition (parent + items), keyed by its raw dotted name, or null. */
+    fun style(styleName: String): StyleData? = styles[styleName]
 
     /** Distinct resource names of [type] (what `R.<type>` exposes). */
     fun names(type: ResourceType): Set<String> =

--- a/android-support/src/main/kotlin/dev/ide/android/support/resources/StdlibResourceModel.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/resources/StdlibResourceModel.kt
@@ -19,6 +19,9 @@ object StdlibResourceModel : ResourceModel {
 
     override fun parse(resDirs: List<Path>): ResourceRepository {
         val out = ArrayList<ResourceItem>()
+        val styleableAttrs = LinkedHashMap<String, List<String>>()
+        val styles = LinkedHashMap<String, StyleData>()
+        val attrFormats = LinkedHashMap<String, String>()
         for (resDir in resDirs) {
             if (!Files.isDirectory(resDir)) continue
             runCatching {
@@ -29,7 +32,7 @@ object StdlibResourceModel : ResourceModel {
                         val base = raw.substringBefore('-')          // strip `-hdpi`, `-night`, `-v21`, …
                         val qualifier = raw.substringAfter('-', "")
                         if (base == "values") {
-                            forEachXml(folder) { parseValues(it, qualifier, out) }
+                            forEachXml(folder) { parseValues(it, qualifier, out, styleableAttrs, styles, attrFormats) }
                         } else {
                             val type = ResourceType.fromFolder(base) ?: continue
                             Files.newDirectoryStream(folder).use { files ->
@@ -43,20 +46,29 @@ object StdlibResourceModel : ResourceModel {
                 }
             }
         }
-        return ResourceRepository(out)
+        return ResourceRepository(out, styleableAttrs, styles, attrFormats)
     }
 
     private fun forEachXml(dir: Path, block: (Path) -> Unit) {
         runCatching { Files.newDirectoryStream(dir, "*.xml").use { it.forEach(block) } }
     }
 
-    private fun parseValues(file: Path, qualifier: String, out: MutableList<ResourceItem>) {
+    private fun parseValues(
+        file: Path,
+        qualifier: String,
+        out: MutableList<ResourceItem>,
+        styleableAttrs: MutableMap<String, List<String>>,
+        styles: MutableMap<String, StyleData>,
+        attrFormats: MutableMap<String, String>,
+    ) {
         val doc = runCatching { documentBuilder().parse(file.toFile()) }.getOrNull() ?: return
         val root = doc.documentElement ?: return
         val children = root.childNodes
         for (i in 0 until children.length) {
             val el = children.item(i) as? Element ?: continue
             if (el.nodeType != Node.ELEMENT_NODE) continue
+            if (el.tagName == "style") captureStyle(el, styles)
+            if (el.tagName == "attr") el.getAttribute("format").ifEmpty { null }?.let { attrFormats[sanitize(el.getAttribute("name"))] = it }
             val name = sanitize(el.getAttribute("name")).ifEmpty { continue }
             val type = when (el.tagName) {
                 "item" -> ResourceType.byRClass(el.getAttribute("type").ifEmpty { "id" })
@@ -64,15 +76,36 @@ object StdlibResourceModel : ResourceModel {
             } ?: continue
             out += ResourceItem(type, name, source = file, qualifier = qualifier, value = el.textContent?.trim()?.ifEmpty { null })
             if (type == ResourceType.STYLEABLE) {
-                // a <declare-styleable>'s child <attr>s are also R.attr entries
+                // a <declare-styleable>'s child <attr>s are also R.attr entries; remember the ordered list
+                // so R.styleable.<name> can emit the matching int[] + per-attr index constants.
                 val attrs = el.childNodes
+                val attrNames = ArrayList<String>()
                 for (j in 0 until attrs.length) {
                     val a = attrs.item(j) as? Element ?: continue
-                    if (a.tagName == "attr") sanitize(a.getAttribute("name")).ifEmpty { null }
-                        ?.let { out += ResourceItem(ResourceType.ATTR, it, source = file, qualifier = qualifier) }
+                    if (a.tagName == "attr") sanitize(a.getAttribute("name")).ifEmpty { null }?.let {
+                        out += ResourceItem(ResourceType.ATTR, it, source = file, qualifier = qualifier)
+                        attrNames += it
+                        a.getAttribute("format").ifEmpty { null }?.let { fmt -> attrFormats[it] = fmt }
+                    }
                 }
+                if (attrNames.isNotEmpty()) styleableAttrs[name] = attrNames
             }
         }
+    }
+
+    /** Capture a `<style>`/theme by its RAW (dotted) name so parent-chain walking and `?attr` resolution work. */
+    private fun captureStyle(el: Element, styles: MutableMap<String, StyleData>) {
+        val rawName = el.getAttribute("name").trim().ifEmpty { return }
+        val parent = el.getAttribute("parent").trim().ifEmpty { null }
+        val items = LinkedHashMap<String, String>()
+        val kids = el.childNodes
+        for (j in 0 until kids.length) {
+            val item = kids.item(j) as? Element ?: continue
+            if (item.tagName != "item") continue
+            val itemName = item.getAttribute("name").trim().ifEmpty { continue }
+            items[itemName] = item.textContent?.trim().orEmpty()
+        }
+        styles[rawName] = StyleData(parent, items)
     }
 
     private fun scanIds(file: Path, qualifier: String, out: MutableList<ResourceItem>) {

--- a/android-support/src/main/kotlin/dev/ide/android/support/templates/AndroidTemplates.kt
+++ b/android-support/src/main/kotlin/dev/ide/android/support/templates/AndroidTemplates.kt
@@ -6,6 +6,7 @@ import dev.ide.model.template.ProjectScaffold
 import dev.ide.model.template.ProjectTemplate
 import dev.ide.model.template.TemplateArgs
 import dev.ide.model.template.TemplateCategory
+import dev.ide.model.template.TemplateDependency
 import dev.ide.model.template.TemplateId
 import dev.ide.model.template.TemplateParameter
 
@@ -57,6 +58,9 @@ internal object AndroidTemplateSupport {
     )
 
     const val COMPILE_SDK = 34
+
+    /** Google's Material Components for Android — the library behind Material You theming + the FAB/Snackbar. */
+    const val MATERIAL_COORDINATE = "com.google.android.material:material:1.12.0"
 
     fun isKotlin(args: TemplateArgs): Boolean = args.string("language", "java").equals("kotlin", ignoreCase = true)
 }
@@ -202,6 +206,205 @@ object AndroidAppTemplate : ProjectTemplate {
                     protected void onCreate(Bundle savedInstanceState) {
                         super.onCreate(savedInstanceState);
                         setContentView(R.layout.activity_main);
+                    }
+                }
+                """,
+            )
+        }
+    }
+}
+
+/**
+ * A Material You (Material 3) Android application: one `app` module wired to **Google's Material Components
+ * library** ([AndroidTemplateSupport.MATERIAL_COORDINATE], resolved by the host after generation). The app
+ * theme extends `Theme.Material3.DynamicColors.DayNight` so it adopts the system **dynamic colour** palette
+ * on Android 12+ and a light/dark Material 3 baseline below it, and the starter screen is the canonical
+ * **FAB example**: a `CoordinatorLayout` with a `FloatingActionButton` whose tap shows a `Snackbar`. The
+ * `MainActivity` extends `AppCompatActivity` (pulled in transitively by Material) so the Material 3 theme
+ * resolves. Assembles to a signed APK through the existing `AndroidBuildSystem` pipeline (AAR resources +
+ * D8 dexing of the Material/AndroidX closure).
+ */
+object MaterialYouAppTemplate : ProjectTemplate {
+    override val id = TemplateId("android-material-you")
+    override val displayName = "Material You App"
+    override val description = "A Material 3 app with dynamic colour theming and a Floating Action Button."
+    override val category = TemplateCategory.ANDROID
+    override val iconId = "module.android"
+
+    override fun parameters(): List<TemplateParameter> = listOf(
+        AndroidTemplateSupport.languageParam,
+        // Material Components requires minSdk 21; drop the lower options the plain app template offers.
+        AndroidTemplateSupport.minSdkParam.copy(
+            options = AndroidTemplateSupport.minSdkParam.options.filter { it.value.toInt() >= 21 },
+            defaultIndex = 0,
+        ),
+        AndroidTemplateSupport.targetSdkParam,
+    )
+
+    override fun dependencies(args: TemplateArgs): List<TemplateDependency> =
+        listOf(TemplateDependency(module = "app", coordinate = AndroidTemplateSupport.MATERIAL_COORDINATE))
+
+    override fun generate(scaffold: ProjectScaffold, args: TemplateArgs) {
+        val pkg = args.packageName
+        val minSdk = args.int("minSdk", 21)
+        val targetSdk = args.int("targetSdk", AndroidTemplateSupport.COMPILE_SDK)
+        val kotlin = AndroidTemplateSupport.isKotlin(args)
+        scaffold.workspace.beginModification().apply {
+            addProject(args.name, BuildSystemId.NATIVE, scaffold.rootDir)
+            commit()
+        }
+        scaffold.workspace.projects.first { it.name == args.name }.beginModification().apply {
+            addModule("app", scaffold.moduleType("android-app")).apply {
+                languageLevel = scaffold.languageLevel
+                putFacet(
+                    AndroidFacet(
+                        namespace = pkg,
+                        compileSdk = AndroidTemplateSupport.COMPILE_SDK,
+                        minSdk = minSdk,
+                        targetSdk = targetSdk,
+                    ),
+                )
+            }
+            commit()
+        }
+
+        val path = AndroidTemplateSupport.pkgPath(pkg)
+        scaffold.writeText(
+            "app/src/main/AndroidManifest.xml",
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="$pkg">
+                <application
+                    android:allowBackup="true"
+                    android:icon="@mipmap/ic_launcher"
+                    android:label="@string/app_name"
+                    android:roundIcon="@mipmap/ic_launcher_round"
+                    android:supportsRtl="true"
+                    android:theme="@style/Theme.App">
+                    <activity android:name=".MainActivity" android:exported="true">
+                        <intent-filter>
+                            <action android:name="android.intent.action.MAIN"/>
+                            <category android:name="android.intent.category.LAUNCHER"/>
+                        </intent-filter>
+                    </activity>
+                </application>
+            </manifest>
+            """,
+        )
+        scaffold.writeText(
+            "app/src/main/res/values/strings.xml",
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <string name="app_name">${args.name}</string>
+                <string name="hello_world">Hello, Material You!</string>
+                <string name="fab_description">Add</string>
+                <string name="fab_clicked">FAB clicked</string>
+            </resources>
+            """,
+        )
+        scaffold.writeText(
+            "app/src/main/res/values/colors.xml",
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <color name="primary">#FF6750A4</color>
+                <color name="on_primary">#FFFFFFFF</color>
+                ${AndroidAppAssets.ICON_BACKGROUND_COLOR_XML}
+            </resources>
+            """,
+        )
+        // Theme.Material3.DynamicColors.DayNight: dynamic (wallpaper-derived) colour on Android 12+, a
+        // Material 3 light/dark baseline below it. No values-night override needed — DayNight handles it.
+        scaffold.writeText(
+            "app/src/main/res/values/themes.xml",
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <style name="Theme.App" parent="Theme.Material3.DynamicColors.DayNight">
+                    <item name="colorPrimary">@color/primary</item>
+                    <item name="colorOnPrimary">@color/on_primary</item>
+                </style>
+            </resources>
+            """,
+        )
+        for ((rel, content) in AndroidAppAssets.launcherIconResFiles) {
+            scaffold.writeText("app/src/main/res/$rel", content)
+        }
+        scaffold.writeText(
+            "app/src/main/res/layout/activity_main.xml",
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <androidx.coordinatorlayout.widget.CoordinatorLayout
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/hello_world"
+                    android:textAppearance="?attr/textAppearanceHeadlineSmall"/>
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/fab"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|end"
+                    android:layout_margin="16dp"
+                    android:contentDescription="@string/fab_description"
+                    android:src="@android:drawable/ic_input_add"/>
+            </androidx.coordinatorlayout.widget.CoordinatorLayout>
+            """,
+        )
+        if (kotlin) {
+            scaffold.writeText(
+                "app/src/main/kotlin/$path/MainActivity.kt",
+                """
+                package $pkg
+
+                import android.os.Bundle
+                import androidx.appcompat.app.AppCompatActivity
+                import com.google.android.material.floatingactionbutton.FloatingActionButton
+                import com.google.android.material.snackbar.Snackbar
+
+                class MainActivity : AppCompatActivity() {
+                    override fun onCreate(savedInstanceState: Bundle?) {
+                        super.onCreate(savedInstanceState)
+                        setContentView(R.layout.activity_main)
+                        findViewById<FloatingActionButton>(R.id.fab).setOnClickListener { view ->
+                            Snackbar.make(view, R.string.fab_clicked, Snackbar.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+                """,
+            )
+        } else {
+            scaffold.writeText(
+                "app/src/main/java/$path/MainActivity.java",
+                """
+                package $pkg;
+
+                import android.os.Bundle;
+                import android.view.View;
+                import androidx.appcompat.app.AppCompatActivity;
+                import com.google.android.material.floatingactionbutton.FloatingActionButton;
+                import com.google.android.material.snackbar.Snackbar;
+
+                public class MainActivity extends AppCompatActivity {
+                    @Override
+                    protected void onCreate(Bundle savedInstanceState) {
+                        super.onCreate(savedInstanceState);
+                        setContentView(R.layout.activity_main);
+                        FloatingActionButton fab = findViewById(R.id.fab);
+                        fab.setOnClickListener(new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                                Snackbar.make(view, R.string.fab_clicked, Snackbar.LENGTH_SHORT).show();
+                            }
+                        });
                     }
                 }
                 """,

--- a/android-support/src/test/kotlin/dev/ide/android/support/AndroidAarAttributeTest.kt
+++ b/android-support/src/test/kotlin/dev/ide/android/support/AndroidAarAttributeTest.kt
@@ -1,0 +1,174 @@
+package dev.ide.android.support
+
+import dev.ide.android.support.tasks.ApkPackaging
+import dev.ide.android.support.tools.AndroidSdk
+import dev.ide.android.support.tools.DebugKeystore
+import dev.ide.build.BuildGoal
+import dev.ide.build.BuildRequest
+import dev.ide.build.VariantSelector
+import dev.ide.build.engine.BuildCache
+import dev.ide.build.engine.JavaCompile
+import dev.ide.build.engine.JavaCompileResult
+import dev.ide.build.engine.SimpleTaskContext
+import dev.ide.build.engine.TaskExecutorImpl
+import dev.ide.lang.jdt.compile.JdtBatchCompiler
+import dev.ide.model.BuildSystemId
+import dev.ide.model.DependencyScope
+import dev.ide.model.LanguageLevel
+import dev.ide.model.LibraryDependency
+import dev.ide.model.LibraryKind
+import dev.ide.model.LibraryRef
+import dev.ide.model.ModuleId
+import dev.ide.model.impl.FacetCodecRegistry
+import dev.ide.model.impl.ModuleTypeRegistry
+import dev.ide.model.impl.ProjectModel
+import dev.ide.platform.impl.PlatformCore
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Proves a custom-view attribute from an external AAR resolves through aapt2. The regression: a Maven
+ * dependency that resolves to an AAR is stored in the model as its *exploded* `classes.jar` (with `res/`
+ * and `AndroidManifest.xml` siblings), NOT as the `.aar` file — so the build must recognise that layout,
+ * merge the AAR's `res/values/attrs.xml`, and pass the AAR's package to aapt2 `--extra-packages`. Without
+ * the fix, the app layout's `app:customText` attribute is unknown and aapt2 link fails.
+ */
+class AndroidAarAttributeTest {
+
+    @Test
+    fun resolvesCustomAttributeFromExplodedAar() {
+        val sdk = AndroidSdk.findSdkRoot()?.let { AndroidSdk.detect(it) }
+        assumeTrue(sdk != null && sdk.isComplete(), "Android SDK not installed; skipping")
+        sdk!!
+
+        val dir = Files.createTempDirectory("android-aar-attr")
+        val platform = PlatformCore()
+        try {
+            // The exploded-AAR layout the Maven resolver produces: classes.jar + res/ + manifest + .extracted.
+            val exploded = explodeAar(dir.resolve("exploded/customview"), sdk.androidJar)
+
+            val store = ProjectModel.open(dir, platform, FacetCodecRegistry().register(AndroidFacetCodec))
+            ModuleTypeRegistry(platform.extensions).register(AndroidAppModuleType, AndroidSupport.PLUGIN)
+            val appType = ModuleTypeRegistry(platform.extensions).resolve("android-app")
+            store.workspace.beginModification().apply { addProject("demo", BuildSystemId.NATIVE, store.vfs.root()); commit() }
+
+            // The library points at the exploded classes.jar (as addDependency does for a Maven AAR), not the .aar.
+            store.workspace.libraryTable.create("customview").apply {
+                kind = LibraryKind.AAR; addClassesRoot(store.vfs.fileFor(exploded)); commit()
+            }
+
+            store.workspace.projects.single().beginModification().apply {
+                addModule("app", appType).apply {
+                    languageLevel = LanguageLevel.JAVA_17
+                    putFacet(AndroidFacet(namespace = "com.example.app", compileSdk = 34, minSdk = 24, targetSdk = 34))
+                    addDependency(LibraryDependency(LibraryRef("customview"), DependencyScope.IMPLEMENTATION))
+                }
+                commit()
+            }
+
+            write(dir, "app/src/main/AndroidManifest.xml", APP_MANIFEST)
+            write(dir, "app/src/main/res/layout/main.xml", APP_LAYOUT)   // uses app:customText from the AAR
+            write(dir, "app/src/main/java/com/example/app/MainActivity.java", APP_ACTIVITY)
+
+            val signing = DebugKeystore.getOrCreate(dir.resolve(".keystore/debug.ks"), sdk.keytool)
+            val buildSystem = AndroidBuildSystem.inProcess(jdtCompile(), sdk, signing)
+            val graph = buildSystem.createBuildGraph(
+                store.workspace.projects.single(),
+                BuildRequest(listOf(ModuleId("app")), VariantSelector("debug"), BuildGoal.PACKAGE),
+            )
+            val log = StringBuilder()
+            val outcome = runBlocking {
+                TaskExecutorImpl(BuildCache(dir.resolve(".caches/build"))).execute(graph, SimpleTaskContext(log = { log.appendLine(it) }), 2)
+            }
+            assertTrue(outcome.succeeded, "custom-attribute APK build failed (AAR attrs.xml not merged?):\n$log")
+
+            // aapt2 --extra-packages generated the AAR's own R (so its classes + attrs resolve).
+            val aarR = dir.resolve("app/build/intermediates/android/debug/gen/io/example/customview/R.java")
+            assertTrue(Files.isRegularFile(aarR), "AAR package R.java not generated (extra-packages missing): $aarR")
+        } finally {
+            platform.dispose(); dir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun jdtCompile(): JavaCompile = JavaCompile { sources, classpath, out, level ->
+        val r = JdtBatchCompiler.compile(sources, classpath, out, level)
+        JavaCompileResult(r.success, r.messages)
+    }
+
+    /** Lay out an already-exploded AAR (classes.jar + res/values/attrs.xml + manifest + marker); returns the jar. */
+    private fun explodeAar(dir: Path, androidJar: Path): Path {
+        write(dir.resolve("src"), "io/example/customview/CustomView.java", CUSTOM_VIEW)
+        val r = JdtBatchCompiler.compile(listOf(dir.resolve("src/io/example/customview/CustomView.java")),
+            listOf(androidJar), dir.resolve("classes"), "17")
+        check(r.success) { "AAR class compile failed: ${r.messages}" }
+        val classesJar = dir.resolve("classes.jar")
+        ApkPackaging.jarClasses(dir.resolve("classes"), classesJar)
+        write(dir, "res/values/attrs.xml", AAR_ATTRS)
+        write(dir, "AndroidManifest.xml", AAR_MANIFEST)
+        Files.writeString(dir.resolve(".extracted"), "")
+        return classesJar
+    }
+
+    private fun write(root: Path, rel: String, content: String) {
+        val f = root.resolve(rel); Files.createDirectories(f.parent); Files.writeString(f, content.trimIndent())
+    }
+
+    private companion object {
+        val CUSTOM_VIEW = """
+            package io.example.customview;
+            import android.content.Context;
+            import android.view.View;
+            public class CustomView extends View {
+                public CustomView(Context c) { super(c); }
+            }
+        """
+        val AAR_ATTRS = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <declare-styleable name="CustomView">
+                    <attr name="customText" format="string"/>
+                </declare-styleable>
+            </resources>
+        """
+        val AAR_MANIFEST = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.example.customview">
+                <application/>
+            </manifest>
+        """
+        val APP_MANIFEST = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+                <application android:label="App">
+                    <activity android:name=".MainActivity" android:exported="true"/>
+                </application>
+            </manifest>
+        """
+        // The custom view + its AAR-declared attribute, referenced via the res-auto namespace.
+        val APP_LAYOUT = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <io.example.customview.CustomView
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:customText="hello"/>
+        """
+        val APP_ACTIVITY = """
+            package com.example.app;
+            import android.app.Activity;
+            import android.os.Bundle;
+            public class MainActivity extends Activity {
+                @Override
+                protected void onCreate(Bundle savedInstanceState) {
+                    super.onCreate(savedInstanceState);
+                    setContentView(R.layout.main);
+                }
+            }
+        """
+    }
+}

--- a/android-support/src/test/kotlin/dev/ide/android/support/AndroidBuildGraphCycleTest.kt
+++ b/android-support/src/test/kotlin/dev/ide/android/support/AndroidBuildGraphCycleTest.kt
@@ -1,0 +1,94 @@
+package dev.ide.android.support
+
+import dev.ide.android.support.tools.AndroidSdk
+import dev.ide.android.support.tools.SigningConfig
+import dev.ide.build.BuildGoal
+import dev.ide.build.BuildRequest
+import dev.ide.build.CyclicTaskDependencyException
+import dev.ide.build.VariantSelector
+import dev.ide.build.engine.JavaCompile
+import dev.ide.build.engine.JavaCompileResult
+import dev.ide.model.BuildSystemId
+import dev.ide.model.ContentRole
+import dev.ide.model.DependencyScope
+import dev.ide.model.FacetTemplate
+import dev.ide.model.LanguageLevel
+import dev.ide.model.ModuleDependency
+import dev.ide.model.ModuleId
+import dev.ide.model.ModuleType
+import dev.ide.model.SourceSetTemplate
+import dev.ide.model.impl.FacetCodecRegistry
+import dev.ide.model.impl.ModuleTypeRegistry
+import dev.ide.model.impl.ProjectModel
+import dev.ide.platform.PluginId
+import dev.ide.platform.impl.PlatformCore
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Regression for issue #993: the default demo (`app android-app → feature android-lib → core java-lib`)
+ * must produce an **acyclic** build graph. A reported cycle
+ * `:feature:classes → :core:jar → :core:classes → :feature:jar → :feature:classes`
+ * meant a clean v3.0.0 install could not build the demo at all. This builds the graph (no SDK needed —
+ * construction only stores paths) and runs the topological sort, which throws on a cycle.
+ */
+class AndroidBuildGraphCycleTest {
+
+    private object JavaLib : ModuleType {
+        override val id = "java-lib"
+        override val displayName = "Java Library"
+        override fun defaultSourceSets(): List<SourceSetTemplate> = emptyList()
+        override fun defaultFacets(): List<FacetTemplate> = emptyList()
+        override fun supportedBuildSystems(): Set<BuildSystemId> = setOf(BuildSystemId.NATIVE)
+    }
+
+    @Test
+    fun demoGraphIsAcyclic() {
+        val dir = Files.createTempDirectory("android-cycle")
+        val platform = PlatformCore()
+        try {
+            val store = ProjectModel.open(dir, platform, FacetCodecRegistry().register(AndroidFacetCodec))
+            val types = ModuleTypeRegistry(platform.extensions)
+            types.register(JavaLib, PluginId("java-support"))
+            AndroidSupport.register(types, FacetCodecRegistry())
+
+            SampleAndroidProject.generate(
+                store,
+                androidApp = types.resolve("android-app"),
+                androidLib = types.resolve("android-lib"),
+                javaLib = types.resolve("java-lib"),
+            )
+            // Mirror the device flow: the demo is generated, saved, then RELOADED from `module.toml` on the
+            // next launch (ProjectManager.open). Path resolution on reload is what the IDE actually builds.
+            store.save()
+            val reopened = ProjectModel.open(dir, platform, FacetCodecRegistry().register(AndroidFacetCodec))
+
+            // Fake SDK / signing — graph construction only records paths, it never reads them.
+            val sdk = AndroidSdk(
+                androidJar = dir.resolve("fake/android.jar"),
+                buildToolsDir = dir.resolve("fake/build-tools"),
+            )
+            val signing = SigningConfig(dir.resolve("fake/debug.ks"), "android", "android", "android")
+            val buildSystem = AndroidBuildSystem.subprocess(noopJavaCompile(), sdk, signing)
+
+            val project = reopened.workspace.projects.single { it.name == SampleAndroidProject.PROJECT }
+            for (goal in listOf(BuildGoal.COMPILE_ONLY, BuildGoal.PACKAGE)) {
+                val graph = buildSystem.createBuildGraph(
+                    project,
+                    BuildRequest(listOf(ModuleId("app")), VariantSelector("debug"), goal),
+                )
+                try {
+                    graph.topologicalLevels()
+                } catch (e: CyclicTaskDependencyException) {
+                    fail("demo build graph has a cycle (goal=$goal): ${e.cycle.joinToString(" -> ") { it.value }}")
+                }
+            }
+        } finally {
+            platform.dispose(); dir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun noopJavaCompile(): JavaCompile = JavaCompile { _, _, _, _ -> JavaCompileResult(true, emptyList()) }
+}

--- a/android-support/src/test/kotlin/dev/ide/android/support/MaterialYouTemplateTest.kt
+++ b/android-support/src/test/kotlin/dev/ide/android/support/MaterialYouTemplateTest.kt
@@ -1,0 +1,100 @@
+package dev.ide.android.support
+
+import dev.ide.android.support.templates.AndroidTemplateSupport
+import dev.ide.android.support.templates.MaterialYouAppTemplate
+import dev.ide.model.LanguageLevel
+import dev.ide.model.ModuleType
+import dev.ide.model.Workspace
+import dev.ide.model.impl.FacetCodecRegistry
+import dev.ide.model.impl.ModuleTypeRegistry
+import dev.ide.model.impl.ProjectModel
+import dev.ide.model.impl.ProjectModelStore
+import dev.ide.model.template.ProjectScaffold
+import dev.ide.model.template.TemplateArgs
+import dev.ide.platform.impl.PlatformCore
+import dev.ide.vfs.VirtualFile
+import java.nio.file.Files
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MaterialYouTemplateTest {
+
+    @Test
+    fun declaresGoogleMaterialDependencyOnTheAppModule() {
+        val deps = MaterialYouAppTemplate.dependencies(args())
+        assertEquals(1, deps.size)
+        assertEquals("app", deps.single().module)
+        assertEquals(AndroidTemplateSupport.MATERIAL_COORDINATE, deps.single().coordinate)
+        assertEquals("implementation", deps.single().scope)
+    }
+
+    @Test
+    fun minSdkChoicesAreMaterialCompatible() {
+        val minSdk = MaterialYouAppTemplate.parameters()
+            .filterIsInstance<dev.ide.model.template.TemplateParameter.Choice>()
+            .first { it.key == "minSdk" }
+        assertTrue(minSdk.options.all { it.value.toInt() >= 21 }, "Material requires minSdk >= 21")
+    }
+
+    @Test
+    fun generatesFabLayoutMaterial3ThemeAndWiredActivity() {
+        withScaffold { scaffold, root ->
+            MaterialYouAppTemplate.generate(scaffold, args())
+
+            val layout = root.resolve("app/src/main/res/layout/activity_main.xml").readText()
+            assertTrue("com.google.android.material.floatingactionbutton.FloatingActionButton" in layout, "layout has the FAB")
+            assertTrue("androidx.coordinatorlayout.widget.CoordinatorLayout" in layout, "FAB sits in a CoordinatorLayout")
+            assertTrue("@+id/fab" in layout)
+
+            val theme = root.resolve("app/src/main/res/values/themes.xml").readText()
+            assertTrue("Theme.Material3.DynamicColors.DayNight" in theme, "Material You dynamic-colour theme")
+
+            val activity = root.resolve("app/src/main/java/com/example/app/MainActivity.java").readText()
+            assertTrue("extends AppCompatActivity" in activity)
+            assertTrue("Snackbar.make" in activity, "FAB tap shows a Snackbar")
+            assertTrue("R.id.fab" in activity)
+        }
+    }
+
+    @Test
+    fun kotlinVariantEmitsKotlinActivity() {
+        withScaffold { scaffold, root ->
+            MaterialYouAppTemplate.generate(scaffold, args(mapOf("language" to "kotlin")))
+            val activity = root.resolve("app/src/main/kotlin/com/example/app/MainActivity.kt").readText()
+            assertTrue("class MainActivity : AppCompatActivity()" in activity)
+            assertTrue("findViewById<FloatingActionButton>(R.id.fab)" in activity)
+        }
+    }
+
+    // --- support ---
+
+    private fun args(extra: Map<String, String> = emptyMap()) = TemplateArgs(
+        mapOf(TemplateArgs.NAME to "MaterialApp", TemplateArgs.PACKAGE to "com.example.app") + extra,
+    )
+
+    private fun withScaffold(body: (ProjectScaffold, root: java.nio.file.Path) -> Unit) {
+        val dir = Files.createTempDirectory("material-you-template")
+        val platform = PlatformCore()
+        try {
+            val store: ProjectModelStore = ProjectModel.open(dir, platform, FacetCodecRegistry().register(AndroidFacetCodec))
+            ModuleTypeRegistry(platform.extensions).register(AndroidAppModuleType, AndroidSupport.PLUGIN)
+            val scaffold = object : ProjectScaffold {
+                override val workspace: Workspace get() = store.workspace
+                override val rootDir: VirtualFile get() = store.vfs.root()
+                override val languageLevel: LanguageLevel = LanguageLevel.JAVA_17
+                override fun moduleType(id: String): ModuleType = ModuleTypeRegistry(platform.extensions).resolve(id)
+                override fun writeText(relPath: String, content: String) {
+                    val file = store.rootPath.resolve(relPath)
+                    Files.createDirectories(file.parent)
+                    file.writeText(content.trimIndent() + "\n")
+                }
+            }
+            body(scaffold, store.rootPath)
+        } finally {
+            platform.dispose(); dir.toFile().deleteRecursively()
+        }
+    }
+}

--- a/android-support/src/test/kotlin/dev/ide/android/support/metadata/CustomViewScannerTest.kt
+++ b/android-support/src/test/kotlin/dev/ide/android/support/metadata/CustomViewScannerTest.kt
@@ -1,0 +1,138 @@
+package dev.ide.android.support.metadata
+
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CustomViewScannerTest {
+
+    /** Emit a minimal `.class` for [internalName] extending [superInternal] with the given access flags. */
+    private fun classBytes(internalName: String, superInternal: String, access: Int): ByteArray {
+        val cw = ClassWriter(0)
+        cw.visit(Opcodes.V1_8, access, internalName, null, superInternal, null)
+        cw.visitEnd()
+        return cw.toByteArray()
+    }
+
+    private fun jar(dir: Path, name: String, classes: Map<String, ByteArray>): Path {
+        val jar = dir.resolve(name)
+        ZipOutputStream(Files.newOutputStream(jar)).use { zip ->
+            for ((internal, bytes) in classes) {
+                zip.putNextEntry(ZipEntry("$internal.class"))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+        return jar
+    }
+
+    private val PUBLIC = Opcodes.ACC_PUBLIC
+    private val ABSTRACT = Opcodes.ACC_PUBLIC or Opcodes.ACC_ABSTRACT
+
+    @Test
+    fun findsLibraryViewSubclassesByFqnAndDetectsViewGroups() {
+        val tmp = Files.createTempDirectory("cvs")
+        // android.view.View / ViewGroup are not in the jar (they live in android.jar / the framework); the
+        // scanner walks whatever ancestry it can see, so a class extending View directly is found.
+        val jar = jar(tmp, "material.jar", mapOf(
+            "com/google/android/material/button/MaterialButton" to classBytes(
+                "com/google/android/material/button/MaterialButton", "android/widget/Button", PUBLIC),
+            "com/example/MyView" to classBytes("com/example/MyView", "android/view/View", PUBLIC),
+            "com/example/MyLayout" to classBytes("com/example/MyLayout", "android/view/ViewGroup", PUBLIC),
+        ))
+
+        val widgets = CustomViewScanner.scan(listOf(jar))
+        val byTag = widgets.associateBy { it.tag }
+
+        assertTrue("com.example.MyView" in byTag, "direct View subclass should be found by FQN")
+        assertEquals(false, byTag["com.example.MyView"]!!.isViewGroup)
+        assertTrue("com.example.MyLayout" in byTag, "ViewGroup subclass should be found")
+        assertEquals(true, byTag["com.example.MyLayout"]!!.isViewGroup, "ViewGroup subclass should be flagged")
+    }
+
+    @Test
+    fun seedsFrameworkBaseClassesAbsentFromJars() {
+        val tmp = Files.createTempDirectory("cvs")
+        // The realistic shape: a library view extends a framework base class (android.widget.Button) that is
+        // NOT packaged in the jar. Only the framework-widget seed lets the scanner recognise it as a View.
+        val jar = jar(tmp, "material.jar", mapOf(
+            "com/google/android/material/button/MaterialButton" to classBytes(
+                "com/google/android/material/button/MaterialButton", "android/widget/Button", PUBLIC),
+            "com/example/MyFrame" to classBytes("com/example/MyFrame", "android/widget/FrameLayout", PUBLIC),
+        ))
+        val seed = mapOf("Button" to false, "FrameLayout" to true)
+
+        val none = CustomViewScanner.scan(listOf(jar)) // no seed → framework ancestry invisible
+        assertTrue(none.isEmpty(), "without the framework seed nothing resolves: ${none.map { it.tag }}")
+
+        val byTag = CustomViewScanner.scan(listOf(jar), seed).associateBy { it.tag }
+        assertTrue("com.google.android.material.button.MaterialButton" in byTag, "seeded View subclass found")
+        assertEquals(false, byTag["com.google.android.material.button.MaterialButton"]!!.isViewGroup)
+        assertEquals(true, byTag["com.example.MyFrame"]!!.isViewGroup, "FrameLayout descendant is a ViewGroup")
+    }
+
+    @Test
+    fun resolvesViewAncestryAcrossJars() {
+        val tmp = Files.createTempDirectory("cvs")
+        // appcompat.jar: AppCompatButton extends the framework View.
+        val appcompat = jar(tmp, "appcompat.jar", mapOf(
+            "androidx/appcompat/widget/AppCompatButton" to classBytes(
+                "androidx/appcompat/widget/AppCompatButton", "android/view/View", PUBLIC),
+        ))
+        // material.jar: MaterialButton extends AppCompatButton (defined in the *other* jar).
+        val material = jar(tmp, "material.jar", mapOf(
+            "com/google/android/material/button/MaterialButton" to classBytes(
+                "com/google/android/material/button/MaterialButton", "androidx/appcompat/widget/AppCompatButton", PUBLIC),
+        ))
+
+        val tags = CustomViewScanner.scan(listOf(appcompat, material)).map { it.tag }
+        assertTrue("com.google.android.material.button.MaterialButton" in tags,
+            "a subclass whose View ancestor lives in another jar must still be recognised")
+        assertTrue("androidx.appcompat.widget.AppCompatButton" in tags)
+    }
+
+    @Test
+    fun excludesFrameworkAbstractInnerAndNonViewClasses() {
+        val tmp = Files.createTempDirectory("cvs")
+        val jar = jar(tmp, "lib.jar", mapOf(
+            // Framework package — covered by SDK metadata, must be excluded.
+            "android/widget/TextView" to classBytes("android/widget/TextView", "android/view/View", PUBLIC),
+            // Abstract custom view — not directly usable as a tag.
+            "com/example/AbstractView" to classBytes("com/example/AbstractView", "android/view/View", ABSTRACT),
+            // Inner class — not a usable tag.
+            "com/example/Outer\$Inner" to classBytes("com/example/Outer\$Inner", "android/view/View", PUBLIC),
+            // Not a View at all.
+            "com/example/Helper" to classBytes("com/example/Helper", "java/lang/Object", PUBLIC),
+        ))
+
+        val tags = CustomViewScanner.scan(listOf(jar)).map { it.tag }
+        assertFalse("android.widget.TextView" in tags, "framework views are excluded")
+        assertFalse("com.example.AbstractView" in tags, "abstract views are excluded")
+        assertFalse(tags.any { it.contains('$') }, "inner classes are excluded")
+        assertFalse("com.example.Helper" in tags, "non-View classes are excluded")
+    }
+
+    @Test
+    fun cachedReusesScanUntilFingerprintChanges() {
+        val tmp = Files.createTempDirectory("cvs")
+        val jar = jar(tmp, "lib.jar", mapOf(
+            "com/example/MyView" to classBytes("com/example/MyView", "android/view/View", PUBLIC),
+        ))
+        val cache = tmp.resolve("cache/views.txt")
+
+        val first = CustomViewScanner.cached(listOf(jar), cache)
+        assertTrue(Files.isRegularFile(cache), "cache file is written")
+        assertEquals(listOf("com.example.MyView"), first.map { it.tag })
+
+        // Second call with the same (unchanged) jar reads the cache and yields the same result.
+        val second = CustomViewScanner.cached(listOf(jar), cache)
+        assertEquals(first.map { it.tag }, second.map { it.tag })
+    }
+}

--- a/android-support/src/test/kotlin/dev/ide/android/support/resources/RIdAssignmentTest.kt
+++ b/android-support/src/test/kotlin/dev/ide/android/support/resources/RIdAssignmentTest.kt
@@ -1,0 +1,45 @@
+package dev.ide.android.support.resources
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class RIdAssignmentTest {
+
+    private val repo = ResourceRepository(
+        items = listOf(
+            ResourceItem(ResourceType.COLOR, "primary", value = "#FF6200EE"),
+            ResourceItem(ResourceType.COLOR, "accent", value = "#FF03DAC5"),
+            ResourceItem(ResourceType.ATTR, "barColor"),
+            ResourceItem(ResourceType.ATTR, "maxValue"),
+            ResourceItem(ResourceType.STYLEABLE, "MyChart"),
+        ),
+        styleableAttrs = mapOf("MyChart" to listOf("barColor", "maxValue")),
+    )
+    private val ids = RIdAssignment(repo)
+
+    @Test fun `ids are in the 0x7f package space and unique per entry`() {
+        val primary = assertNotNull(ids.id(ResourceType.COLOR, "primary"))
+        val accent = assertNotNull(ids.id(ResourceType.COLOR, "accent"))
+        assertEquals(0x7f, primary ushr 24)
+        assertNotEquals(primary, accent)
+    }
+
+    @Test fun `assignment is deterministic across instances`() {
+        val again = RIdAssignment(repo)
+        assertEquals(ids.id(ResourceType.COLOR, "primary"), again.id(ResourceType.COLOR, "primary"))
+        assertEquals(ids.id(ResourceType.ATTR, "barColor"), again.id(ResourceType.ATTR, "barColor"))
+    }
+
+    @Test fun `styleable array holds its attr ids in declaration order`() {
+        val array = ids.styleableArray(repo, "MyChart")
+        assertEquals(listOf(ids.id(ResourceType.ATTR, "barColor"), ids.id(ResourceType.ATTR, "maxValue")), array.toList())
+    }
+
+    @Test fun `id round-trips back to type and name for the bridge reverse lookup`() {
+        val id = assertNotNull(ids.id(ResourceType.ATTR, "barColor"))
+        assertEquals(ResourceType.ATTR to "barColor", ids.nameOf(id))
+    }
+}

--- a/build-engine/src/main/kotlin/dev/ide/build/engine/TaskEngine.kt
+++ b/build-engine/src/main/kotlin/dev/ide/build/engine/TaskEngine.kt
@@ -42,15 +42,35 @@ class TaskGraphImpl(
 
     /** Hard dependencies per task (external + declared + inferred), restricted to tasks in this graph. */
     private val hardDeps: Map<TaskName, Set<TaskName>> = run {
-        // Explicit (author-declared) deps first; inference must not reverse these (see inferOutputDeps).
+        // Explicit (author-declared) deps are authoritative; inference must not reverse them (see inferOutputDeps).
         val explicit = tasks.associate { t ->
             t.name to (deps[t.name].orEmpty() + t.dependsOn).filterTo(LinkedHashSet()) { it != t.name && it in byName }
         }
         val inferred = inferOutputDeps(explicit)
-        tasks.associate { t ->
-            t.name to (explicit.getValue(t.name) + inferred[t.name].orEmpty())
-                .filterTo(LinkedHashSet()) { it != t.name && it in byName }
+        // Start from the explicit graph, then fold in inferred edges one at a time, DROPPING any that would
+        // close a cycle. An inferred edge (t depends on producer) is only a scheduling convenience — the real
+        // data dependency is always also declared explicitly — so refusing the few that conflict can never
+        // break correctness, but it guarantees no path-overlap coincidence can forge a cycle (issue #993:
+        // two cross-module `classes`/`jar` reverse edges that the one-hop guard alone cannot catch).
+        val acc = tasks.associateTo(HashMap()) { it.name to LinkedHashSet(explicit.getValue(it.name)) }
+        // True if `target` is reachable from `from` by following current dependency edges in [acc].
+        fun reaches(from: TaskName, target: TaskName): Boolean {
+            val seen = HashSet<TaskName>()
+            val stack = ArrayDeque<TaskName>().apply { add(from) }
+            while (stack.isNotEmpty()) {
+                val n = stack.removeLast()
+                if (n == target) return true
+                if (!seen.add(n)) continue
+                acc[n]?.let { stack.addAll(it) }
+            }
+            return false
         }
+        for (t in tasks) for (producer in inferred[t.name].orEmpty()) {
+            if (producer == t.name || producer !in byName || producer in acc.getValue(t.name)) continue
+            // Adding `t -> producer` closes a cycle iff `t` is already reachable from `producer`; if so, drop it.
+            if (!reaches(producer, t.name)) acc.getValue(t.name).add(producer)
+        }
+        acc
     }
 
     /** Predecessors per task = hard deps + ordering-only edges (mustRunAfter / mustRunBefore, declared on

--- a/build-engine/src/test/kotlin/dev/ide/build/engine/EngineDependencyTest.kt
+++ b/build-engine/src/test/kotlin/dev/ide/build/engine/EngineDependencyTest.kt
@@ -141,6 +141,40 @@ class EngineDependencyTest {
     }
 
     @Test
+    fun outputInferenceNeverFormsACrossModuleCycle() {
+        // Issue #993: the reported demo cycle was four tasks across TWO modules —
+        // `:feature:classes -> :core:jar -> :core:classes -> :feature:jar -> :feature:classes`.
+        // It arises when each module's `classes` lifecycle tracks a dir that the OTHER module's `jar`
+        // artifact lands inside (overlapping/shared output roots), so inference wants BOTH reverse edges
+        // `feature:classes -> core:jar` and `core:classes -> feature:jar`. Neither is a *direct* reversal of
+        // an explicit dep, so the one-hop guard misses them — together with the two explicit `jar -> classes`
+        // edges they close a cycle. Inferred edges are a convenience, never required for correctness, so an
+        // inferred edge must never close a cycle over the authoritative explicit graph.
+        val dir = Files.createTempDirectory("infer-xmod")
+        try {
+            val shared = dir.resolve("build")                       // a shared/overlapping output root
+            val coreJar = shared.resolve("libs/core.jar")
+            val featureJar = shared.resolve("libs/feature.jar")     // both jars land UNDER `shared`
+
+            val coreCompile = TestTask(TaskName(":core:compileJava"), outPaths = listOf(shared.resolve("core/Calc.class")))
+            val coreClasses = TestTask(TaskName(":core:classes"), inPaths = listOf(shared), dependsOn = listOf(TaskName(":core:compileJava")))
+            val coreJarT = TestTask(TaskName(":core:jar"), inPaths = listOf(shared), outPaths = listOf(coreJar), dependsOn = listOf(TaskName(":core:classes")))
+            val featCompile = TestTask(TaskName(":feature:compileJava"), outPaths = listOf(shared.resolve("feature/Feat.class")))
+            val featClasses = TestTask(TaskName(":feature:classes"), inPaths = listOf(shared), dependsOn = listOf(TaskName(":feature:compileJava")))
+            val featJarT = TestTask(TaskName(":feature:jar"), inPaths = listOf(shared), outPaths = listOf(featureJar), dependsOn = listOf(TaskName(":feature:classes")))
+
+            val graph = TaskGraphImpl(listOf(featJarT, featClasses, featCompile, coreJarT, coreClasses, coreCompile))
+            graph.topologicalLevels()   // must NOT throw CyclicTaskDependencyException — the cycle is broken
+            // The authoritative explicit ordering is preserved within each module (no `jar -> classes` reversal):
+            // a `classes` lifecycle never ends up depending on its OWN module's jar.
+            assertFalse(graph.dependencies(coreClasses).any { it.name.value == ":core:jar" }, "core:classes must not depend on core:jar")
+            assertFalse(graph.dependencies(featClasses).any { it.name.value == ":feature:jar" }, "feature:classes must not depend on feature:jar")
+            assertTrue(levelOf(graph, ":core:classes") < levelOf(graph, ":core:jar"))
+            assertTrue(levelOf(graph, ":feature:classes") < levelOf(graph, ":feature:jar"))
+        } finally { dir.toFile().deleteRecursively() }
+    }
+
+    @Test
     fun taskWithNoInputsIsSkippedAsNoSource() = runBlocking {
         val dir = Files.createTempDirectory("nosrc")
         try {

--- a/deps-api/src/main/kotlin/dev/ide/deps/Deps.kt
+++ b/deps-api/src/main/kotlin/dev/ide/deps/Deps.kt
@@ -14,11 +14,21 @@ import dev.ide.vfs.VirtualFile
  * resolve offline from cache when possible.
  */
 interface DependencyResolver {
+    /**
+     * Resolve [coordinates] into their transitive closure.
+     *
+     * [platforms] are BOM coordinates (Maven `pom`-packaged "bill of materials") imported for their
+     * `dependencyManagement` only — the Gradle `platform(...)` semantics. They contribute no artifact;
+     * they supply versions to any [coordinates] (or transitive dependency) declared *without* a version
+     * (a blank [Coordinate.version]). Plain-platform semantics: a BOM never overrides a version that was
+     * stated explicitly — it only fills the blanks. Earlier platforms win when two manage the same artifact.
+     */
     suspend fun resolve(
         coordinates: List<Coordinate>,
         repositories: List<Repository>,
         conflict: ConflictPolicy = ConflictPolicy.NEWEST,
         progress: ProgressReporter,
+        platforms: List<Coordinate> = emptyList(),
     ): ResolutionResult
 }
 

--- a/deps-impl/src/main/kotlin/dev/ide/deps/impl/MavenDependencyResolver.kt
+++ b/deps-impl/src/main/kotlin/dev/ide/deps/impl/MavenDependencyResolver.kt
@@ -41,6 +41,7 @@ class MavenDependencyResolver(
         repositories: List<Repository>,
         conflict: ConflictPolicy,
         progress: ProgressReporter,
+        platforms: List<Coordinate>,
     ): ResolutionResult {
         val repos = repositories.ifEmpty { DEFAULT_REPOSITORIES }
         val pomMemo = HashMap<Coordinate, EffPom?>()
@@ -54,8 +55,23 @@ class MavenDependencyResolver(
         val unresolved = LinkedHashSet<Coordinate>()
         val directGAs = LinkedHashSet<GA>()
 
+        // Imported BOMs (Gradle `platform(...)`): merge their dependencyManagement into one version source
+        // for versionless coordinates. Earlier platforms win on overlap (putIfAbsent); a BOM that can't be
+        // fetched is surfaced as unresolved so the caller can flag it.
+        val platformManaged = LinkedHashMap<GA, String>()
+        for (p in platforms) {
+            val eff = loadEffective(p, repos, HashSet())
+            if (eff == null) { unresolved += p; continue }
+            eff.managed.forEach { (ga, v) -> platformManaged.putIfAbsent(ga, v) }
+        }
+
         val queue = ArrayDeque<Req>()
-        for (c in coordinates) {
+        for (c0 in coordinates) {
+            // A blank version means "take it from a platform BOM" — fill it, or record it unresolved.
+            val c = if (c0.version.isBlank()) {
+                val v = platformManaged[c0.ga] ?: run { unresolved += c0; continue }
+                c0.copy(version = v)
+            } else c0
             directVersions[c.ga] = c.version
             directGAs += c.ga
             queue.add(Req(c, emptySet(), direct = true))
@@ -89,13 +105,15 @@ class MavenDependencyResolver(
             }
             packagingByGa[ga] = eff.packaging
             for (d in eff.dependencies) {
-                if (d.version.isNullOrBlank()) continue            // unmanaged version → can't place it
                 if (!d.isTransitivelyIncluded()) continue          // drop test/provided/system/optional
                 val childGa = GA(d.groupId, d.artifactId)
+                // A versionless transitive (one whose own POM left the version to dependencyManagement it
+                // didn't carry) is placeable iff a platform BOM manages it.
+                val version = d.version?.ifBlank { null } ?: platformManaged[childGa] ?: continue
                 if (childGa.excludedBy(req.exclusions)) continue
                 edges.getOrPut(ga) { linkedSetOf() }.add(childGa)
                 if (d.type.equals("aar", ignoreCase = true)) packagingByGa.putIfAbsent(childGa, "aar")
-                queue.add(Req(Coordinate(d.groupId, d.artifactId, d.version), req.exclusions + d.exclusions, direct = false))
+                queue.add(Req(Coordinate(d.groupId, d.artifactId, version), req.exclusions + d.exclusions, direct = false))
             }
             if (++processed % 4 == 0) progress.report(-1.0, "Resolving ${req.coord.name}…")
         }
@@ -224,16 +242,18 @@ class MavenDependencyResolver(
     }
 
     /**
-     * Explode an `.aar` into the cache, returning its `classes.jar`. Alongside it, the AAR's `res/` and
-     * `assets/` are unpacked into the same exploded dir — so a consumer (the IDE's resource model) can find
-     * a library's resources as a `res/` sibling of its `classes.jar`, with no further unzip at use time.
+     * Explode an `.aar` into the cache, returning its `classes.jar`. Alongside it, the AAR's `res/`,
+     * `assets/`, `jni/` and `AndroidManifest.xml` are unpacked into the same exploded dir — so a consumer
+     * (the IDE's resource model / Android build) can find a library's resources as a `res/` sibling of its
+     * `classes.jar` and its package name in the sibling manifest, with no further unzip at use time.
      */
     private fun extractClassesJar(coord: Coordinate, aar: Path): Path {
         val dir = cache.explodedDir(coord)
         Files.createDirectories(dir)
         val classesJar = dir.resolve("classes.jar")
         val marker = dir.resolve(".extracted")
-        if (Files.isRegularFile(marker)) return classesJar // already fully exploded (classes + res + assets)
+        // Re-extract if a prior (pre-manifest) explosion left no manifest, so the package name is available.
+        if (Files.isRegularFile(marker) && Files.isRegularFile(dir.resolve("AndroidManifest.xml"))) return classesJar
 
         var foundClasses = false
         ZipInputStream(Files.newInputStream(aar)).use { zin ->
@@ -245,7 +265,8 @@ class MavenDependencyResolver(
                         Files.copy(zin, classesJar, StandardCopyOption.REPLACE_EXISTING)
                         foundClasses = true
                     }
-                    !entry.isDirectory && (name.startsWith("res/") || name.startsWith("assets/")) -> {
+                    !entry.isDirectory && (name.startsWith("res/") || name.startsWith("assets/") ||
+                        name.startsWith("jni/") || name == "AndroidManifest.xml") -> {
                         val target = dir.resolve(name).normalize()
                         if (target.startsWith(dir)) { // zip-slip guard
                             Files.createDirectories(target.parent)

--- a/deps-impl/src/test/kotlin/dev/ide/deps/impl/MavenDependencyResolverTest.kt
+++ b/deps-impl/src/test/kotlin/dev/ide/deps/impl/MavenDependencyResolverTest.kt
@@ -140,6 +140,55 @@ class MavenDependencyResolverTest {
     }
 
     @Test
+    fun platformBomSuppliesVersionForVersionlessDependency() {
+        // A BOM manages common:1.5; the user declares `common` with no version + imports the BOM.
+        val files = FakeRepo()
+        files.put("common", "1.5")
+        files.putBom("bom", "1.0", manages = listOf(Dep("g", "common", "1.5")))
+        val (resolver, _) = newResolver(files)
+
+        val result = runBlocking {
+            resolver.resolve(
+                listOf(coord("common", "")), listOf(repo), ConflictPolicy.NEWEST, noProgress,
+                platforms = listOf(coord("bom", "1.0")),
+            )
+        }
+        assertTrue(result.unresolved.isEmpty(), "unexpected unresolved: ${result.unresolved}")
+        assertEquals("1.5", result.resolved.single { it.coordinate.name == "common" }.coordinate.version)
+    }
+
+    @Test
+    fun platformDoesNotOverrideAnExplicitVersion() {
+        // Plain-platform semantics: an explicitly-declared version wins over the BOM's managed version.
+        val files = FakeRepo()
+        files.put("common", "1.0")
+        files.put("common", "2.0")
+        files.putBom("bom", "1.0", manages = listOf(Dep("g", "common", "2.0")))
+        val (resolver, _) = newResolver(files)
+
+        val result = runBlocking {
+            resolver.resolve(
+                listOf(coord("common", "1.0")), listOf(repo), ConflictPolicy.NEWEST, noProgress,
+                platforms = listOf(coord("bom", "1.0")),
+            )
+        }
+        assertEquals("1.0", result.resolved.single { it.coordinate.name == "common" }.coordinate.version)
+    }
+
+    @Test
+    fun versionlessDependencyWithoutPlatformIsUnresolved() {
+        val files = FakeRepo()
+        files.put("common", "1.0")
+        val (resolver, _) = newResolver(files)
+
+        val result = runBlocking {
+            resolver.resolve(listOf(coord("common", "")), listOf(repo), ConflictPolicy.NEWEST, noProgress)
+        }
+        assertTrue(result.resolved.isEmpty(), "nothing should resolve: ${result.resolved.map { it.coordinate }}")
+        assertEquals(listOf(coord("common", "")), result.unresolved)
+    }
+
+    @Test
     fun unresolvedWhenRepoLacksTheArtifact() {
         val (resolver, _) = newResolver(FakeRepo())
         val result = runBlocking { resolver.resolve(listOf(coord("ghost", "9.9")), listOf(repo), ConflictPolicy.NEWEST, noProgress) }
@@ -173,15 +222,27 @@ class MavenDependencyResolverTest {
             val ext = if (packaging == "aar") "aar" else "jar"
             byUrl[url("g", name, version, ext)] = jarBytes
         }
+
+        /** A `pom`-packaged BOM: only a POM with a `<dependencyManagement>` block, no artifact. */
+        fun putBom(name: String, version: String, manages: List<Dep>) {
+            byUrl[url("g", name, version, "pom")] = pom("g", name, version, "pom", emptyList(), manages).toByteArray()
+        }
     }
 
     private fun url(g: String, a: String, v: String, ext: String): String =
         "$BASE/${g.replace('.', '/')}/$a/$v/$a-$v.$ext"
 
-    private fun pom(g: String, a: String, v: String, packaging: String, deps: List<Dep>): String = buildString {
+    private fun pom(g: String, a: String, v: String, packaging: String, deps: List<Dep>, managed: List<Dep> = emptyList()): String = buildString {
         append("""<?xml version="1.0" encoding="UTF-8"?><project>""")
         append("<groupId>$g</groupId><artifactId>$a</artifactId><version>$v</version>")
         if (packaging != "jar") append("<packaging>$packaging</packaging>")
+        if (managed.isNotEmpty()) {
+            append("<dependencyManagement><dependencies>")
+            for (d in managed) {
+                append("<dependency><groupId>${d.g}</groupId><artifactId>${d.a}</artifactId><version>${d.v}</version></dependency>")
+            }
+            append("</dependencies></dependencyManagement>")
+        }
         if (deps.isNotEmpty()) {
             append("<dependencies>")
             for (d in deps) {

--- a/docs/fdroid-izzyondroid.md
+++ b/docs/fdroid-izzyondroid.md
@@ -1,0 +1,100 @@
+# Distributing CodeAssist via IzzyOnDroid (F-Droid)
+
+This documents how CodeAssist is published to the **IzzyOnDroid** F-Droid repository, why the
+**official F-Droid main repo is not used**, and the exact steps to cut a release IzzyOnDroid can pick up.
+
+## Why IzzyOnDroid and not the official F-Droid repo
+
+The official F-Droid repo builds every app **from source on its own buildserver**, with no network
+access for arbitrary downloads and no prebuilt binaries. CodeAssist's on-device Android pipeline
+cannot meet that today:
+
+- **Prebuilt `aapt2`** (`ide-android/src/main/jniLibs/<abi>/libaapt2.so`, fetched from the ReVanced
+  GitHub releases by the `fetchAndroidBuildTools` Gradle task). aapt2 is itself free software (AOSP,
+  Apache-2.0) but building it from source on the F-Droid buildserver is infeasible, and F-Droid will
+  not ship a binary it did not build.
+- **Build-time network download** (`fetchAndroidBuildTools`) — forbidden on the buildserver.
+- **Bundled `android.jar`** (`ide-android/src/main/assets/android.jar`) — the Android SDK platform
+  stubs, shipped inside the APK as the on-device compiler boot classpath. The Android SDK is under
+  Google's non-free SDK licence, so shipping it is a non-free asset.
+
+IzzyOnDroid instead distributes the **developer's own prebuilt, signed APK** (pulled from GitHub
+Releases). It requires the app to be FOSS-licensed and free of proprietary trackers/libraries — which
+CodeAssist is — and discloses any binary blobs as *Anti-Features* rather than rejecting them.
+
+## One-time prerequisites (done in this repo)
+
+- [x] **FOSS licence** — `LICENSE` is GPL-3.0-or-later; declared in `README.md`.
+- [x] **Fastlane metadata** — `fastlane/metadata/android/en-US/` holds `title.txt`,
+      `short_description.txt`, `full_description.txt`, and `changelogs/<versionCode>.txt`. IzzyOnDroid
+      reads these for the listing.
+- [ ] **Promo images (optional)** — add to `fastlane/metadata/android/en-US/images/`:
+      `icon.png` (512×512, optional — IzzyOnDroid otherwise extracts it from the APK),
+      `featureGraphic.png` (1024×500), and `phoneScreenshots/1.png …` (real device screenshots).
+- [x] **Public source** — https://github.com/tyron12233/CodeAssist (branch `main`).
+
+## Signing — important
+
+The APK published to IzzyOnDroid is signed with the **upload key**
+(`keystore/upload-keystore.jks`, alias `upload-key`) — the same key used for the Play *upload*.
+
+Because Google Play uses **Play App Signing** (Google re-signs with a managed key), the Play-distributed
+build and the IzzyOnDroid build have **different signatures**. That is expected and unavoidable: a user
+cannot update across the two stores; they are independent installs. Keep using the **same** key for every
+IzzyOnDroid release so in-store updates work — if the signature ever changes, IzzyOnDroid users must
+uninstall/reinstall.
+
+## Cutting a release IzzyOnDroid can ingest
+
+IzzyOnDroid's updater watches the GitHub **Releases** of the repo and picks up the APK asset whose
+`versionCode` is newest.
+
+1. **Bump the version** in `ide-android/build.gradle.kts` (`versionCode` must strictly increase;
+   `versionName` is the human label, e.g. `3.0.0`).
+2. **Add a changelog** `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+3. **Build a signed release APK** (not an AAB — IzzyOnDroid distributes APKs):
+
+   ```sh
+   export JAVA_HOME="/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home"
+   ./gradlew :ide-android:assembleRelease
+   # → ide-android/build/outputs/apk/release/ide-android-release.apk
+   ```
+
+4. **Tag and publish a GitHub release**, attaching the APK:
+
+   ```sh
+   git tag v3.0.0 && git push origin v3.0.0
+   gh release create v3.0.0 \
+     ide-android/build/outputs/apk/release/ide-android-release.apk \
+     --title "CodeAssist 3.0" \
+     --notes-file fastlane/metadata/android/en-US/changelogs/31.txt
+   ```
+
+## Requesting addition to IzzyOnDroid (first time only)
+
+Open a **Request For Packaging** issue at the IzzyOnDroid repo:
+https://gitlab.com/IzzyOnDroid/repo/-/issues (use the "Request packaging of an app" template), with:
+
+- **App name:** CodeAssist
+- **Source / repo:** https://github.com/tyron12233/CodeAssist
+- **Releases (APK):** https://github.com/tyron12233/CodeAssist/releases
+- **Licence:** GPL-3.0-or-later
+- **applicationId:** `com.tyron.code`
+- **Update mechanism:** GitHub Releases (APK attached per release)
+- **Anti-Features (disclose up front):** see below.
+
+After the app is accepted once, every later GitHub release with a higher `versionCode` is picked up
+automatically — no further requests needed.
+
+## Anti-Features to disclose
+
+IzzyOnDroid runs the F-Droid scanner over the APK. Declare these proactively so review is smooth:
+
+- **NonFreeAssets** — the bundled `android.jar` (Android SDK platform stubs, non-free SDK licence)
+  shipped as the on-device compiler boot classpath.
+- **Prebuilt component** — the bundled `libaapt2.so` binaries (Apache-2.0 source, but shipped prebuilt).
+
+Neither is a tracker and the app contains **no analytics, ads, or proprietary libraries**. The only
+network use is the user-initiated Maven dependency download on the Dependencies screen (declared via the
+`INTERNET` permission), and the optional install of the user's own built APK via `PackageInstaller`
+(`REQUEST_INSTALL_PACKAGES`).

--- a/fastlane/metadata/android/en-US/changelogs/31.txt
+++ b/fastlane/metadata/android/en-US/changelogs/31.txt
@@ -1,0 +1,13 @@
+CodeAssist 3.0 — rebuilt from the ground up.
+
+* New native incremental build engine and on-device Android APK pipeline
+  (aapt2, R, D8 dexing, packaging, signing) — build and install on-device.
+* Build and run mixed Kotlin/Java projects; the Kotlin compiler now runs on
+  device.
+* Multi-module projects, Android app/library modules, variants and JAR/AAR
+  Maven dependencies.
+* Error-tolerant code completion, Android XML intelligence, inline diagnostics
+  and quick-fixes, go-to-symbol and auto-import.
+* New Scratch/Blockly-style block editor that projects your real code.
+* Run sandbox that prompts before code accesses network, files or processes.
+* Rebuilt Compose UI shared across desktop and Android.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,39 @@
+CodeAssist is an on-device IDE that compiles and runs real Android and Java
+projects directly on your phone or tablet — no PC, no server, and no Gradle
+daemon required.
+
+Version 3.0 is a complete rewrite. The entire IDE — editor, build system, and
+Android toolchain — was re-engineered from scratch to be fast, incremental, and
+fully offline.
+
+<b>A real on-device build system</b>
+* Native incremental build engine — only what changed is rebuilt.
+* Full Android APK pipeline on-device: resource compilation (aapt2), R
+  generation, D8 dexing, packaging and signing, all in-process.
+* Build, install and launch a debug APK straight from your device.
+
+<b>Java and Kotlin</b>
+* First-class Java support backed by the Eclipse compiler.
+* End-to-end Kotlin: edit, compile and run mixed Kotlin/Java modules with the
+  Kotlin compiler running on-device.
+* Multi-module projects, Android app and library modules, build variants, and
+  JAR/AAR library dependencies resolved from Maven.
+
+<b>A smarter editor</b>
+* Fast, error-tolerant code completion that works on half-typed code.
+* Android XML intelligence for layouts, manifests, values and drawables, driven
+  by the real Android SDK, with resource references and go-to-definition.
+* Inline diagnostics, quick-fixes and intentions.
+* Go-to-symbol and auto-import powered by a low-memory on-device index.
+
+<b>Block editor</b>
+* A Scratch/Blockly-style projectional editor with typed sockets — a live
+  projection of your real code, so switching between Code and Blocks loses
+  nothing.
+
+<b>Safe runs</b>
+* A run sandbox prompts you before code you run touches the network, files,
+  reflection or other processes.
+
+CodeAssist is free and open-source software, licensed under the GNU General
+Public License v3.0 or later.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Build, edit and run Android and Java apps entirely on your device.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+CodeAssist

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,9 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 kotlin.code.style=official
+
+# :ide-ui declares a custom `jvmShared` intermediate source set (shared by the desktop + android targets so
+# it can depend on the plain-JVM layout-preview-api). Explicit dependsOn edges conflict with the default
+# Kotlin hierarchy template; we use no native/apple targets, so disabling it loses nothing and silences the
+# "Default Kotlin Hierarchy Template Not Applied" warning.
+kotlin.mpp.applyDefaultHierarchyTemplate=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ r8 = "8.13.19"        # com.android.tools.r8.D8 — the dexer
 apksig = "8.7.3"      # com.android.apksig.ApkSigner — APK v1/v2/v3 signing
 asm = "9.7"           # org.ow2.asm — bytecode rewrite of System.exit for the in-process Java dex-run
 trove4j = "1.0.20200330"  # gnu.trove.* — IntelliJ-core dependency the Kotlin compiler needs but doesn't bundle
+desugarJdkLibs = "2.1.5"  # com.android.tools:desugar_jdk_libs — core-library desugaring (temporarily enabled)
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -47,8 +48,10 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 android-r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 android-apksig = { module = "com.android.tools.build:apksig", version.ref = "apksig" }
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 ow2-asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 ow2-asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
+ow2-asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" } # ClassRemapper/Remapper — bridge reparent + type remap
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/ide-android/build.gradle.kts
+++ b/ide-android/build.gradle.kts
@@ -116,8 +116,8 @@ android {
         minSdk = 26
         targetSdk = 36
         // versionCode must exceed the last published release (the previous-codebase app reached ~29).
-        versionCode = 30
-        versionName = "2.0.0"
+        versionCode = 31
+        versionName = "3.0.0"
         // connectedAndroidTest harness (the on-device Kotlin-compiler discovery spike).
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/ide-android/build.gradle.kts
+++ b/ide-android/build.gradle.kts
@@ -168,6 +168,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Temporarily enabled: backports newer java.* APIs (java.time, java.nio.file.Files.readString, …)
+        // below their native API level via desugar_jdk_libs (see the coreLibraryDesugaring dep below).
+        isCoreLibraryDesugaringEnabled = true
     }
 
     // The Eclipse/OSGi jars (jdt.core, ecj, core.runtime, equinox.*, osgi, …) ship lots of overlapping
@@ -323,6 +326,11 @@ dependencies {
     implementation(project(":ide-core")) {
         exclude(group = "org.eclipse.jdt", module = "ecj")
     }
+    // Layout-preview live custom-view runtime: the Bridge classes + DexClassLoader factory live here and
+    // need the contracts (api), the CustomViewRuntime/StyledAttrResolver seam (impl), and D8InProcessDexer.
+    implementation(project(":layout-preview-api"))
+    implementation(project(":layout-preview-impl"))
+    implementation(project(":android-support"))
     implementation(files(relocateEcjForArt.flatMap { it.outputJar }))
 
     // The JDK `java.compiler` module's javax.* classes (javax.lang.model / .tools / .annotation.processing),
@@ -349,6 +357,9 @@ dependencies {
     // here — they ship as jniLibs prebuilts (see fetchAndroidBuildTools below).
     implementation(libs.android.r8)
     implementation(libs.android.apksig)
+
+    // Core-library desugaring runtime (temporarily enabled — see isCoreLibraryDesugaringEnabled above).
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(compose.runtime)
     implementation(compose.foundation)

--- a/ide-android/src/main/kotlin/dev/ide/android/AndroidIde.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/AndroidIde.kt
@@ -44,6 +44,11 @@ object AndroidIde {
         val dexRunner = DexClassLoaderRunner(File(context.cacheDir, "dexrun"))
         // Installs + launches a built APK (the android Run) via the system package installer.
         val apkInstaller = ApkInstallerImpl(context)
+        // Renders live custom views in the layout preview: D8-dex the instrumented classes + DexClassLoader.
+        val previewRuntime = dev.ide.preview.bridge.DexCustomViewRuntime(
+            context.applicationContext, androidJar.toPath(),
+            File(context.cacheDir, "preview"), android.os.Build.VERSION.SDK_INT,
+        )
         // dataDir = the whole app filesDir, so a backup also sweeps up project files left by a previous
         // (incompatible) app version that still live in app storage after the update.
         val manager = ProjectManager.onDevice(
@@ -67,6 +72,7 @@ object AndroidIde {
                 dexRunner = dexRunner,
                 deviceApiLevel = android.os.Build.VERSION.SDK_INT,
                 apkInstaller = apkInstaller,
+                customViewRuntime = previewRuntime,
             )
         } else {
             manager.open(manager.list().first().rootPath)

--- a/ide-android/src/main/kotlin/dev/ide/preview/bridge/BridgeRuntime.kt
+++ b/ide-android/src/main/kotlin/dev/ide/preview/bridge/BridgeRuntime.kt
@@ -1,0 +1,83 @@
+package dev.ide.preview.bridge
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import dev.ide.preview.NativeCanvasHolder
+import dev.ide.preview.RCanvas
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ViewHost
+import dev.ide.preview.impl.StyledAttrResolver
+
+/**
+ * The on-device Bridge runtime the BridgeRemapper reparents user views onto. The instrumented user class
+ * `extends dev.ide.preview.bridge.widget.BridgeView` (a real `android.view.View`), and its
+ * `obtainStyledAttributes(...)` call is redirected to [Bridges.obtainStyledAttributes], which returns a
+ * [dev.ide.preview.bridge.res.BridgeTypedArray] of pre-resolved values. The view renders into our owned
+ * canvas via [ViewHost], unwrapping the native `android.graphics.Canvas` for the user's `onDraw`.
+ *
+ * Package/class names here MUST match `dev.ide.preview.impl.bridge.BridgeTypeMap` exactly.
+ */
+
+/** Raw layout attributes for a custom view (KXml-free; built from the inflater's neutral attrs). */
+class BridgeAttributeSet(val rawAttrs: Map<String, String>) : AttributeSet {
+    private val names = rawAttrs.keys.toList()
+    private val values = names.map { rawAttrs[it] ?: "" }
+
+    override fun getAttributeCount(): Int = names.size
+    override fun getAttributeName(index: Int): String = names.getOrElse(index) { "" }
+    override fun getAttributeValue(index: Int): String = values.getOrElse(index) { "" }
+    override fun getAttributeValue(namespace: String?, name: String?): String? = rawAttrs[name]
+    override fun getPositionDescription(): String = "preview"
+    override fun getAttributeNameResource(index: Int): Int = 0
+    override fun getAttributeListValue(ns: String?, attr: String?, options: Array<out String>?, def: Int): Int = def
+    override fun getAttributeBooleanValue(ns: String?, attr: String?, def: Boolean): Boolean = rawAttrs[attr]?.toBoolean() ?: def
+    override fun getAttributeResourceValue(ns: String?, attr: String?, def: Int): Int = def
+    override fun getAttributeIntValue(ns: String?, attr: String?, def: Int): Int = rawAttrs[attr]?.toIntOrNull() ?: def
+    override fun getAttributeUnsignedIntValue(ns: String?, attr: String?, def: Int): Int = rawAttrs[attr]?.toIntOrNull() ?: def
+    override fun getAttributeFloatValue(ns: String?, attr: String?, def: Float): Float = rawAttrs[attr]?.toFloatOrNull() ?: def
+    override fun getAttributeListValue(index: Int, options: Array<out String>?, def: Int): Int = def
+    override fun getAttributeBooleanValue(index: Int, def: Boolean): Boolean = values.getOrNull(index)?.toBoolean() ?: def
+    override fun getAttributeResourceValue(index: Int, def: Int): Int = def
+    override fun getAttributeIntValue(index: Int, def: Int): Int = values.getOrNull(index)?.toIntOrNull() ?: def
+    override fun getAttributeUnsignedIntValue(index: Int, def: Int): Int = values.getOrNull(index)?.toIntOrNull() ?: def
+    override fun getAttributeFloatValue(index: Int, def: Float): Float = values.getOrNull(index)?.toFloatOrNull() ?: def
+    override fun getIdAttribute(): String? = rawAttrs["id"]
+    override fun getClassAttribute(): String? = null
+    override fun getIdAttributeResourceValue(def: Int): Int = def
+    override fun getStyleAttribute(): Int = 0
+}
+
+/**
+ * The static trampoline the instrumented `obtainStyledAttributes` call lands on. Resolves the styleable's
+ * attr ids → values via the [StyledAttrResolver] set for the current preview (thread-local), reading the
+ * view's raw attrs from its [BridgeAttributeSet].
+ */
+object Bridges {
+    val styledResolver: ThreadLocal<StyledAttrResolver?> = ThreadLocal()
+
+    @JvmStatic
+    fun obtainStyledAttributes(context: Context?, set: AttributeSet?, attrs: IntArray, defStyleAttr: Int, defStyleRes: Int): dev.ide.preview.bridge.res.BridgeTypedArray {
+        val raw = (set as? BridgeAttributeSet)?.rawAttrs ?: emptyMap()
+        val values = styledResolver.get()?.resolve(raw, attrs) ?: emptyList()
+        return dev.ide.preview.bridge.res.BridgeTypedArray(values)
+    }
+}
+
+/** Helper: unwrap the owned [RCanvas] to the native `android.graphics.Canvas`. */
+internal fun RCanvas.androidCanvas(): android.graphics.Canvas? =
+    (this as? NativeCanvasHolder)?.nativeCanvas() as? android.graphics.Canvas
+
+/**
+ * Adapts a reparented [dev.ide.preview.bridge.widget.BridgeView] (a real `View`) to the engine's [ViewHost]:
+ * the engine's measure/layout passes drive the `View`, and [drawContent] runs the user's `onDraw` on the
+ * unwrapped native canvas. Kept as a wrapper (rather than `BridgeView : ViewHost`) so `View.getMeasuredWidth`
+ * etc. don't clash with the interface's `val` members.
+ */
+class AndroidViewHost(private val view: dev.ide.preview.bridge.widget.BridgeView) : ViewHost {
+    override fun measure(widthSpec: Int, heightSpec: Int) { view.measure(widthSpec, heightSpec) }
+    override val measuredWidth: Int get() = view.measuredWidth
+    override val measuredHeight: Int get() = view.measuredHeight
+    override fun layout(l: Int, t: Int, r: Int, b: Int) { view.layout(l, t, r, b) }
+    override fun drawContent(canvas: RCanvas) { canvas.androidCanvas()?.let { view.renderContent(it) } }
+}

--- a/ide-android/src/main/kotlin/dev/ide/preview/bridge/DexCustomViewRuntime.kt
+++ b/ide-android/src/main/kotlin/dev/ide/preview/bridge/DexCustomViewRuntime.kt
@@ -9,9 +9,11 @@ import dev.ide.preview.RenderContext
 import dev.ide.preview.RenderNode
 import dev.ide.preview.bridge.widget.BridgeView
 import dev.ide.preview.impl.CustomViewFactory
+import dev.ide.preview.impl.CustomViewPreviewException
 import dev.ide.preview.impl.CustomViewRuntime
 import dev.ide.preview.impl.StyledAttrResolver
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -33,14 +35,17 @@ class DexCustomViewRuntime(
         val inputs = ArrayList<Path>()
         Files.walk(classesDir).use { w -> w.filter { it.toString().endsWith(".class") }.forEach { inputs.add(it) } }
         deps.filter { it.toString().endsWith(".jar") }.forEach { inputs.add(it) }
-        if (inputs.isEmpty()) return null
+        if (inputs.isEmpty()) throw CustomViewPreviewException("nothing to dex for preview (no compiled classes)")
 
         val dexOut = File(cacheDir, "preview-dex").apply { deleteRecursively(); mkdirs() }
-        val result = runCatching { D8InProcessDexer().dex(inputs, androidJar, minApi, false, dexOut.toPath()) }.getOrNull()
-        if (result == null || !result.success) return null
+        val result = runCatching { D8InProcessDexer().dex(inputs, androidJar, minApi, false, dexOut.toPath()) }
+            .getOrElse { throw CustomViewPreviewException("D8 dexing of preview classes threw: ${it.message ?: it.javaClass.simpleName}", it) }
+        if (!result.success) {
+            throw CustomViewPreviewException("D8 dexing of preview classes failed: ${result.log.takeLast(3).joinToString(" / ").ifBlank { "(no diagnostics)" }}")
+        }
 
         val dexes = dexOut.walkTopDown().filter { it.extension == "dex" }.map { it.absolutePath }.toList()
-        if (dexes.isEmpty()) return null
+        if (dexes.isEmpty()) throw CustomViewPreviewException("D8 produced no .dex output for preview classes")
         val optimized = File(cacheDir, "preview-oat").apply { mkdirs() }
         val loader = DexClassLoader(dexes.joinToString(File.pathSeparator), optimized.absolutePath, null, javaClass.classLoader)
 
@@ -50,12 +55,25 @@ class DexCustomViewRuntime(
                 for (i in 0 until attrs.count) rawAttrs[attrs.name(i)] = attrs.value(i)
                 Bridges.styledResolver.set(styled)
                 return try {
-                    val cls = loader.loadClass(fqName)
-                    val ctor = cls.getConstructor(Context::class.java, AttributeSet::class.java)
-                    val view = ctor.newInstance(context, BridgeAttributeSet(rawAttrs)) as? BridgeView ?: return null
+                    val cls = try {
+                        loader.loadClass(fqName)
+                    } catch (e: Throwable) {
+                        throw CustomViewPreviewException("class $fqName not found in preview dex (${e.javaClass.simpleName})", e)
+                    }
+                    val ctor = try {
+                        cls.getConstructor(Context::class.java, AttributeSet::class.java)
+                    } catch (e: NoSuchMethodException) {
+                        throw CustomViewPreviewException("$fqName has no (Context, AttributeSet) constructor", e)
+                    }
+                    val instance = try {
+                        ctor.newInstance(context, BridgeAttributeSet(rawAttrs))
+                    } catch (e: InvocationTargetException) {
+                        val cause = e.targetException ?: e
+                        throw CustomViewPreviewException("$fqName constructor threw ${cause.javaClass.simpleName}: ${cause.message ?: "(no message)"}", cause)
+                    }
+                    val view = instance as? BridgeView
+                        ?: throw CustomViewPreviewException("$fqName is not a bridged View subclass (got ${instance.javaClass.name}) — its base may not have been instrumented")
                     RenderNode(host = AndroidViewHost(view)).also { it.tag = fqName }
-                } catch (t: Throwable) {
-                    null
                 } finally {
                     Bridges.styledResolver.remove()
                 }

--- a/ide-android/src/main/kotlin/dev/ide/preview/bridge/DexCustomViewRuntime.kt
+++ b/ide-android/src/main/kotlin/dev/ide/preview/bridge/DexCustomViewRuntime.kt
@@ -1,0 +1,65 @@
+package dev.ide.preview.bridge
+
+import android.content.Context
+import android.util.AttributeSet
+import dalvik.system.DexClassLoader
+import dev.ide.android.support.tools.D8InProcessDexer
+import dev.ide.preview.AttrReader
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.bridge.widget.BridgeView
+import dev.ide.preview.impl.CustomViewFactory
+import dev.ide.preview.impl.CustomViewRuntime
+import dev.ide.preview.impl.StyledAttrResolver
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * On-device [CustomViewRuntime]: D8-dexes the preview-compiled, BridgeRemapper-instrumented classes and
+ * loads them through a [DexClassLoader] whose parent (the app classloader) exposes `android.*` and the
+ * `dev.ide.preview.bridge.*` runtime. The returned factory instantiates each custom view against the app
+ * [context] + a [BridgeAttributeSet], with the styled-attribute resolver bound on [Bridges] for the
+ * duration of the constructor (so the instrumented `obtainStyledAttributes` resolves).
+ */
+class DexCustomViewRuntime(
+    private val context: Context,
+    private val androidJar: Path,
+    private val cacheDir: File,
+    private val minApi: Int,
+) : CustomViewRuntime {
+
+    override fun createFactory(classesDir: Path, deps: List<Path>, styled: StyledAttrResolver): CustomViewFactory? {
+        val inputs = ArrayList<Path>()
+        Files.walk(classesDir).use { w -> w.filter { it.toString().endsWith(".class") }.forEach { inputs.add(it) } }
+        deps.filter { it.toString().endsWith(".jar") }.forEach { inputs.add(it) }
+        if (inputs.isEmpty()) return null
+
+        val dexOut = File(cacheDir, "preview-dex").apply { deleteRecursively(); mkdirs() }
+        val result = runCatching { D8InProcessDexer().dex(inputs, androidJar, minApi, false, dexOut.toPath()) }.getOrNull()
+        if (result == null || !result.success) return null
+
+        val dexes = dexOut.walkTopDown().filter { it.extension == "dex" }.map { it.absolutePath }.toList()
+        if (dexes.isEmpty()) return null
+        val optimized = File(cacheDir, "preview-oat").apply { mkdirs() }
+        val loader = DexClassLoader(dexes.joinToString(File.pathSeparator), optimized.absolutePath, null, javaClass.classLoader)
+
+        return object : CustomViewFactory {
+            override fun create(fqName: String, attrs: AttrReader, ctx: RenderContext): RenderNode? {
+                val rawAttrs = HashMap<String, String>()
+                for (i in 0 until attrs.count) rawAttrs[attrs.name(i)] = attrs.value(i)
+                Bridges.styledResolver.set(styled)
+                return try {
+                    val cls = loader.loadClass(fqName)
+                    val ctor = cls.getConstructor(Context::class.java, AttributeSet::class.java)
+                    val view = ctor.newInstance(context, BridgeAttributeSet(rawAttrs)) as? BridgeView ?: return null
+                    RenderNode(host = AndroidViewHost(view)).also { it.tag = fqName }
+                } catch (t: Throwable) {
+                    null
+                } finally {
+                    Bridges.styledResolver.remove()
+                }
+            }
+        }
+    }
+}

--- a/ide-android/src/main/kotlin/dev/ide/preview/bridge/res/BridgeTypedArray.kt
+++ b/ide-android/src/main/kotlin/dev/ide/preview/bridge/res/BridgeTypedArray.kt
@@ -1,0 +1,27 @@
+package dev.ide.preview.bridge.res
+
+import dev.ide.preview.ResolvedValue
+
+/**
+ * A drop-in for `android.content.res.TypedArray` in instrumented user code (the remapper remaps the user's
+ * `TypedArray` local type to this). It is NOT a real `TypedArray`; it just exposes the same getters, reading
+ * the values pre-resolved by [dev.ide.preview.bridge.Bridges.obtainStyledAttributes] (indexed by styleable
+ * position — the `R.styleable.X_attr` index constants).
+ */
+class BridgeTypedArray(private val values: List<ResolvedValue?>) {
+    fun hasValue(index: Int): Boolean = values.getOrNull(index) != null
+    fun getColor(index: Int, defValue: Int): Int = (values.getOrNull(index) as? ResolvedValue.Color)?.argb ?: defValue
+    fun getDimension(index: Int, defValue: Float): Float = (values.getOrNull(index) as? ResolvedValue.Dimension)?.px ?: defValue
+    fun getDimensionPixelSize(index: Int, defValue: Int): Int = (values.getOrNull(index) as? ResolvedValue.Dimension)?.px?.toInt() ?: defValue
+    fun getDimensionPixelOffset(index: Int, defValue: Int): Int = (values.getOrNull(index) as? ResolvedValue.Dimension)?.px?.toInt() ?: defValue
+    fun getInt(index: Int, defValue: Int): Int = (values.getOrNull(index) as? ResolvedValue.IntV)?.v ?: defValue
+    fun getInteger(index: Int, defValue: Int): Int = getInt(index, defValue)
+    fun getFloat(index: Int, defValue: Float): Float = (values.getOrNull(index) as? ResolvedValue.FloatV)?.v ?: defValue
+    fun getBoolean(index: Int, defValue: Boolean): Boolean = (values.getOrNull(index) as? ResolvedValue.BoolV)?.v ?: defValue
+    fun getString(index: Int): String? = (values.getOrNull(index) as? ResolvedValue.Str)?.text?.toString()
+    fun getText(index: Int): CharSequence? = (values.getOrNull(index) as? ResolvedValue.Str)?.text
+    fun getResourceId(index: Int, defValue: Int): Int = defValue
+    fun getDrawable(index: Int): android.graphics.drawable.Drawable? = null
+    fun getIndexCount(): Int = values.count { it != null }
+    fun recycle() { /* no pool */ }
+}

--- a/ide-android/src/main/kotlin/dev/ide/preview/bridge/widget/BridgeViews.kt
+++ b/ide-android/src/main/kotlin/dev/ide/preview/bridge/widget/BridgeViews.kt
@@ -1,0 +1,52 @@
+package dev.ide.preview.bridge.widget
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+
+/**
+ * The owned view base a user custom view is reparented onto (`extends android.view.View`). The
+ * `(Context, AttributeSet)` ctor drops the attrs for the `View` base (the user reads them via the
+ * instrumented `obtainStyledAttributes`), so `View` never parses our synthetic [AttributeSet].
+ * [renderContent] exposes the protected `onDraw` so the [dev.ide.preview.ViewHost] adapter can run the
+ * user's drawing (virtual dispatch reaches the user override).
+ */
+open class BridgeView : View {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context)
+
+    fun renderContent(canvas: android.graphics.Canvas) = onDraw(canvas)
+}
+
+// View bases the remapper targets for users subclassing widgets. They extend BridgeView so no framework
+// drawing leaks in (a faithful enough base for leaf custom views in a static preview).
+open class BridgeViewGroup : BridgeView {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+}
+
+open class BridgeTextView : BridgeView {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+}
+
+open class BridgeImageView : BridgeView {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+}
+
+open class BridgeLinearLayout : BridgeView {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+}
+
+open class BridgeFrameLayout : BridgeView {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+}

--- a/ide-core/build.gradle.kts
+++ b/ide-core/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation(project(":build-api"))
     implementation(project(":build-engine"))
     implementation(project(":android-support")) // android-app/-lib module types + AndroidFacet codec
+    api(project(":layout-preview-api")) // owned XML-layout preview contracts; `api` because IdeServicesBackend implements LayoutPreviewBackend (public supertype, must be on consumers' classpath)
+    implementation(project(":layout-preview-impl")) // the preview engine (inflater + resolver + chrome)
     implementation(project(":deps-api"))
     implementation(project(":deps-impl")) // Maven dependency resolver (download/transitive/conflict)
     implementation(project(":vfs-api"))

--- a/ide-core/src/main/kotlin/dev/ide/core/AndroidXmlCompletion.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AndroidXmlCompletion.kt
@@ -3,6 +3,7 @@ package dev.ide.core
 import dev.ide.android.support.metadata.AndroidSdkMetadata
 import dev.ide.android.support.metadata.AttributeSpec
 import dev.ide.android.support.metadata.LayoutMetadata
+import dev.ide.android.support.metadata.Widget
 import dev.ide.android.support.resources.AndroidManifestCatalog
 import dev.ide.android.support.resources.DrawableXmlCatalog
 import dev.ide.android.support.resources.ResourceType
@@ -28,6 +29,8 @@ class AndroidXmlContributor(
     private val resourceNames: (ResourceType) -> List<String>,
     private val layout: () -> LayoutMetadata = { AndroidSdkMetadata.bundled() },
     private val customAttrs: () -> LayoutMetadata? = { null },
+    /** Custom View subclasses from the module's library classpath (FQN tags); offered alongside framework widgets. */
+    private val customViews: () -> List<Widget> = { emptyList() },
 ) : XmlCompletionContributor {
 
     override fun contribute(position: XmlCompletionPosition): List<CompletionItem> {
@@ -77,15 +80,23 @@ class AndroidXmlContributor(
         return (framework + custom).distinctBy { it.name }
     }
 
-    private fun tagItems(pos: XmlCompletionPosition): List<CompletionItem> =
-        layout().childTagsFor(pos.parentTag).map { w ->
-            CompletionItem(
-                label = w.tag,
-                insertText = w.tag,
-                kind = CompletionItemKind.CLASS,
-                detail = if (w.isViewGroup) "ViewGroup" else "View",
-            )
-        }
+    private fun tagItems(pos: XmlCompletionPosition): List<CompletionItem> {
+        // Framework widgets (simple names, from the SDK metadata) + custom views from the library classpath
+        // (fully-qualified names — a layout must spell a non-framework view with its FQN). Deduped by tag.
+        val seen = HashSet<String>()
+        val out = ArrayList<CompletionItem>()
+        for (w in layout().childTagsFor(pos.parentTag)) if (seen.add(w.tag)) out += widgetItem(w)
+        for (w in customViews()) if (seen.add(w.tag)) out += widgetItem(w)
+        return out
+    }
+
+    private fun widgetItem(w: Widget): CompletionItem =
+        CompletionItem(
+            label = w.tag,
+            insertText = w.tag,
+            kind = CompletionItemKind.CLASS,
+            detail = if (w.isViewGroup) "ViewGroup" else "View",
+        )
 
     private fun manifestTagItems(pos: XmlCompletionPosition): List<CompletionItem> =
         AndroidManifestCatalog.childrenOf(pos.parentTag).map { tag ->

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
@@ -180,6 +180,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
@@ -1723,6 +1724,108 @@ class IdeServices private constructor(
         return RenameOutcome(true, "Renamed '${target.oldName}' to '$name'", occurrences, editsByPath.size, newPath?.toString())
     }
 
+    // ---- file & package operations (delete / rename / move / copy), for files AND directories/packages ----
+
+    /** Absolute-normalized form, matching how [openDocuments] is keyed. */
+    private fun normPath(p: Path): Path = p.toAbsolutePath().normalize()
+
+    /** Drop every open-document overlay at [root] or under it (after a delete). */
+    private fun dropOverlaysUnder(root: Path) {
+        val r = normPath(root)
+        openDocuments.keys.filter { it == r || it.startsWith(r) }.forEach { openDocuments.remove(it) }
+    }
+
+    /** Re-point open-document overlays from [from] (a file or directory) to [to] after a move/rename. */
+    private fun rekeyOverlays(from: Path, to: Path) {
+        val f = normPath(from); val t = normPath(to)
+        for (k in openDocuments.keys.filter { it == f || it.startsWith(f) }) {
+            val dest = if (k == f) t else t.resolve(f.relativize(k))
+            openDocuments.remove(k)?.let { openDocuments[normPath(dest)] = it }
+        }
+    }
+
+    /** Offset of the identifier in a top-level `class/interface/enum/record TypeName` declaration, or null. */
+    private fun javaTypeNameOffset(text: String, typeName: String): Int? =
+        Regex("\\b(?:class|interface|enum|record)\\s+(${Regex.escape(typeName)})\\b")
+            .find(text)?.groups?.get(1)?.range?.first
+
+    /**
+     * Delete a file or directory (recursively). Drops any open-document overlays under it, then invalidates
+     * analyzers and resyncs the index. Returns true on success.
+     */
+    fun deletePath(target: Path): Boolean {
+        val abs = normPath(target)
+        val ok = runCatching {
+            if (Files.isDirectory(abs)) abs.toFile().deleteRecursively() else Files.deleteIfExists(abs)
+        }.getOrDefault(false)
+        if (ok) { dropOverlaysUnder(abs); invalidateAnalyzers(); resyncIndex() }
+        return ok
+    }
+
+    /**
+     * Rename a file or directory in place (same parent) to [newName]. For a Java source file whose public type
+     * matches the file name, this delegates to the symbol [rename] so the type and all references update too
+     * (the backing file is renamed as part of that). Otherwise it is a plain filesystem rename. [newName] is
+     * the full new name (with extension for files).
+     */
+    suspend fun renameFile(target: Path, newName: String): RenameOutcome {
+        val name = newName.trim()
+        if (name.isEmpty() || name.contains('/') || name.contains('\\')) return RenameOutcome(false, "'$newName' is not a valid name.")
+        val abs = normPath(target)
+        if (!Files.exists(abs)) return RenameOutcome(false, "'${abs.fileName}' no longer exists.")
+        val parent = abs.parent ?: return RenameOutcome(false, "Can't rename the workspace root.")
+
+        // Java class-aware path: when the file actually declares a top-level type matching its name, rename the
+        // type (and every reference) — which also moves the backing file — instead of a bare filesystem rename.
+        if (!analysisUnavailable && abs.toString().endsWith(".java")) {
+            val oldType = abs.fileName.toString().removeSuffix(".java")
+            val newType = name.removeSuffix(".java")
+            if (isValidJavaIdentifier(newType)) {
+                val text = openDocuments[abs] ?: runCatching { abs.readText() }.getOrNull()
+                val offset = text?.let { javaTypeNameOffset(it, oldType) }
+                if (text != null && offset != null) return rename(abs, text, offset, newType)
+            }
+        }
+
+        val dest = parent.resolve(name)
+        if (dest == abs) return RenameOutcome(false, "The new name is the same as the current one.")
+        if (Files.exists(dest)) return RenameOutcome(false, "'$name' already exists here.")
+        return runCatching {
+            Files.move(abs, dest)
+            rekeyOverlays(abs, dest)
+            invalidateAnalyzers(); resyncIndex()
+            RenameOutcome(true, "Renamed to '$name'", newPath = dest.toString())
+        }.getOrElse { RenameOutcome(false, "Rename failed: ${it.message}") }
+    }
+
+    /** Move a file or directory into [destDir]. Returns the new path, or null on conflict/failure. */
+    fun movePath(target: Path, destDir: Path): Path? {
+        val abs = normPath(target); val dir = normPath(destDir)
+        val dest = dir.resolve(abs.fileName)
+        if (Files.exists(dest) || dest == abs || dir == abs || dir.startsWith(abs)) return null // no overwrite / move-into-self
+        return runCatching {
+            Files.createDirectories(dir)
+            Files.move(abs, dest)
+            rekeyOverlays(abs, dest)
+            invalidateAnalyzers(); resyncIndex()
+            dest
+        }.getOrNull()
+    }
+
+    /** Copy a file or directory into [destDir]. Returns the new path, or null on conflict/failure. */
+    fun copyPath(target: Path, destDir: Path): Path? {
+        val abs = normPath(target); val dir = normPath(destDir)
+        val dest = dir.resolve(abs.fileName)
+        if (Files.exists(dest) || dest.startsWith(abs)) return null
+        return runCatching {
+            Files.createDirectories(dir)
+            if (Files.isDirectory(abs)) abs.toFile().copyRecursively(dest.toFile(), overwrite = false)
+            else Files.copy(abs, dest)
+            invalidateAnalyzers(); resyncIndex()
+            dest
+        }.getOrNull()
+    }
+
     /** Every `.java` file across the workspace's modules (for the project-wide reference sweep). */
     private fun projectJavaFiles(): List<Path> {
         val out = ArrayList<Path>()
@@ -2094,8 +2197,8 @@ class IdeServices private constructor(
      * runtime, no `android.jar`, or compilation fails (the inflater then shows placeholders).
      */
     private fun buildCustomViewFactory(module: Module, repo: dev.ide.android.support.resources.ResourceRepository): dev.ide.preview.impl.CustomViewFactory? {
-        val runtime = customViewRuntime ?: return null
-        val androidJar = previewAndroidJar() ?: return null
+        val runtime = customViewRuntime ?: return failingCustomViewFactory("no custom-view preview runtime on this platform")
+        val androidJar = previewAndroidJar() ?: return failingCustomViewFactory("no android.jar available for the preview compile")
         return runCatching {
             val work = store.rootPath.resolve(".platform/caches/preview/${module.id.value}")
             val srcDir = work.resolve("src"); val outDir = work.resolve("classes")
@@ -2118,7 +2221,10 @@ class IdeServices private constructor(
                 runCatching { ModuleCompilationContext.create(store.workspace, m).classpath.entries.map { Paths.get(it.root.path) } }.getOrDefault(emptyList())
             }.filter { Files.exists(it) }.distinct()
             val result = JdtBatchCompiler.compile(sources, deps, outDir, sourceLevel = "17", bootClasspath = listOf(androidJar))
-            if (!result.success) return@runCatching null
+            if (!result.success) {
+                val errs = result.messages.filter { it.contains("ERROR", ignoreCase = true) }.ifEmpty { result.messages }
+                return@runCatching failingCustomViewFactory("preview compile failed: ${errs.take(3).joinToString(" / ").ifBlank { "(no diagnostics)" }}")
+            }
 
             // Instrument every compiled .class in place (reparent View bases, redirect obtainStyledAttributes).
             val remapper = dev.ide.preview.impl.bridge.BridgeRemapper()
@@ -2139,8 +2245,21 @@ class IdeServices private constructor(
                 }
             }
             runtime.createFactory(outDir, deps, styled)
-        }.getOrNull()
+                ?: failingCustomViewFactory("the custom-view runtime returned no factory")
+        }.getOrElse { t ->
+            // Surface the reason (incl. a CustomViewPreviewException thrown by createFactory, e.g. a dex
+            // failure) through a factory that fails every create() with it, rather than a silent null →
+            // generic "no preview runtime" message in the preview pane.
+            failingCustomViewFactory(t.message ?: "preview setup failed (${t.javaClass.simpleName})")
+        }
     }
+
+    /** A [CustomViewFactory] whose every [create] fails with [reason], so the preview pane shows it. */
+    private fun failingCustomViewFactory(reason: String): dev.ide.preview.impl.CustomViewFactory =
+        object : dev.ide.preview.impl.CustomViewFactory {
+            override fun create(fqName: String, attrs: dev.ide.preview.AttrReader, ctx: dev.ide.preview.RenderContext): dev.ide.preview.RenderNode =
+                throw dev.ide.preview.impl.CustomViewPreviewException(reason)
+        }
 
     /** Map a project attr's declared `format` (or an inference) to a preview [dev.ide.preview.ValueFormat]. */
     private fun attrFormatOf(repo: dev.ide.android.support.resources.ResourceRepository, name: String): dev.ide.preview.ValueFormat =
@@ -2515,9 +2634,19 @@ class IdeServices private constructor(
             store.replaceSdks(listOf(sdk))
             val template = ProjectTemplateRegistry(platform.extensions).byId(TemplateId(templateId))
                 ?: error("Unknown project template '$templateId'")
-            template.generate(ScaffoldImpl(store, languageLevel), TemplateArgs(args))
+            val templateArgs = TemplateArgs(args)
+            template.generate(ScaffoldImpl(store, languageLevel), templateArgs)
             store.save()
-            return IdeServices(platform, store, androidTools, dexRunner, apkInstaller)
+            val services = IdeServices(platform, store, androidTools, dexRunner, apkInstaller)
+            // Resolve + attach the template's declared Maven dependencies (e.g. Material You's
+            // com.google.android.material:material). Resolution is suspend/network, so it runs here after the
+            // synchronous generate rather than inside the scaffold. A failure (offline, no cache) is left to
+            // surface at build time — the project is still created.
+            val templateDeps = template.dependencies(templateArgs)
+            if (templateDeps.isNotEmpty()) runBlocking {
+                for (dep in templateDeps) services.addDependency(dep.module, dep.coordinate, dep.scope)
+            }
+            return services
         }
 
         /** Open the existing workspace at [root] (seeding [sdk] only if it has none). The [ProjectManager.open] core. */

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
@@ -73,6 +73,7 @@ import dev.ide.lang.kotlin.compile.KotlinJvmCompiler
 import dev.ide.lang.xml.XmlLanguageBackend
 import dev.ide.lang.xml.XmlSourceAnalyzer
 import dev.ide.lang.jdt.context.ModuleCompilationContext
+import dev.ide.lang.jdt.rename.JdtRename
 import dev.ide.lang.jdt.index.JavaClassNamesIndex
 import dev.ide.lang.jdt.index.JavaMembersByOwnerIndex
 import dev.ide.lang.jdt.index.JavaMembersIndex
@@ -117,6 +118,7 @@ import dev.ide.model.LibraryDependency
 import dev.ide.model.LibraryKind
 import dev.ide.model.LibraryRef
 import dev.ide.model.ModuleDependency
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 import dev.ide.android.support.resources.AndroidResources
 import dev.ide.android.support.resources.DrawableXmlCatalog
@@ -233,6 +235,8 @@ class IdeServices private constructor(
     private val dexRunner: DexRunner? = null,
     /** Non-null only on-device (supplied by :ide-android): installs + launches a built APK (the android Run). */
     private val apkInstaller: ApkInstaller? = null,
+    /** Optional platform runtime that renders *live* custom views in the layout preview (device dex / desktop shim). */
+    private val customViewRuntime: dev.ide.preview.impl.CustomViewRuntime? = null,
 ) : AutoCloseable {
 
     // Language backends are contributed through the `platform.languageBackend` EP and selected per file by
@@ -787,6 +791,23 @@ class IdeServices private constructor(
     private fun parseCoordinate(name: String): Coordinate? =
         name.split(":").takeIf { it.size >= 3 }?.let { Coordinate(it[0], it[1], it[2]) }
 
+    /**
+     * Parse a user-entered dependency coordinate. Accepts `group:name:version` and the versionless
+     * `group:name` form (version filled from an imported platform BOM at resolve time → blank here).
+     */
+    private fun parseInputCoordinate(name: String): Coordinate? =
+        name.split(":").map { it.trim() }.let {
+            when (it.size) {
+                2 -> Coordinate(it[0], it[1], "")
+                3 -> Coordinate(it[0], it[1], it[2])
+                else -> null
+            }
+        }
+
+    /** The BOM coordinates [module] imports as platforms — the version source for its versionless deps. */
+    private fun declaredPlatforms(module: Module): List<Coordinate> =
+        module.dependencies.filterIsInstance<PlatformDependency>().map { it.bom }
+
     private fun findLibrary(name: String) =
         store.workspace.libraryTable.byName(name)
             ?: store.workspace.projects.firstNotNullOfOrNull { it.libraryTable.byName(name) }
@@ -842,7 +863,7 @@ class IdeServices private constructor(
 
         val result = if (externalCoords.isEmpty()) null else {
             _depsState.value = DepsResolveState(resolving = true, message = "Resolving ${module.name}…")
-            runCatching { depsResolver.resolve(externalCoords, DEFAULT_REPOSITORIES, ConflictPolicy.NEWEST, depsProgress()) }
+            runCatching { depsResolver.resolve(externalCoords, DEFAULT_REPOSITORIES, ConflictPolicy.NEWEST, depsProgress(), platforms = declaredPlatforms(module)) }
                 .getOrNull()
                 .also { _depsState.update { s -> s.copy(resolving = false) } }
         }
@@ -915,6 +936,17 @@ class IdeServices private constructor(
                 declaredRoots += node
                 nodes.putIfAbsent(node.coordinate, node)
             }
+            is PlatformDependency -> {
+                // A BOM contributes no artifact — show it as a declared root so the user sees the
+                // version source for their versionless dependencies.
+                val node = UiDependencyNode(
+                    coordinate = entry.bom.toString(),
+                    group = entry.bom.group, name = entry.bom.name, version = entry.bom.version,
+                    kind = UiDepKind.Platform, declared = true, scope = "platform",
+                )
+                declaredRoots += node
+                nodes.putIfAbsent(node.coordinate, node)
+            }
             is SdkDependency -> { /* the SDK is shown by the project tree, not as a managed dependency */ }
         }
 
@@ -952,13 +984,17 @@ class IdeServices private constructor(
      */
     suspend fun addDependency(moduleName: String, coordinate: String, scope: String): UiAddResult {
         val module = modules().firstOrNull { it.name == moduleName } ?: return UiAddResult(false, "No module '$moduleName'.")
-        val coord = parseCoordinate(coordinate) ?: return UiAddResult(false, "Invalid coordinate — expected group:name:version.")
+        val coord = parseInputCoordinate(coordinate) ?: return UiAddResult(false, "Invalid coordinate — expected group:name[:version].")
+        val versionless = coord.version.isBlank()
+        val platforms = declaredPlatforms(module)
+        if (versionless && platforms.isEmpty())
+            return UiAddResult(false, "$coordinate has no version — import a platform (BOM) first, or give an explicit version.")
         if (module.dependencies.any { it is LibraryDependency && it.library.name == coordinate })
             return UiAddResult(false, "$coordinate is already a dependency of '$moduleName'.")
 
         _depsState.value = DepsResolveState(resolving = true, message = "Resolving $coordinate…")
         val result = try {
-            depsResolver.resolve(listOf(coord), DEFAULT_REPOSITORIES, ConflictPolicy.NEWEST, depsProgress())
+            depsResolver.resolve(listOf(coord), DEFAULT_REPOSITORIES, ConflictPolicy.NEWEST, depsProgress(), platforms = platforms)
         } catch (e: Exception) {
             return UiAddResult(false, "Resolution failed: ${e.message}")
         } finally {
@@ -966,11 +1002,19 @@ class IdeServices private constructor(
         }
 
         val primary = result.resolved.firstOrNull { it.coordinate.group == coord.group && it.coordinate.name == coord.name }
-            ?: return UiAddResult(false, "Couldn't find $coordinate in the configured repositories.")
+            ?: return UiAddResult(false, if (versionless)
+                "No imported platform provides a version for ${coord.group}:${coord.name}."
+            else "Couldn't find $coordinate in the configured repositories.")
         if (primary.kind == ArtifactKind.AAR && !acceptsAar(module))
             return UiAddResult(false, "$coordinate is an Android library (.aar) — ${aarReason(module)}.")
 
-        store.workspace.libraryTable.create(coordinate).apply {
+        // Persist with the resolved, concrete coordinate — a versionless declaration is pinned to the
+        // version the platform supplied at add time (a later BOM bump won't move it; re-add to update).
+        val libraryName = primary.coordinate.toString()
+        if (libraryName != coordinate && module.dependencies.any { it is LibraryDependency && it.library.name == libraryName })
+            return UiAddResult(false, "$libraryName is already a dependency of '$moduleName'.")
+
+        store.workspace.libraryTable.create(libraryName).apply {
             kind = if (primary.kind == ArtifactKind.AAR) LibraryKind.AAR else LibraryKind.JAR
             result.resolved.forEach { addClassesRoot(it.classesRoot) }   // declared + its whole transitive closure
             primary.sourcesRoot?.let { addSourcesRoot(it) }
@@ -978,7 +1022,7 @@ class IdeServices private constructor(
         }
         val project = projectOf(module) ?: return UiAddResult(false, "No project owns '$moduleName'.")
         project.beginModification().apply {
-            module(module.id).addDependency(LibraryDependency(LibraryRef(coordinate), parseScope(scope)))
+            module(module.id).addDependency(LibraryDependency(LibraryRef(libraryName), parseScope(scope)))
             commit()
         }
         store.save()
@@ -986,13 +1030,47 @@ class IdeServices private constructor(
         resyncIndex()
         val transitiveCount = result.resolved.size - 1
         val suffix = if (transitiveCount > 0) " (+$transitiveCount transitive)" else ""
-        return UiAddResult(true, "Added $coordinate$suffix", result.resolved.size)
+        return UiAddResult(true, "Added $libraryName$suffix", result.resolved.size)
     }
 
-    /** Remove the declared library dependency [coordinate] from [moduleName] (returns false if absent). */
+    /**
+     * Import a Maven BOM ([coordinate], `group:name:version`) as a platform of [moduleName] — the Gradle
+     * `platform(...)` semantics. It contributes no artifact; it supplies versions to versionless
+     * dependencies added afterwards. Verified resolvable before it's persisted.
+     */
+    suspend fun addPlatform(moduleName: String, coordinate: String): UiAddResult {
+        val module = modules().firstOrNull { it.name == moduleName } ?: return UiAddResult(false, "No module '$moduleName'.")
+        val bom = parseCoordinate(coordinate) ?: return UiAddResult(false, "A platform BOM needs a version — expected group:name:version.")
+        if (module.dependencies.any { it is PlatformDependency && it.bom == bom })
+            return UiAddResult(false, "$coordinate is already a platform of '$moduleName'.")
+
+        _depsState.value = DepsResolveState(resolving = true, message = "Importing BOM $coordinate…")
+        val result = try {
+            depsResolver.resolve(emptyList(), DEFAULT_REPOSITORIES, ConflictPolicy.NEWEST, depsProgress(), platforms = listOf(bom))
+        } catch (e: Exception) {
+            return UiAddResult(false, "Couldn't import BOM: ${e.message}")
+        } finally {
+            _depsState.update { it.copy(resolving = false) }
+        }
+        if (bom in result.unresolved)
+            return UiAddResult(false, "Couldn't find the BOM $coordinate in the configured repositories.")
+
+        val project = projectOf(module) ?: return UiAddResult(false, "No project owns '$moduleName'.")
+        project.beginModification().apply {
+            module(module.id).addDependency(PlatformDependency(bom))
+            commit()
+        }
+        store.save()
+        return UiAddResult(true, "Imported platform $coordinate", 0)
+    }
+
+    /** Remove the declared library dependency or platform BOM [coordinate] from [moduleName] (false if absent). */
     fun removeDependency(moduleName: String, coordinate: String): Boolean {
         val module = modules().firstOrNull { it.name == moduleName } ?: return false
-        val entry = module.dependencies.firstOrNull { it is LibraryDependency && it.library.name == coordinate } ?: return false
+        val entry = module.dependencies.firstOrNull {
+            (it is LibraryDependency && it.library.name == coordinate) ||
+                (it is PlatformDependency && it.bom.toString() == coordinate)
+        } ?: return false
         val project = projectOf(module) ?: return false
         project.beginModification().apply {
             module(module.id).removeDependency(entry)
@@ -1320,11 +1398,13 @@ class IdeServices private constructor(
                         // the curated catalog) + custom-view attributes (project/AAR attrs.xml, parsed once per
                         // analyzer) + resource references (the module's merged repository, rebuilt per request).
                         val custom = runCatching { customAttrsMetadata(module) }.getOrNull()
+                        val customViews = runCatching { customViewWidgets(module) }.getOrDefault(emptyList())
                         it.contributors = listOf(
                             AndroidXmlContributor(
                                 resourceNames = { type -> resourceNamesFor(module, type) },
                                 layout = { sdkLayoutMetadata() },
                                 customAttrs = { custom },
+                                customViews = { customViews },
                             )
                         )
                     }
@@ -1551,6 +1631,112 @@ class IdeServices private constructor(
         }
     }
 
+    // ---- rename refactoring ----------------------------------------------------------------------
+
+    /** The renameable symbol under the caret (its current name + a kind label), or null. Java only. */
+    fun prepareRename(file: Path, text: String, offset: Int): RenameInfo? {
+        if (analysisUnavailable || !file.toString().endsWith(".java")) return null
+        val module = moduleForFile(file) ?: return null
+        val analyzer = analyzerFor(module) as? JdtSourceAnalyzer ?: return null
+        return try {
+            JdtRename.targetAt(analyzer.parse(store.vfs.fileFor(file), text), offset)?.let { RenameInfo(it.oldName, it.kind) }
+        } catch (e: LinkageError) {
+            analysisUnavailable = true; null
+        }
+    }
+
+    /**
+     * Rename the symbol under the caret to [newName] across the whole project: resolve the target, find every
+     * reference (binding-key match; a file-local symbol stays in its own file, otherwise project `.java` files
+     * are pre-filtered by name then parsed), then apply a multi-file edit to disk + the editor overlay. When a
+     * top-level public type whose name matches its file is renamed, the backing `.java` file is renamed too
+     * (its new path is returned so the editor can reopen it). Re-indexes and invalidates analyzers.
+     */
+    suspend fun rename(file: Path, text: String, offset: Int, newName: String): RenameOutcome {
+        val name = newName.trim()
+        if (!isValidJavaIdentifier(name)) return RenameOutcome(false, "'$newName' is not a valid Java identifier.")
+        if (analysisUnavailable) return RenameOutcome(false, "Java analysis is unavailable.")
+        val module = moduleForFile(file) ?: return RenameOutcome(false, "This file is not in a source module.")
+        val analyzer = analyzerFor(module) as? JdtSourceAnalyzer ?: return RenameOutcome(false, "Rename is only supported for Java.")
+        val fileAbs = file.toAbsolutePath().normalize()
+
+        val target: dev.ide.lang.jdt.rename.RenameTarget
+        val editsByPath = LinkedHashMap<Path, List<DocumentEdit>>()
+        var occurrences = 0
+        try {
+            val parsed = analyzer.parse(store.vfs.fileFor(file), text)
+            target = JdtRename.targetAt(parsed, offset) ?: return RenameOutcome(false, "Place the caret on a symbol to rename.")
+            if (name == target.oldName) return RenameOutcome(false, "The new name is the same as the current one.")
+
+            fun editsFor(ranges: List<TextRange>) = ranges.map { DocumentEdit(it.start, it.end - it.start, name) }
+            if (target.fileLocal) {
+                val ranges = JdtRename.referencesIn(parsed, target)
+                if (ranges.isNotEmpty()) { editsByPath[fileAbs] = editsFor(ranges); occurrences += ranges.size }
+            } else {
+                for (cand in projectJavaFiles()) {
+                    val candAbs = cand.toAbsolutePath().normalize()
+                    val candText = openDocuments[candAbs] ?: runCatching { cand.readText() }.getOrNull() ?: continue
+                    if (!candText.contains(target.oldName)) continue // cheap pre-filter before the binding parse
+                    val candParsed = if (candAbs == fileAbs) parsed else {
+                        val m = moduleForFile(cand) ?: continue
+                        val a = analyzerFor(m) as? JdtSourceAnalyzer ?: continue
+                        a.parse(store.vfs.fileFor(cand), candText)
+                    }
+                    val ranges = JdtRename.referencesIn(candParsed, target)
+                    if (ranges.isNotEmpty()) { editsByPath[candAbs] = editsFor(ranges); occurrences += ranges.size }
+                }
+            }
+        } catch (e: LinkageError) {
+            analysisUnavailable = true
+            return RenameOutcome(false, "Java analysis is unavailable.")
+        }
+        if (editsByPath.isEmpty()) return RenameOutcome(false, "No occurrences of '${target.oldName}' found.")
+
+        // Apply each file's edits descending (offsets stay valid), writing disk + the live overlay together.
+        for ((path, edits) in editsByPath) {
+            val current = openDocuments[path] ?: runCatching { path.readText() }.getOrNull() ?: continue
+            val sb = StringBuilder(current)
+            for (e in edits.sortedByDescending { it.offset }) {
+                val s = e.offset.coerceIn(0, sb.length)
+                val en = (e.offset + e.oldLength).coerceIn(s, sb.length)
+                sb.replace(s, en, e.newText.toString())
+            }
+            val updated = sb.toString()
+            openDocuments[path] = updated
+            runCatching { path.parent?.let { Files.createDirectories(it) }; path.writeText(updated) }
+        }
+
+        // Rename the backing file when a top-level public type's name matched the file name (Java convention).
+        var newPath: Path? = null
+        if (target.isType && fileAbs.fileName?.toString() == "${target.oldName}.java") {
+            val dest = fileAbs.resolveSibling("$name.java")
+            if (!Files.exists(dest)) runCatching {
+                Files.move(fileAbs, dest)
+                openDocuments.remove(fileAbs)?.let { openDocuments[dest] = it }
+                newPath = dest
+            }
+        }
+
+        invalidateAnalyzers()
+        invalidateSyntheticClasses()
+        resyncIndex()
+        return RenameOutcome(true, "Renamed '${target.oldName}' to '$name'", occurrences, editsByPath.size, newPath?.toString())
+    }
+
+    /** Every `.java` file across the workspace's modules (for the project-wide reference sweep). */
+    private fun projectJavaFiles(): List<Path> {
+        val out = ArrayList<Path>()
+        for (m in modules()) for (root in sourceRoots(m)) {
+            if (!Files.isDirectory(root)) continue
+            runCatching { Files.walk(root).use { s -> s.filter { it.toString().endsWith(".java") }.forEach { out.add(it) } } }
+        }
+        return out
+    }
+
+    private fun isValidJavaIdentifier(s: String): Boolean =
+        s.isNotEmpty() && Character.isJavaIdentifierStart(s[0]) &&
+            s.drop(1).all { Character.isJavaIdentifierPart(it) } && s !in JAVA_RESERVED
+
     // ---- XML layout completion metadata ----
 
     // The SDK-derived metadata (widget/attribute set from attrs.xml + the android.jar hierarchy).
@@ -1598,6 +1784,29 @@ class IdeServices private constructor(
         }
         if (attrs.isEmpty() && styleables.isEmpty()) return null
         return AndroidSdkMetadata(0, attrs, styleables, emptyMap(), emptyList(), attrPrefix = "app:")
+    }
+
+    /**
+     * Custom `android.view.View` subclasses on [module]'s library classpath (Maven jars + AAR `classes.jar`),
+     * so the layout editor suggests them as element tags by their fully-qualified name (e.g.
+     * `com.google.android.material.button.MaterialButton`). Framework widgets come from the SDK metadata; this
+     * fills the rest. The bytecode scan is content-fingerprint cached on disk — it only re-runs when the jar
+     * set changes — so it does not repeat per analyzer rebuild.
+     */
+    private fun customViewWidgets(module: Module): List<dev.ide.android.support.metadata.Widget> {
+        val jars = runCatching { ModuleCompilationContext.create(store.workspace, module).classpath.entries }
+            .getOrDefault(emptyList())
+            .mapNotNull { runCatching { Paths.get(it.root.path) }.getOrNull() }
+            .filter { it.toString().endsWith(".jar") && Files.exists(it) }
+            .distinct()
+        if (jars.isEmpty()) return emptyList()
+        // Seed the scanner with the framework View hierarchy (a library view's chain bottoms out at a
+        // framework base class that isn't in any jar) — simple name → is-it-a-ViewGroup.
+        val frameworkWidgets = runCatching {
+            sdkLayoutMetadata().childTagsFor(null).associate { it.tag to it.isViewGroup }
+        }.getOrDefault(emptyMap())
+        val cacheFile = store.rootPath.resolve(".platform/caches/custom-views/${module.id.value}.txt")
+        return dev.ide.android.support.metadata.CustomViewScanner.cached(jars, cacheFile, frameworkWidgets)
     }
 
     /**
@@ -1849,6 +2058,121 @@ class IdeServices private constructor(
     /** Raw bytes of a resource file (for bitmap preview); null if unreadable. */
     fun resourceBytes(file: Path): ByteArray? = runCatching { Files.readAllBytes(file) }.getOrNull()
 
+    /**
+     * Build the owned render tree + system chrome for a layout XML [file] (live buffer [text]) at the given
+     * device viewport, for the Preview view. Null if [file] isn't an Android `res/layout` file. Custom views
+     * currently render as placeholders (the live bridge is the next phase); built-ins + chrome are rendered.
+     */
+    fun layoutPreview(file: Path, text: String, request: dev.ide.preview.PreviewRequest): dev.ide.preview.LayoutPreviewResult? {
+        if (!file.toString().replace('\\', '/').contains("/res/layout")) return null
+        val module = moduleForResourceFile(file) ?: return null
+        if (module.facets.get(AndroidFacet.KEY) == null) return null
+        val repo = runCatching { AndroidResources.repository(module, store.workspace) }.getOrNull() ?: return null
+        val (themeName, title) = manifestThemeAndLabel(module, repo)
+        val customViews = if (referencesCustomView(text)) buildCustomViewFactory(module, repo) else null
+        return runCatching {
+            dev.ide.preview.impl.LayoutPreviewService(customViewFactory = customViews ?: dev.ide.preview.impl.CustomViewFactory.NONE).preview(
+                xml = text, repo = repo, themeName = themeName, title = title,
+                density = request.density, scaledDensity = request.density,
+                showChrome = request.showChrome, night = request.night,
+                layoutProvider = { name ->
+                    repo.definitions(ResourceType.LAYOUT, name).firstOrNull()?.source
+                        ?.let { runCatching { it.readText() }.getOrNull() }
+                },
+            )
+        }.getOrNull()
+    }
+
+    /** Cheap check: does the layout reference a `pkg.Custom` view tag (lower-case pkg + Capitalised class)? */
+    private val customViewTagRegex = Regex("""<[a-z][\w.]*\.[A-Z]\w*[\s/>]""")
+    private fun referencesCustomView(xml: String): Boolean = customViewTagRegex.containsMatchIn(xml)
+
+    /**
+     * Preview-compile the module's Java sources + synthetic `R`/`BuildConfig` against `android.jar`, instrument
+     * each class with [dev.ide.preview.impl.BridgeRemapper], and hand the result to the platform
+     * [dev.ide.preview.impl.CustomViewRuntime] to produce a live custom-view factory. Null when there's no
+     * runtime, no `android.jar`, or compilation fails (the inflater then shows placeholders).
+     */
+    private fun buildCustomViewFactory(module: Module, repo: dev.ide.android.support.resources.ResourceRepository): dev.ide.preview.impl.CustomViewFactory? {
+        val runtime = customViewRuntime ?: return null
+        val androidJar = previewAndroidJar() ?: return null
+        return runCatching {
+            val work = store.rootPath.resolve(".platform/caches/preview/${module.id.value}")
+            val srcDir = work.resolve("src"); val outDir = work.resolve("classes")
+            outDir.toFile().deleteRecursively(); Files.createDirectories(srcDir); Files.createDirectories(outDir)
+
+            // Synthetic R/BuildConfig as compilable Java so R.styleable.* etc. resolve at preview-compile time.
+            val sources = ArrayList<Path>()
+            for ((fqn, src) in syntheticOverlay()) {
+                val f = srcDir.resolve(fqn.replace('.', '/') + ".java")
+                Files.createDirectories(f.parent); Files.write(f, String(src).toByteArray()); sources.add(f)
+            }
+            // Compile the whole project's Java closure together so cross-module refs (the custom view's
+            // siblings/deps) resolve; library jars come from each module's analysis classpath.
+            modules().forEach { m ->
+                sourceRoots(m).forEach { root ->
+                    if (Files.isDirectory(root)) Files.walk(root).use { w -> w.filter { it.toString().endsWith(".java") }.forEach { sources.add(it) } }
+                }
+            }
+            val deps = modules().flatMap { m ->
+                runCatching { ModuleCompilationContext.create(store.workspace, m).classpath.entries.map { Paths.get(it.root.path) } }.getOrDefault(emptyList())
+            }.filter { Files.exists(it) }.distinct()
+            val result = JdtBatchCompiler.compile(sources, deps, outDir, sourceLevel = "17", bootClasspath = listOf(androidJar))
+            if (!result.success) return@runCatching null
+
+            // Instrument every compiled .class in place (reparent View bases, redirect obtainStyledAttributes).
+            val remapper = dev.ide.preview.impl.bridge.BridgeRemapper()
+            Files.walk(outDir).use { w ->
+                w.filter { it.toString().endsWith(".class") }.forEach { p ->
+                    runCatching { Files.write(p, remapper.transform(Files.readAllBytes(p))) }
+                }
+            }
+
+            val ids = dev.ide.android.support.resources.RIdAssignment(repo)
+            val resolver = dev.ide.preview.impl.ProjectPreviewResources(repo)
+            val styled = dev.ide.preview.impl.StyledAttrResolver { rawAttrs, styleableIds ->
+                styleableIds.map { id ->
+                    val (type, name) = ids.nameOf(id) ?: return@map null
+                    if (type != ResourceType.ATTR) return@map null
+                    val raw = rawAttrs[name] ?: return@map null
+                    resolver.resolve(raw, attrFormatOf(repo, name))
+                }
+            }
+            runtime.createFactory(outDir, deps, styled)
+        }.getOrNull()
+    }
+
+    /** Map a project attr's declared `format` (or an inference) to a preview [dev.ide.preview.ValueFormat]. */
+    private fun attrFormatOf(repo: dev.ide.android.support.resources.ResourceRepository, name: String): dev.ide.preview.ValueFormat =
+        when (repo.attrFormat(name)) {
+            "color" -> dev.ide.preview.ValueFormat.COLOR
+            "dimension" -> dev.ide.preview.ValueFormat.DIMENSION
+            "integer" -> dev.ide.preview.ValueFormat.INTEGER
+            "boolean" -> dev.ide.preview.ValueFormat.BOOLEAN
+            "float", "fraction" -> dev.ide.preview.ValueFormat.FLOAT
+            "string" -> dev.ide.preview.ValueFormat.STRING
+            "reference" -> dev.ide.preview.ValueFormat.REFERENCE
+            else -> dev.ide.preview.ValueFormat.ANY
+        }
+
+    /** The `android.jar` for the preview compile — the device's bundled jar, else a detected desktop SDK's. */
+    private fun previewAndroidJar(): Path? = androidTools?.androidJar
+        ?: (dev.ide.android.support.tools.AndroidSdk.findSdkRoot()?.let { dev.ide.android.support.tools.AndroidSdk.detect(it) }?.androidJar)
+
+    /** The activity/application theme name (raw dotted, sans `@style/`) and window title from the manifest. */
+    private fun manifestThemeAndLabel(module: Module, repo: dev.ide.android.support.resources.ResourceRepository): Pair<String?, String> {
+        val manifest = manifestPath(module)?.let { runCatching { it.readText() }.getOrNull() } ?: ""
+        val themeName = Regex("""android:theme\s*=\s*"@style/([^"]+)"""").find(manifest)?.groupValues?.get(1)
+        val labelRaw = Regex("""android:label\s*=\s*"([^"]+)"""").find(manifest)?.groupValues?.get(1)
+        val title = when {
+            labelRaw == null -> module.name
+            labelRaw.startsWith("@string/") ->
+                repo.definitions(ResourceType.STRING, sanitizeResName(labelRaw.removePrefix("@string/"))).firstOrNull()?.value ?: module.name
+            else -> labelRaw
+        }
+        return themeName to title
+    }
+
     /** A [DrawableResolver] backed by [module]'s merged resource repository (colors/dimens/nested drawables). */
     private fun drawableResolver(module: Module): DrawableResolver {
         val repo = runCatching { AndroidResources.repository(module, store.workspace) }.getOrNull()
@@ -2019,6 +2343,16 @@ class IdeServices private constructor(
         private val MAIN_METHOD = Regex("""\bstatic\s+void\s+main\s*\(""")
         private val NAME_ATTR = Regex("""name\s*=\s*"([^"]+)"""")
 
+        /** Java reserved words + literals, rejected as rename targets (a valid identifier can't be one). */
+        private val JAVA_RESERVED = setOf(
+            "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+            "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float",
+            "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native",
+            "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp",
+            "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void",
+            "volatile", "while", "true", "false", "null", "var", "record", "yield", "sealed", "permits",
+        )
+
         /** Cap on a single file's size for find-in-files (skip generated/huge blobs). */
         private const val MAX_SEARCH_FILE_CHARS = 2_000_000
 
@@ -2100,6 +2434,8 @@ class IdeServices private constructor(
             deviceApiLevel: Int = 21,
             /** On-device APK installer (from :ide-android) — enables the android Run (build + install + launch). */
             apkInstaller: ApkInstaller? = null,
+            /** On-device live custom-view runtime (from :ide-android) — dex + Bridge classloader for the layout preview. */
+            customViewRuntime: dev.ide.preview.impl.CustomViewRuntime? = null,
         ): IdeServices {
             if (generateDemo && Files.exists(root)) root.toFile().deleteRecursively()
             Files.createDirectories(root)
@@ -2122,7 +2458,7 @@ class IdeServices private constructor(
             // boot-classpath entry); the in-process Android build (AndroidBuildSystem.inProcess) runs off these.
             val androidTools = if (androidToolsDir != null && debugKeystore != null && bootClasspath.isNotEmpty())
                 AndroidDeviceTools(Paths.get(bootClasspath.first()), androidToolsDir, debugKeystore, deviceApiLevel) else null
-            return IdeServices(platform, store, androidTools, dexRunner, apkInstaller)
+            return IdeServices(platform, store, androidTools, dexRunner, apkInstaller, customViewRuntime)
         }
 
         private fun openStore(root: Path): Pair<PlatformCore, ProjectModelStore> {
@@ -2222,3 +2558,18 @@ private fun <T> runSync(block: suspend () -> T): T {
 
 /** Whether the Android platform sources (parameter names + javadoc for `android.*`) are installed/obtainable. */
 data class AndroidSourcesInfo(val platform: String, val installed: Boolean, val downloadable: Boolean)
+
+/** The renameable symbol under the caret: its current [oldName] and a human [kind] label (e.g. "method"). */
+data class RenameInfo(val oldName: String, val kind: String)
+
+/**
+ * Outcome of a project-wide rename: [occurrences] identifiers across [filesChanged] files were rewritten;
+ * [newPath] is set when the backing `.java` file was itself renamed (so the editor can reopen it).
+ */
+data class RenameOutcome(
+    val success: Boolean,
+    val message: String,
+    val occurrences: Int = 0,
+    val filesChanged: Int = 0,
+    val newPath: String? = null,
+)

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
@@ -114,6 +114,22 @@ class IdeServicesBackend(
     @Volatile
     private var services: IdeServices = initial
 
+    /**
+     * The thread the editor's language work (parse/complete/analyze/hints/actions/rename) runs on.
+     *
+     * Those calls reach the per-(module,language) [SourceAnalyzer]s, which hold mutable incremental-parser
+     * and JDT-environment state and are NOT safe for concurrent use, and `IdeServices.runSync` takes no
+     * lock — so they must stay serialized. They used to be serialized only incidentally, by all running on
+     * the Compose main thread, which also meant every JDT call (tens to hundreds of ms on ART) blocked
+     * typing: the editor stuttered whenever a debounced completion/analysis fired between keystrokes.
+     *
+     * Confining them to a single background thread keeps the serialization (one worker → never two
+     * analyzer calls at once) while freeing the UI thread, so typing stays smooth no matter how slow a
+     * given analysis is. `limitedParallelism(1)` borrows one worker from the shared Default pool (no
+     * dedicated thread to close).
+     */
+    private val engineDispatcher = Dispatchers.Default.limitedParallelism(1)
+
     private val _projectEpoch = MutableStateFlow(0)
     override val projectEpoch: StateFlow<Int> get() = _projectEpoch
 
@@ -296,16 +312,17 @@ class IdeServicesBackend(
         services.moduleForFile(Paths.get(path))?.name
 
     override suspend fun breadcrumbAt(path: String, text: String, offset: Int): List<String> =
-        services.breadcrumbAt(Paths.get(path), text, offset)
+        withContext(engineDispatcher) { services.breadcrumbAt(Paths.get(path), text, offset) }
 
     override suspend fun definitionAt(path: String, text: String, offset: Int): UiDefinition? =
-        services.definitionAt(Paths.get(path), text, offset)?.let { (p, o) -> UiDefinition(p.toString(), o) }
+        withContext(engineDispatcher) { services.definitionAt(Paths.get(path), text, offset) }
+            ?.let { (p, o) -> UiDefinition(p.toString(), o) }
 
     override suspend fun prepareRename(path: String, text: String, offset: Int): UiRenameTarget? =
-        withContext(Dispatchers.IO) { services.prepareRename(Paths.get(path), text, offset)?.let { UiRenameTarget(it.oldName, it.kind) } }
+        withContext(engineDispatcher) { services.prepareRename(Paths.get(path), text, offset)?.let { UiRenameTarget(it.oldName, it.kind) } }
 
     override suspend fun rename(path: String, text: String, offset: Int, newName: String): UiRenameResult =
-        withContext(Dispatchers.IO) {
+        withContext(engineDispatcher) {
             val r = services.rename(Paths.get(path), text, offset, newName)
             if (r.success) _fsEpoch.value += 1 // the multi-file edit / file rename changed the tree + other buffers
             UiRenameResult(r.success, r.message, r.occurrences, r.filesChanged, r.newPath)
@@ -318,7 +335,7 @@ class IdeServicesBackend(
         services.save(Paths.get(path), text)
 
     override suspend fun complete(path: String, text: String, offset: Int): UiCompletionResult {
-        val result = services.complete(Paths.get(path), text, offset)
+        val result = withContext(engineDispatcher) { services.complete(Paths.get(path), text, offset) }
         return UiCompletionResult(
             items = result.items.map { item ->
                 UiCompletionItem(
@@ -477,7 +494,7 @@ class IdeServicesBackend(
     override suspend fun analyze(path: String, text: String): List<UiDiagnostic> {
         // Routes through the full analysis engine: JDT compiler errors + the Java analyzers, merged,
         // suppression-filtered, and profile-adjusted into one set.
-        return services.analyzeDiagnostics(Paths.get(path), text).map { d ->
+        return withContext(engineDispatcher) { services.analyzeDiagnostics(Paths.get(path), text) }.map { d ->
             val (line, col) = lineColOf(text, d.range.start)
             UiDiagnostic(
                 severity = when (d.severity) {
@@ -508,7 +525,7 @@ class IdeServicesBackend(
     override suspend fun downloadJdkSources(feature: Int): String = services.sdkManager.downloadJdkSources(feature)
 
     override suspend fun hintsAt(path: String, text: String, startOffset: Int, endOffset: Int): List<UiInlayHint> =
-        services.inlayHints(Paths.get(path), text, startOffset, endOffset).map { h ->
+        withContext(engineDispatcher) { services.inlayHints(Paths.get(path), text, startOffset, endOffset) }.map { h ->
             UiInlayHint(
                 offset = h.offset,
                 parts = h.parts.map { UiInlayPart(it.text) },
@@ -527,11 +544,11 @@ class IdeServicesBackend(
     // ---- code actions (quick-fixes + intentions) ----
 
     override suspend fun actionsAt(path: String, text: String, selStart: Int, selEnd: Int): List<UiAction> =
-        services.editorActions(Paths.get(path), text, selStart, selEnd)
+        withContext(engineDispatcher) { services.editorActions(Paths.get(path), text, selStart, selEnd) }
             .mapIndexed { i, fix -> UiAction(i, fix.title, mapActionKind(fix.kind)) }
 
     override suspend fun applyAction(path: String, text: String, selStart: Int, selEnd: Int, actionId: Int): List<UiTextEdit> =
-        services.applyEditorAction(Paths.get(path), text, selStart, selEnd, actionId)
+        withContext(engineDispatcher) { services.applyEditorAction(Paths.get(path), text, selStart, selEnd, actionId) }
             .map { UiTextEdit(it.offset, it.offset + it.oldLength, it.newText.toString()) }
 
     private fun mapActionKind(k: dev.ide.analysis.CodeActionKind): UiActionKind = when (k) {
@@ -543,7 +560,7 @@ class IdeServicesBackend(
     // ---- block-based editing ----
 
     override suspend fun projectBlocks(path: String, text: String): UiBlockNode? =
-        services.projectBlocks(Paths.get(path), text)?.let { toUiBlock(it.root) }
+        withContext(engineDispatcher) { services.projectBlocks(Paths.get(path), text) }?.let { toUiBlock(it.root) }
 
     override suspend fun applyBlockEdit(path: String, text: String, edit: UiBlockEdit): List<UiTextEdit> {
         val blockEdit: BlockEdit = when (edit) {
@@ -563,7 +580,7 @@ class IdeServicesBackend(
                 SlotRef(BlockId(edit.toOwnerBlockId), edit.toSlotIndex, edit.toIndex),
             )
         }
-        return services.computeBlockEdit(Paths.get(path), text, blockEdit)
+        return withContext(engineDispatcher) { services.computeBlockEdit(Paths.get(path), text, blockEdit) }
             .map { UiTextEdit(it.offset, it.offset + it.oldLength, it.newText.toString()) }
     }
 

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
@@ -305,6 +305,25 @@ class IdeServicesBackend(
         }
     }.getOrNull()
 
+    override fun deletePath(path: String): Boolean {
+        val ok = services.deletePath(Paths.get(path))
+        if (ok) _fsEpoch.value += 1
+        return ok
+    }
+
+    override suspend fun renamePath(path: String, newName: String): UiRenameResult =
+        withContext(engineDispatcher) {
+            val r = services.renameFile(Paths.get(path), newName)
+            if (r.success) _fsEpoch.value += 1
+            UiRenameResult(r.success, r.message, r.occurrences, r.filesChanged, r.newPath)
+        }
+
+    override fun movePath(path: String, destDir: String): String? =
+        services.movePath(Paths.get(path), Paths.get(destDir))?.toString()?.also { _fsEpoch.value += 1 }
+
+    override fun copyPath(path: String, destDir: String): String? =
+        services.copyPath(Paths.get(path), Paths.get(destDir))?.toString()?.also { _fsEpoch.value += 1 }
+
     override fun readFile(path: String): String =
         runCatching { (Paths.get(path)).readText() }.getOrDefault("")
 

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServicesBackend.kt
@@ -69,6 +69,8 @@ import dev.ide.ui.backend.UiCompletionItem
 import dev.ide.ui.backend.UiCompletionKind
 import dev.ide.ui.backend.UiCompletionResult
 import dev.ide.ui.backend.UiDefinition
+import dev.ide.ui.backend.UiRenameResult
+import dev.ide.ui.backend.UiRenameTarget
 import dev.ide.ui.backend.UiDiagnostic
 import dev.ide.ui.backend.UiSeverity
 import dev.ide.ui.backend.UiTextEdit
@@ -107,7 +109,7 @@ import kotlin.io.path.writeText
 class IdeServicesBackend(
     initial: IdeServices,
     private val manager: ProjectManager? = null,
-) : IdeBackend {
+) : IdeBackend, dev.ide.preview.LayoutPreviewBackend {
 
     @Volatile
     private var services: IdeServices = initial
@@ -299,6 +301,16 @@ class IdeServicesBackend(
     override suspend fun definitionAt(path: String, text: String, offset: Int): UiDefinition? =
         services.definitionAt(Paths.get(path), text, offset)?.let { (p, o) -> UiDefinition(p.toString(), o) }
 
+    override suspend fun prepareRename(path: String, text: String, offset: Int): UiRenameTarget? =
+        withContext(Dispatchers.IO) { services.prepareRename(Paths.get(path), text, offset)?.let { UiRenameTarget(it.oldName, it.kind) } }
+
+    override suspend fun rename(path: String, text: String, offset: Int, newName: String): UiRenameResult =
+        withContext(Dispatchers.IO) {
+            val r = services.rename(Paths.get(path), text, offset, newName)
+            if (r.success) _fsEpoch.value += 1 // the multi-file edit / file rename changed the tree + other buffers
+            UiRenameResult(r.success, r.message, r.occurrences, r.filesChanged, r.newPath)
+        }
+
     override fun updateDocument(path: String, text: String) =
         services.updateDocument(Paths.get(path), text)
 
@@ -348,6 +360,9 @@ class IdeServicesBackend(
 
     override suspend fun addDependency(moduleName: String, coordinate: String, scope: String): UiAddResult =
         withContext(Dispatchers.IO) { services.addDependency(moduleName, coordinate, scope) }
+
+    override suspend fun addPlatform(moduleName: String, coordinate: String): UiAddResult =
+        withContext(Dispatchers.IO) { services.addPlatform(moduleName, coordinate) }
 
     override fun removeDependency(moduleName: String, coordinate: String): Boolean =
         services.removeDependency(moduleName, coordinate)
@@ -592,6 +607,9 @@ class IdeServicesBackend(
 
     override suspend fun resourceImageBytes(path: String): ByteArray? =
         services.resourceBytes(Paths.get(path))
+
+    override suspend fun layoutPreview(path: String, text: String, request: dev.ide.preview.PreviewRequest): dev.ide.preview.LayoutPreviewResult? =
+        services.layoutPreview(Paths.get(path), text, request)
 
     /** Map the engine's [DrawablePreview] onto the UI's neutral [UiDrawable] DTO. */
     private fun toUiDrawable(d: DrawablePreview): UiDrawable = when (d) {

--- a/ide-core/src/test/kotlin/dev/ide/core/AndroidXmlCompletionTest.kt
+++ b/ide-core/src/test/kotlin/dev/ide/core/AndroidXmlCompletionTest.kt
@@ -81,6 +81,23 @@ class AndroidXmlCompletionTest {
     }
 
     @Test
+    fun completesCustomViewTagsFromLibrariesByFqnAndSimpleName() {
+        val views = listOf(
+            dev.ide.android.support.metadata.Widget("com.google.android.material.button.MaterialButton", false),
+            dev.ide.android.support.metadata.Widget("androidx.constraintlayout.widget.ConstraintLayout", true),
+        )
+        val svc = XmlCompletionService(contributors = {
+            listOf(AndroidXmlContributor(resourceNames = { type -> repo.names(type).toList() }, customViews = { views }))
+        })
+        // Typing the simple name matches the fully-qualified custom view (which is what gets inserted).
+        assertTrue("com.google.android.material.button.MaterialButton" in complete("<Material|", svc = svc),
+            "library custom view should be suggested by its simple name")
+        // Framework widgets and custom views coexist.
+        val all = complete("<C|", svc = svc)
+        assertTrue("androidx.constraintlayout.widget.ConstraintLayout" in all, "got $all")
+    }
+
+    @Test
     fun completesAttributeNames() {
         val labels = complete("<TextView android:tex|")
         assertTrue("android:text" in labels, "got $labels")

--- a/ide-core/src/test/kotlin/dev/ide/core/IdeFileOperationsTest.kt
+++ b/ide-core/src/test/kotlin/dev/ide/core/IdeFileOperationsTest.kt
@@ -1,0 +1,119 @@
+package dev.ide.core
+
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * File & package operations the file-tree context menu drives (issue #995): delete / rename / move / copy,
+ * for both files and directories. Renaming a Java source file whose public type matches its name also renames
+ * the type and every reference (reusing the symbol-rename machinery).
+ *
+ * Test bodies are block-bodied (not `= runBlocking { … }`): an expression body would take the return type of
+ * its last statement, and a non-Unit return makes JUnit silently skip the method.
+ */
+class IdeFileOperationsTest {
+
+    @Test
+    fun deletesAFileAndReportsMissingTargets() {
+        val dir = Files.createTempDirectory("fileops-del")
+        IdeServices.bootstrapJavaDemo(dir).use { ide ->
+            val core = ide.modules().first { it.name == "core" }
+            val scratch = ide.sourceRoots(core).first().resolve("com/example/core/Scratch.java")
+            Files.writeString(scratch, "package com.example.core; class Scratch {}")
+            assertTrue(ide.deletePath(scratch), "delete should succeed")
+            assertFalse(Files.exists(scratch), "file removed from disk")
+            assertFalse(ide.deletePath(dir.resolve("does/not/exist.java")), "deleting a missing path reports failure")
+        }
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun renamesAJavaClassAndItsReferencesAcrossFiles() {
+        val dir = Files.createTempDirectory("fileops-rename")
+        IdeServices.bootstrapJavaDemo(dir).use { ide ->
+            val core = ide.modules().first { it.name == "core" }
+            val greeter = ide.sourceRoots(core).first().resolve("com/example/core/Greeter.java")
+            val util = ide.modules().first { it.name == "util" }
+            val formatter = ide.sourceRoots(util).first().resolve("com/example/util/Formatter.java")
+
+            val outcome = runBlocking { ide.renameFile(greeter, "Salutation.java") }
+            assertTrue(outcome.success, "rename failed: ${outcome.message}")
+
+            val renamed = greeter.resolveSibling("Salutation.java")
+            assertFalse(Files.exists(greeter), "old file is gone")
+            assertTrue(Files.exists(renamed), "new file exists")
+            assertEquals(renamed.toString(), outcome.newPath, "newPath points at the renamed file")
+            assertTrue(Files.readString(renamed).contains("class Salutation"), "the type is renamed in its own file")
+
+            val fmt = Files.readString(formatter)
+            assertTrue("Salutation" in fmt, "cross-file reference updated in Formatter:\n$fmt")
+            assertFalse("Greeter" in fmt, "the old name is gone from Formatter:\n$fmt")
+        }
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun renamesANonSourceFileInPlace() {
+        val dir = Files.createTempDirectory("fileops-rename2")
+        IdeServices.bootstrapJavaDemo(dir).use { ide ->
+            val core = ide.modules().first { it.name == "core" }
+            val notes = ide.sourceRoots(core).first().resolveSibling("notes.txt")
+            Files.createDirectories(notes.parent); Files.writeString(notes, "hi")
+            val outcome = runBlocking { ide.renameFile(notes, "readme.txt") }
+            assertTrue(outcome.success, outcome.message)
+            assertFalse(Files.exists(notes), "old name gone")
+            assertTrue(Files.exists(notes.resolveSibling("readme.txt")), "renamed in place")
+        }
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun movesAndCopiesFilesWithConflictGuards() {
+        val dir = Files.createTempDirectory("fileops-move")
+        IdeServices.bootstrapJavaDemo(dir).use { ide ->
+            val core = ide.modules().first { it.name == "core" }
+            val pkg = ide.sourceRoots(core).first().resolve("com/example/core")
+            val sub = pkg.resolve("sub"); Files.createDirectories(sub)
+
+            val src = pkg.resolve("Scratch.java")
+            Files.writeString(src, "package com.example.core; class Scratch {}")
+            val copied = ide.copyPath(src, sub)
+            assertNotNull(copied, "copy returns the new path")
+            assertTrue(Files.exists(sub.resolve("Scratch.java")), "copy created the destination")
+            assertTrue(Files.exists(src), "copy keeps the original")
+            assertNull(ide.copyPath(src, sub), "copy onto an existing file is refused")
+
+            val src2 = pkg.resolve("Scratch2.java")
+            Files.writeString(src2, "package com.example.core; class Scratch2 {}")
+            val moved = ide.movePath(src2, sub)
+            assertNotNull(moved, "move returns the new path")
+            assertFalse(Files.exists(src2), "move removes the source")
+            assertTrue(Files.exists(sub.resolve("Scratch2.java")), "move created the destination")
+            assertNull(ide.movePath(sub, sub.resolve("deeper")), "moving a directory into itself is refused")
+        }
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun renamesAndDeletesADirectory() {
+        val dir = Files.createTempDirectory("fileops-dir")
+        IdeServices.bootstrapJavaDemo(dir).use { ide ->
+            val core = ide.modules().first { it.name == "core" }
+            val pkg = ide.sourceRoots(core).first().resolve("com/example/core")
+            val renamed = pkg.resolveSibling("renamed")
+
+            assertTrue(runBlocking { ide.renameFile(pkg, "renamed") }.success, "directory rename succeeds")
+            assertTrue(Files.exists(renamed) && !Files.exists(pkg), "directory moved in place")
+
+            assertTrue(ide.deletePath(renamed), "recursive directory delete succeeds")
+            assertFalse(Files.exists(renamed), "directory removed")
+        }
+        dir.toFile().deleteRecursively()
+    }
+}

--- a/ide-ui/build.gradle.kts
+++ b/ide-ui/build.gradle.kts
@@ -42,6 +42,16 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
         }
 
+        // An intermediate JVM-only source set shared by the desktop + android targets, so it can depend on
+        // the plain-JVM `layout-preview-api` (which commonMain — platform-agnostic — cannot). The layout
+        // preview pane + its Compose-backed RCanvas live here; commonMain reaches them via an expect/actual.
+        val jvmShared = create("jvmShared") {
+            dependsOn(getByName("commonMain"))
+            dependencies { implementation(project(":layout-preview-api")) }
+        }
+        getByName("desktopMain").dependsOn(jvmShared)
+        getByName("androidMain").dependsOn(jvmShared)
+
         // `compose.uiTooling` carries `ComposeViewAdapter`, the harness the preview pane instantiates to
         // render an @Preview. Without it on the target's classpath, Studio/IntelliJ fail with
         // `ClassNotFoundException: androidx.compose.ui.tooling.ComposeViewAdapter`. Added per target so

--- a/ide-ui/src/androidMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.android.kt
+++ b/ide-ui/src/androidMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.android.kt
@@ -10,7 +10,9 @@ import android.view.inputmethod.InputMethodManager
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusEventModifierNode
 import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.node.ModifierNodeElement
+import android.view.KeyEvent as AndroidKeyEvent
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputModifierNode
 import androidx.compose.ui.platform.establishTextInputSession
@@ -25,6 +27,20 @@ import kotlinx.coroutines.launch
  */
 actual fun Modifier.editorTextInput(session: EditorSession): Modifier =
     this then EditorTextInputElement(session)
+
+actual fun textInputCodePoint(event: KeyEvent): Int {
+    val native = event.nativeKeyEvent
+    // Android's own keycode classification catches every modifier/lock/function/sym key — including the
+    // non-standard codes some Bluetooth keyboards emit that Compose's Key enum leaves as Key.Unknown
+    // (the "shift / combos typed as text" bug). This is why we go through the native event, not Compose's Key.
+    if (AndroidKeyEvent.isModifierKey(native.keyCode)) return -1
+    // Ctrl/Meta chords are shortcuts, never text. AltGr is reported as Alt (not Ctrl), so it still types.
+    if (native.isCtrlPressed || native.isMetaPressed) return -1
+    // unicodeChar folds in Shift/AltGr; 0 = a non-printable key (arrows, F-keys, …), and a dead-key accent
+    // has its COMBINING_ACCENT high bit set (a negative Int here) so the range check drops it — as before.
+    val cp = native.unicodeChar
+    return if (cp in 32..0x10FFFF && cp != 127) cp else -1
+}
 
 private data class EditorTextInputElement(val session: EditorSession) : ModifierNodeElement<EditorTextInputNode>() {
     override fun create() = EditorTextInputNode(session)

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/AppState.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/AppState.kt
@@ -157,6 +157,27 @@ class IdeUiState(val backend: IdeBackend) {
     /** Re-read the workspace tree from the backend (after a file is created/removed). */
     fun refreshTree() { tree = backend.fileTree() }
 
+    /**
+     * Reflect a completed project-wide rename in the open tabs. The rename wrote every reference site to
+     * disk, so each clean tab is re-read (a no-op for files it didn't touch — those keep their session, undo
+     * and caret). The active tab follows the backing-file rename to [newPath] when the file itself was
+     * renamed. Tabs with unsaved edits are left untouched so a rename never clobbers in-progress work.
+     */
+    fun reloadAfterRename(activePath: String?, newPath: String?) {
+        for (i in openFiles.indices) {
+            val f = openFiles[i]
+            val followsFileRename = newPath != null && f.path == activePath
+            if (!followsFileRename && f.modified) continue
+            val diskPath = if (followsFileRename) newPath!! else f.path
+            val text = runCatching { backend.readFile(diskPath) }.getOrNull() ?: continue
+            if (!followsFileRename && text == f.savedText) continue // untouched → preserve session/undo/caret
+            val name = diskPath.substringAfterLast('/').substringAfterLast('\\')
+            openFiles[i] = OpenFile(diskPath, name, text)
+            backend.updateDocument(diskPath, text)
+        }
+        refreshTree()
+    }
+
     /** Create a new file through the backend, refresh the tree, and open it in the editor. */
     fun createFile(dirPath: String, fileName: String, content: String) {
         val path = backend.createFile(dirPath, fileName, content) ?: return

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/AppState.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/AppState.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import dev.ide.ui.backend.IdeBackend
 import dev.ide.ui.backend.NodeKind
 import dev.ide.ui.backend.TreeNode
+import dev.ide.ui.backend.UiRenameResult
 import dev.ide.ui.components.NewFileTarget
 import dev.ide.ui.components.newFileTargetOf
 import dev.ide.ui.editor.core.EditorSession
@@ -91,6 +92,8 @@ class IdeUiState(val backend: IdeBackend) {
     var paletteOpen by mutableStateOf(false)
     /** Editor inlay hints (inferred types, parameter names) — on by default; toggled from the editor top bar. */
     var inlayHintsEnabled by mutableStateOf(true)
+    /** Editor text zoom (pinch / Ctrl-+ / Ctrl--), 1.0 = the theme's default code size. Shared across tabs. */
+    var editorFontScale by mutableStateOf(1f)
 
     /** A transient destination shown as a sheet/overlay (Source, More) — null when none is open. */
     var sheetDest by mutableStateOf<RailDestination?>(null)
@@ -188,6 +191,73 @@ class IdeUiState(val backend: IdeBackend) {
     /** Create a new directory through the backend and refresh the tree (nothing to open). */
     fun createDirectory(parentPath: String, name: String) {
         if (backend.createDirectory(parentPath, name) != null) refreshTree()
+    }
+
+    // ---- file & package operations (delete / rename / move / copy) ----
+
+    /** Delete a file or directory/package: close any open tabs under it, then refresh the tree. */
+    fun deletePath(path: String) {
+        if (!backend.deletePath(path)) return
+        closeTabsUnder(path)
+        refreshTree()
+    }
+
+    /** Rename a file/directory to [newName]; rebase open tabs onto the new path + refresh. Returns the result. */
+    suspend fun renamePath(path: String, newName: String): UiRenameResult {
+        val r = backend.renamePath(path, newName)
+        if (r.success) { rebaseTabs(path, r.newPath ?: path); refreshCleanTabs(); refreshTree() }
+        return r
+    }
+
+    /** Move a file/directory into [destDir]; rebase open tabs + refresh. Returns true on success. */
+    fun movePath(path: String, destDir: String): Boolean {
+        val newPath = backend.movePath(path, destDir) ?: return false
+        rebaseTabs(path, newPath); refreshTree()
+        return true
+    }
+
+    /** Copy a file/directory into [destDir]; refresh the tree. Returns true on success. */
+    fun copyPath(path: String, destDir: String): Boolean {
+        if (backend.copyPath(path, destDir) == null) return false
+        refreshTree()
+        return true
+    }
+
+    /** True if [p] is [root] or lives under it (matching on either path separator). */
+    private fun underPath(p: String, root: String): Boolean =
+        p == root || p.startsWith("$root/") || p.startsWith("$root\\")
+
+    /** Close every open tab at [path] or under it (after a delete). */
+    private fun closeTabsUnder(path: String) {
+        openFiles.filter { underPath(it.path, path) }.forEach(::close)
+    }
+
+    /** Re-point open tabs at [oldPath] (or under it, for a directory) to [newPath], re-reading from disk. */
+    private fun rebaseTabs(oldPath: String, newPath: String) {
+        for (i in openFiles.indices) {
+            val p = openFiles[i].path
+            val rebased = when {
+                p == oldPath -> newPath
+                underPath(p, oldPath) -> newPath + p.substring(oldPath.length)
+                else -> continue
+            }
+            val text = runCatching { backend.readFile(rebased) }.getOrNull() ?: continue
+            val name = rebased.substringAfterLast('/').substringAfterLast('\\')
+            openFiles[i] = OpenFile(rebased, name, text)
+            backend.updateDocument(rebased, text)
+        }
+    }
+
+    /** Re-read clean (unmodified) tabs whose disk content changed — e.g. references rewritten by a rename. */
+    private fun refreshCleanTabs() {
+        for (i in openFiles.indices) {
+            val f = openFiles[i]
+            if (f.modified) continue
+            val text = runCatching { backend.readFile(f.path) }.getOrNull() ?: continue
+            if (text == f.savedText) continue
+            openFiles[i] = OpenFile(f.path, f.name, text)
+            backend.updateDocument(f.path, text)
+        }
     }
 
     /** A sensible default New-Class target: the first Java/Kotlin source root in the tree. */

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/backend/IdeBackend.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/backend/IdeBackend.kt
@@ -35,6 +35,33 @@ interface IdeBackend {
      */
     fun createDirectory(parentPath: String, name: String): String? = null
 
+    /**
+     * Delete a file or directory/package (recursively). Returns true on success. Bumps [fileSystemEpoch] so
+     * the tree refreshes. The default is a no-op for read-only backends.
+     */
+    fun deletePath(path: String): Boolean = false
+
+    /**
+     * Rename a file or directory/package in place (same parent) to [newName] (the full new name, with
+     * extension for files). For a Java source file whose public type matches the file name, the type and all
+     * its references are renamed too (and the backing file moved). On success [UiRenameResult.newPath] is the
+     * new path so the UI can reopen it. Bumps [fileSystemEpoch].
+     */
+    suspend fun renamePath(path: String, newName: String): UiRenameResult =
+        UiRenameResult(false, "Rename is not supported by this backend")
+
+    /**
+     * Move a file or directory/package into [destDir]. Returns the new path, or null on conflict/failure.
+     * Bumps [fileSystemEpoch].
+     */
+    fun movePath(path: String, destDir: String): String? = null
+
+    /**
+     * Copy a file or directory/package into [destDir]. Returns the new path, or null on conflict/failure.
+     * Bumps [fileSystemEpoch].
+     */
+    fun copyPath(path: String, destDir: String): String? = null
+
     /** Read a file's current on-disk text. */
     fun readFile(path: String): String
 

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/backend/IdeBackend.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/backend/IdeBackend.kt
@@ -108,6 +108,20 @@ interface IdeBackend {
      */
     suspend fun definitionAt(path: String, text: String, offset: Int): UiDefinition? = null
 
+    /**
+     * The renameable symbol under the caret at [offset] in [path]'s buffer [text] (its current name + a kind
+     * label), or null when the caret isn't on one. The UI uses this to prompt for the new name. Java only.
+     */
+    suspend fun prepareRename(path: String, text: String, offset: Int): UiRenameTarget? = null
+
+    /**
+     * Rename the symbol under [offset] to [newName] across the whole project, applying the multi-file edit
+     * to disk and bumping [fileSystemEpoch] so open editors/the tree refresh. On success [UiRenameResult.newPath]
+     * is set when the backing file was renamed too (the UI should reopen it).
+     */
+    suspend fun rename(path: String, text: String, offset: Int, newName: String): UiRenameResult =
+        UiRenameResult(false, "Rename is not supported by this backend")
+
     // ---- block-based editing (projectional editor) ----
 
     /**
@@ -204,14 +218,23 @@ interface IdeBackend {
     suspend fun searchArtifacts(query: String, moduleName: String): List<UiArtifactHit> = emptyList()
 
     /**
-     * Resolve and add `group:name:version` ([coordinate]) to [moduleName] at [scope] (e.g. `implementation`),
-     * bundling its resolved transitive closure onto the module classpath. Blocked (with a reason) when the
-     * artifact is incompatible — e.g. an `.aar` on a pure-Java module.
+     * Resolve and add [coordinate] to [moduleName] at [scope] (e.g. `implementation`), bundling its resolved
+     * transitive closure onto the module classpath. [coordinate] is `group:name:version`, or the versionless
+     * `group:name` when a platform (BOM) imported via [addPlatform] supplies the version. Blocked (with a
+     * reason) when the artifact is incompatible — e.g. an `.aar` on a pure-Java module.
      */
     suspend fun addDependency(moduleName: String, coordinate: String, scope: String): UiAddResult =
         UiAddResult(false, "Dependency management not supported by this backend")
 
-    /** Remove the declared dependency [coordinate] from [moduleName]. Returns false if it wasn't present. */
+    /**
+     * Import a Maven BOM ([coordinate], `group:name:version`) as a platform of [moduleName] — Gradle
+     * `platform(...)` semantics. It adds no artifact; it supplies the version for versionless dependencies
+     * (added via [addDependency] with a `group:name` coordinate). Verified resolvable before it's added.
+     */
+    suspend fun addPlatform(moduleName: String, coordinate: String): UiAddResult =
+        UiAddResult(false, "Dependency management not supported by this backend")
+
+    /** Remove the declared dependency or platform [coordinate] from [moduleName]. False if it wasn't present. */
     fun removeDependency(moduleName: String, coordinate: String): Boolean = false
 
     // ---- module configuration (the Module Settings editor) ----
@@ -367,7 +390,7 @@ data class UiArtifactHit(
 )
 
 /** What a node in the dependency graph *is* — drives its icon and the compatibility rules. */
-enum class UiDepKind { Jar, Aar, Module, Sdk }
+enum class UiDepKind { Jar, Aar, Module, Sdk, Platform }
 
 /**
  * One node in a module's dependency picture — a declared dependency or one pulled in transitively. The
@@ -630,6 +653,18 @@ data class UiCompletionResult(
 
 /** A go-to-definition target: open [path] and move the caret to [offset]. */
 data class UiDefinition(val path: String, val offset: Int)
+
+/** The renameable symbol under the caret: its current [oldName] and a human [kind] label (e.g. "method"). */
+data class UiRenameTarget(val oldName: String, val kind: String)
+
+/** Outcome of a project-wide rename. [newPath] is set when the edited file was itself renamed (reopen it). */
+data class UiRenameResult(
+    val success: Boolean,
+    val message: String,
+    val occurrences: Int = 0,
+    val filesChanged: Int = 0,
+    val newPath: String? = null,
+)
 
 /** Whether an action fixes a problem ([QUICK_FIX]), is a context action with no diagnostic ([INTENTION]), or refactors ([REFACTOR]). Drives the menu icon. */
 enum class UiActionKind { QUICK_FIX, INTENTION, REFACTOR }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FileNavigator.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FileNavigator.kt
@@ -1,7 +1,8 @@
 package dev.ide.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -18,11 +19,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -63,10 +68,16 @@ fun FileNavigator(
     onImport: () -> Unit = {},
     canShare: Boolean = false,
     onShare: (TreeNode) -> Unit = {},
+    canModify: Boolean = false,
+    onRename: (TreeNode) -> Unit = {},
+    onMove: (TreeNode) -> Unit = {},
+    onCopy: (TreeNode) -> Unit = {},
+    onDelete: (TreeNode) -> Unit = {},
 ) {
     val expanded = remember {
         mutableSetExpandedDefaults(root)
     }
+    val ctx = FileRowActions(canModify, onRename, onMove, onCopy, onDelete)
     Column(modifier) {
         // header
         Row(
@@ -85,10 +96,21 @@ fun FileNavigator(
         }
         Box(Modifier.fillMaxWidth().height(1.dp).background(Ca.colors.separator))
         Column(Modifier.fillMaxWidth().weight(1f).verticalScroll(rememberScrollState()).padding(vertical = 6.dp)) {
-            root.children.forEach { TreeRow(it, 0, expanded, activePath, onOpen, onNewFile, onViewDependencies, onConfigureModule, canShare, onShare) }
+            root.children.forEach { TreeRow(it, 0, expanded, activePath, onOpen, onNewFile, onViewDependencies, onConfigureModule, canShare, onShare, ctx) }
         }
     }
 }
+
+/** The delete/rename/move/copy callbacks the per-row context menu invokes (bundled to avoid threading five
+ *  parameters through the recursive [TreeRow]). [enabled] gates whether the menu is offered at all. */
+private class FileRowActions(
+    val enabled: Boolean,
+    val onRename: (TreeNode) -> Unit,
+    val onMove: (TreeNode) -> Unit,
+    val onCopy: (TreeNode) -> Unit,
+    val onDelete: (TreeNode) -> Unit,
+)
+
 
 private fun mutableSetExpandedDefaults(root: TreeNode): androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean> {
     val map = androidx.compose.runtime.mutableStateMapOf<String, Boolean>()
@@ -100,6 +122,7 @@ private fun mutableSetExpandedDefaults(root: TreeNode): androidx.compose.runtime
     return map
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TreeRow(
     node: TreeNode,
@@ -112,6 +135,7 @@ private fun TreeRow(
     onConfigureModule: (TreeNode) -> Unit,
     canShare: Boolean = false,
     onShare: (TreeNode) -> Unit = {},
+    ctx: FileRowActions,
 ) {
     val isExpandable = node.children.isNotEmpty()
     val isOpen = expanded[node.id] == true
@@ -120,19 +144,27 @@ private fun TreeRow(
     val canNewFile = (node.sourceRootPath != null &&
         (node.kind == NodeKind.SourceRoot || node.kind == NodeKind.Package)) ||
         node.resDirPath != null
+    // Long-press / right-click opens delete/rename/move/copy for files, packages, and res/ folders.
+    val canContext = ctx.enabled && node.fileOpPath() != null &&
+        (node.kind == NodeKind.File || node.kind == NodeKind.Package || node.kind == NodeKind.Folder)
+    var menuOpen by remember { mutableStateOf(false) }
     val interaction = remember { MutableInteractionSource() }
     val hovered by interaction.collectIsHoveredAsState()
 
+    Box {
     Row(
         Modifier
             .fillMaxWidth()
             .height(30.dp)
             .background(if (isActive) Ca.colors.accentSoft else Color.Transparent)
             .hoverable(interaction)
-            .clickable {
-                if (node.filePath != null) onOpen(node)
-                else expanded[node.id] = !isOpen
-            }
+            .combinedClickable(
+                onClick = {
+                    if (node.filePath != null) onOpen(node)
+                    else expanded[node.id] = !isOpen
+                },
+                onLongClick = if (canContext) ({ menuOpen = true }) else null,
+            )
             .padding(start = (8 + depth * 16).dp, end = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -173,8 +205,29 @@ private fun TreeRow(
                 Box(Modifier.size(6.dp).background(gitColor(node.gitStatus), RoundedCornerShape(Ca.radius.pill)))
         }
     }
+        if (canContext) DropdownMenu(
+            expanded = menuOpen,
+            onDismissRequest = { menuOpen = false },
+            modifier = Modifier.background(Ca.colors.surface2),
+        ) {
+            FileActionItem(CaIcons.docText, "Rename…") { menuOpen = false; ctx.onRename(node) }
+            FileActionItem(CaIcons.arrowRight, "Move…") { menuOpen = false; ctx.onMove(node) }
+            FileActionItem(CaIcons.copy, "Copy…") { menuOpen = false; ctx.onCopy(node) }
+            FileActionItem(CaIcons.close, "Delete", danger = true) { menuOpen = false; ctx.onDelete(node) }
+        }
+    }
 
-    if (isOpen) node.children.forEach { TreeRow(it, depth + 1, expanded, activePath, onOpen, onNewFile, onViewDependencies, onConfigureModule, canShare, onShare) }
+    if (isOpen) node.children.forEach { TreeRow(it, depth + 1, expanded, activePath, onOpen, onNewFile, onViewDependencies, onConfigureModule, canShare, onShare, ctx) }
+}
+
+@Composable
+private fun FileActionItem(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, danger: Boolean = false, onClick: () -> Unit) {
+    val tint = if (danger) Ca.colors.error else Ca.colors.textSecondary
+    DropdownMenuItem(
+        text = { Text(label, color = if (danger) Ca.colors.error else Ca.colors.textPrimary, style = Ca.type.footnote) },
+        leadingIcon = { Icon(icon, null, Modifier.size(15.dp), tint = tint) },
+        onClick = onClick,
+    )
 }
 
 @Composable

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FileOperationsDialogs.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FileOperationsDialogs.kt
@@ -1,0 +1,196 @@
+package dev.ide.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.ide.ui.backend.NodeKind
+import dev.ide.ui.backend.TreeNode
+import dev.ide.ui.theme.Ca
+
+/** The on-disk path a node's file operations act on: a file's own path, a package's deepest directory, or an
+ *  Android `res/` folder. Null for nodes that aren't safe to move/rename/delete (modules, source roots). */
+internal fun TreeNode.fileOpPath(): String? = when (kind) {
+    NodeKind.File -> filePath
+    NodeKind.Package -> packageSegments.lastOrNull()?.dirPath ?: sourceRootPath
+    NodeKind.Folder -> resDirPath
+    else -> null
+}
+
+/** Which file operation a context-menu pick requested. */
+enum class FileOpKind { Rename, Move, Copy, Delete }
+
+/** A pending file operation: the [node] it targets and the [kind] of operation. */
+data class FileOpRequest(val node: TreeNode, val kind: FileOpKind)
+
+/** A destination directory offered by the move/copy picker (a human label + the absolute path). */
+data class DirChoice(val label: String, val path: String)
+
+/**
+ * Candidate destination directories for move/copy: every source root and package directory in the tree
+ * (each compacted-package level is offered separately) plus Android `res/` folders. Sorted by label.
+ */
+fun collectDirChoices(root: TreeNode): List<DirChoice> {
+    val out = LinkedHashMap<String, DirChoice>() // de-dupe by path; keep first label
+    fun add(path: String, label: String) { if (path !in out) out[path] = DirChoice(label, path) }
+    fun walk(node: TreeNode) {
+        when (node.kind) {
+            NodeKind.SourceRoot -> node.sourceRootPath?.let { add(it, node.name) }
+            NodeKind.Package -> for (seg in node.packageSegments) add(seg.dirPath, seg.packageName)
+            NodeKind.Folder -> node.resDirPath?.let { add(it, node.name) }
+            else -> {}
+        }
+        node.children.forEach(::walk)
+    }
+    walk(root)
+    return out.values.sortedBy { it.label.lowercase() }
+}
+
+/** Host the rename / move / copy / delete dialogs for [request]; [onDismiss] clears it. */
+@Composable
+fun FileOperationDialog(
+    request: FileOpRequest?,
+    tree: TreeNode,
+    onRename: (TreeNode, String) -> Unit,
+    onMove: (TreeNode, String) -> Unit,
+    onCopy: (TreeNode, String) -> Unit,
+    onDelete: (TreeNode) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    // Retain the last request so the exit animation doesn't flash empty.
+    var shown by remember { mutableStateOf<FileOpRequest?>(null) }
+    if (request != null) shown = request
+    val visible = request != null
+    DropdownOverlay(visible = visible, onDismiss = onDismiss, topPadding = 110.dp) {
+        val r = shown ?: return@DropdownOverlay
+        when (r.kind) {
+            FileOpKind.Rename -> RenamePanel(r.node, onDismiss) { onRename(r.node, it) }
+            FileOpKind.Delete -> DeletePanel(r.node, onDismiss) { onDelete(r.node) }
+            FileOpKind.Move, FileOpKind.Copy ->
+                DestinationPanel(r.node, r.kind, collectDirChoices(tree), onDismiss) { dest ->
+                    if (r.kind == FileOpKind.Move) onMove(r.node, dest) else onCopy(r.node, dest)
+                }
+        }
+    }
+}
+
+@Composable
+private fun RenamePanel(node: TreeNode, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    // Edit the leaf name on disk: a file's name, or a (possibly compacted) package's deepest directory.
+    val current = node.fileOpPath()?.substringAfterLast('/')?.substringAfterLast('\\') ?: node.name
+    var name by remember(node) { mutableStateOf(current) }
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(node) { runCatching { focus.requestFocus() } }
+    val valid = name.isNotBlank() && name != current && '/' !in name && '\\' !in name
+    fun submit() { if (valid) { onConfirm(name.trim()); onDismiss() } }
+
+    DialogCard("Rename '${node.name}'") {
+        FieldLabel("New name")
+        DialogField(value = name, onValueChange = { name = it }, placeholder = node.name, focusRequester = focus, onSubmit = ::submit, onCancel = onDismiss)
+        Spacer12()
+        ButtonRow(onDismiss, "Rename", valid, ::submit)
+    }
+}
+
+@Composable
+private fun DeletePanel(node: TreeNode, onDismiss: () -> Unit, onConfirm: () -> Unit) {
+    val isDir = node.kind != NodeKind.File
+    DialogCard(if (isDir) "Delete '${node.name}' and its contents?" else "Delete '${node.name}'?") {
+        Text(
+            if (isDir) "This permanently removes the folder and everything inside it." else "This permanently removes the file.",
+            color = Ca.colors.textSecondary, style = Ca.type.footnote,
+        )
+        Spacer12()
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Spacer(Modifier.weight(1f))
+            DialogButton("Cancel", primary = false, enabled = true, onClick = onDismiss)
+            DangerButton("Delete") { onConfirm(); onDismiss() }
+        }
+    }
+}
+
+@Composable
+private fun DestinationPanel(node: TreeNode, kind: FileOpKind, choices: List<DirChoice>, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    var selected by remember(node) { mutableStateOf<String?>(null) }
+    val verb = if (kind == FileOpKind.Move) "Move" else "Copy"
+    DialogCard("$verb '${node.name}' to…") {
+        if (choices.isEmpty()) {
+            Text("No destination folders found.", color = Ca.colors.textSecondary, style = Ca.type.footnote)
+        } else {
+            Column(
+                Modifier.fillMaxWidth().heightIn(max = 280.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                choices.forEach { c ->
+                    val isSel = c.path == selected
+                    Row(
+                        Modifier.fillMaxWidth()
+                            .background(if (isSel) Ca.colors.accentSoft else Ca.colors.surface2, RoundedCornerShape(Ca.radius.control))
+                            .clickable { selected = c.path }
+                            .padding(horizontal = 12.dp, vertical = 9.dp),
+                    ) {
+                        Text(c.label, color = if (isSel) Ca.colors.accent else Ca.colors.textPrimary, style = Ca.type.footnote,
+                            fontWeight = if (isSel) FontWeight.SemiBold else FontWeight.Normal)
+                    }
+                }
+            }
+        }
+        Spacer12()
+        ButtonRow(onDismiss, verb, selected != null) { selected?.let { onConfirm(it); onDismiss() } }
+    }
+}
+
+@Composable
+private fun DialogCard(title: String, content: @Composable () -> Unit) {
+    Column(
+        Modifier.widthIn(max = 520.dp).fillMaxWidth().padding(horizontal = 12.dp)
+            .background(Ca.colors.glassThick, RoundedCornerShape(Ca.radius.xl))
+            .border(1.dp, Ca.colors.glassEdge, RoundedCornerShape(Ca.radius.xl))
+            .padding(20.dp),
+    ) {
+        Text(title, color = Ca.colors.textPrimary, style = Ca.type.subhead, fontWeight = FontWeight.SemiBold)
+        Spacer12()
+        content()
+    }
+}
+
+@Composable
+private fun ButtonRow(onCancel: () -> Unit, confirmLabel: String, enabled: Boolean, onConfirm: () -> Unit) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Spacer(Modifier.weight(1f))
+        DialogButton("Cancel", primary = false, enabled = true, onClick = onCancel)
+        DialogButton(confirmLabel, primary = true, enabled = enabled, onClick = onConfirm)
+    }
+}
+
+@Composable
+private fun DangerButton(label: String, onClick: () -> Unit) {
+    Box(
+        Modifier.background(Ca.colors.error, RoundedCornerShape(Ca.radius.control))
+            .clickable(onClick = onClick).padding(horizontal = 18.dp, vertical = 9.dp),
+    ) {
+        Text(label, color = Ca.colors.textOnAccent, style = Ca.type.footnote, fontWeight = FontWeight.SemiBold)
+    }
+}

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/NewFileDialog.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/NewFileDialog.kt
@@ -402,13 +402,13 @@ private fun kotlinStub(pkg: String, kind: NewFileKind, name: String): String {
 }
 
 @Composable
-private fun FieldLabel(text: String) {
+internal fun FieldLabel(text: String) {
     Text(text, color = Ca.colors.textTertiary, style = Ca.type.caption2, fontWeight = FontWeight.SemiBold)
     Spacer(Modifier.height(4.dp))
 }
 
 @Composable
-private fun DialogField(
+internal fun DialogField(
     value: String,
     onValueChange: (String) -> Unit,
     placeholder: String,
@@ -462,7 +462,7 @@ private fun SelectChip(label: String, selected: Boolean, onClick: () -> Unit) {
 }
 
 @Composable
-private fun DialogButton(label: String, primary: Boolean, enabled: Boolean, onClick: () -> Unit) {
+internal fun DialogButton(label: String, primary: Boolean, enabled: Boolean, onClick: () -> Unit) {
     val fill = when {
         primary && enabled -> Ca.colors.accent
         primary -> Ca.colors.accent.copy(alpha = 0.4f)
@@ -479,8 +479,8 @@ private fun DialogButton(label: String, primary: Boolean, enabled: Boolean, onCl
     }
 }
 
-@Composable private fun Spacer8() = Spacer(Modifier.height(8.dp))
-@Composable private fun Spacer12() = Spacer(Modifier.height(12.dp))
+@Composable internal fun Spacer8() = Spacer(Modifier.height(8.dp))
+@Composable internal fun Spacer12() = Spacer(Modifier.height(12.dp))
 
 // Compose Multiplatform commonMain has no java.lang.Character — minimal Java-identifier checks.
 private fun Char.isJavaIdentifierStartCompat(): Boolean = isLetter() || this == '_' || this == '$'

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/Overlays.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/Overlays.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -113,6 +114,11 @@ fun BottomSheet(
                     modifier
                         .fillMaxWidth()
                         .fillMaxHeight(fraction.value)
+                        // Keep the sheet above the soft keyboard. The app root already insets `safeDrawing`
+                        // (which includes the IME) and consumes it, so this is a no-op there — but it makes
+                        // the sheet self-sufficient if ever hosted outside that box. Scrollable content
+                        // (e.g. the More sheet) handles whatever vertical space remains (issue #994).
+                        .imePadding()
                         .shadow(24.dp, shape, clip = false)
                         .background(Ca.colors.glassThick, shape)
                         .border(1.dp, Ca.colors.glassEdgeTop, shape),

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeActionsPopup.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeActionsPopup.kt
@@ -3,10 +3,13 @@ package dev.ide.ui.editor
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -15,18 +18,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.ide.ui.backend.UiAction
 import dev.ide.ui.backend.UiActionKind
+import dev.ide.ui.backend.UiSeverity
 import dev.ide.ui.icons.CaIcons
 import dev.ide.ui.theme.Ca
 
@@ -73,11 +84,11 @@ fun CodeActionsMenu(
 }
 
 @Composable
-private fun ActionRow(action: UiAction, selected: Boolean, onPick: () -> Unit) {
+private fun ActionRow(action: UiAction, selected: Boolean, onPick: () -> Unit, height: Dp = 38.dp) {
     Row(
         Modifier
             .fillMaxWidth()
-            .height(38.dp)
+            .height(height)
             .background(if (selected) Ca.colors.accentSoft else Color.Transparent)
             .clickable(onClick = onPick)
             .padding(horizontal = 12.dp),
@@ -98,5 +109,83 @@ private fun ActionRow(action: UiAction, selected: Boolean, onPick: () -> Unit) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+}
+
+/**
+ * A bottom-docked sheet for a single diagnostic: the **full** (selectable, scrollable) message — so a long
+ * error is readable on a phone where the inline chip is truncated — plus its quick-fixes as large touch
+ * targets. Tapping the scrim or the × dismisses it. Pure UI; the host fetches the [actions] for the
+ * diagnostic's range and applies the picked one over the [dev.ide.ui.backend.IdeBackend.applyAction] round-trip.
+ */
+@Composable
+fun DiagnosticSheet(
+    severity: UiSeverity,
+    unused: Boolean,
+    message: String,
+    actions: List<UiAction>,
+    onPick: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val color = when (severity) {
+        UiSeverity.Error -> Ca.colors.error
+        UiSeverity.Warning -> if (unused) Ca.colors.textTertiary else Ca.colors.warning
+        UiSeverity.Info -> Ca.colors.info
+        UiSeverity.Hint -> Ca.colors.textTertiary
+    }
+    val icon = when (severity) {
+        UiSeverity.Error -> CaIcons.error
+        UiSeverity.Warning -> CaIcons.warning
+        UiSeverity.Info, UiSeverity.Hint -> CaIcons.info
+    }
+    val label = when (severity) {
+        UiSeverity.Error -> "Error"
+        UiSeverity.Warning -> if (unused) "Unused" else "Warning"
+        UiSeverity.Info -> "Info"
+        UiSeverity.Hint -> "Hint"
+    }
+    val sheetShape = RoundedCornerShape(topStart = Ca.radius.sheet, topEnd = Ca.radius.sheet)
+    // scrim over the editor pane (tap to dismiss); panel docked at the bottom for thumb reach
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(Ca.colors.scrim)
+            .pointerInput(Unit) { detectTapGestures { onDismiss() } },
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .background(Ca.colors.glassThick, sheetShape)
+                .border(1.dp, Ca.colors.separator, sheetShape)
+                .pointerInput(Unit) { detectTapGestures { } } // swallow taps so the panel itself doesn't dismiss
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(icon, null, Modifier.size(18.dp), tint = color)
+                Text(label, color = color, style = Ca.type.caption, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(0.dp).weight(1f))
+                Box(
+                    Modifier.size(30.dp).clip(CircleShape).clickable(onClick = onDismiss),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(CaIcons.close, "Dismiss", Modifier.size(16.dp), tint = Ca.colors.textSecondary) }
+            }
+            Spacer(Modifier.height(10.dp))
+            SelectionContainer {
+                Text(
+                    message,
+                    color = Ca.colors.textPrimary,
+                    style = Ca.type.code,
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).verticalScroll(rememberScrollState()),
+                )
+            }
+            if (actions.isNotEmpty()) {
+                Spacer(Modifier.height(12.dp))
+                Box(Modifier.fillMaxWidth().height(1.dp).background(Ca.colors.separator))
+                Spacer(Modifier.height(6.dp))
+                Text("Quick fixes", color = Ca.colors.textTertiary, style = Ca.type.caption2, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp))
+                actions.forEachIndexed { i, a -> ActionRow(a, selected = false, onPick = { onPick(i) }, height = 48.dp) }
+            }
+            Spacer(Modifier.height(8.dp))
+        }
     }
 }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeEditor.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeEditor.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.gestures.rememberScrollableState
@@ -40,6 +41,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -68,7 +70,6 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.key.utf16CodePoint
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -108,6 +109,7 @@ import dev.ide.ui.backend.UiInlayHint
 import dev.ide.ui.editor.core.RangeEdit
 import dev.ide.ui.editor.core.TokenType
 import dev.ide.ui.editor.core.editorTextInput
+import dev.ide.ui.editor.core.textInputCodePoint
 import dev.ide.ui.icons.CaIcons
 import dev.ide.ui.theme.Ca
 import dev.ide.ui.theme.SyntaxColors
@@ -144,6 +146,11 @@ fun CodeEditor(
     onNavigate: (path: String, offset: Int) -> Unit = { _, _ -> },
     onRenamed: (newPath: String?) -> Unit = {},
     showInlayHints: Boolean = true,
+    /** Bump from the host (a toolbar Find button) to open the in-file find bar; 0 = no request. */
+    findEpoch: Int = 0,
+    /** Editor text zoom; 1.0 = the theme's code size. Driven by pinch + Ctrl-+/-/0; hoisted so it persists across tabs. */
+    fontScale: Float = 1f,
+    onFontScaleChange: (Float) -> Unit = {},
 ) {
     val colors = Ca.colors
     val syntax = colors.syntax
@@ -160,8 +167,14 @@ fun CodeEditor(
     // ---- text metrics + per-line layout cache ----
     val measurer = rememberTextMeasurer(cacheSize = 0)
     val typography = Ca.type
-    val codeStyle = remember(syntax, typography) { typography.code.copy(color = syntax.default) }
-    val gutterStyle = typography.codeSmall
+    // Zoom scales the code + gutter text size; the metrics/render-cache below key on these styles, so a zoom
+    // recomputes line metrics and re-shapes lines at the new size (the cache is rebuilt — expected on zoom).
+    val zoom = clampFontScale(fontScale)
+    val liveScale = rememberUpdatedState(zoom) // read inside the pinch gesture (pointerInput captures once)
+    val codeStyle = remember(syntax, typography, zoom) {
+        typography.code.copy(color = syntax.default, fontSize = typography.code.fontSize * zoom)
+    }
+    val gutterStyle = remember(typography, zoom) { typography.codeSmall.copy(fontSize = typography.codeSmall.fontSize * zoom) }
     val metrics = remember(measurer, codeStyle, density) {
         val probe = measurer.measure(AnnotatedString("MMMMMMMMMM"), style = codeStyle, softWrap = false, maxLines = 1)
         with(density) {
@@ -250,6 +263,9 @@ fun CodeEditor(
         val x = layoutFor(line).getHorizontalPosition(renderCache.rawToVisual(line, offset - doc.lineStart(line)), usePrimaryDirection = true)
         return Triple(line, textLeft() + x, lineTop(line))
     }
+    fun lineAtY(y: Float): Int =
+        floor((y + vOffset.floatValue - metrics.padTop) / metrics.lineHeight)
+            .toInt().coerceIn(0, editorSession.doc.lineCount - 1)
     fun offsetAt(pos: Offset): Int {
         val doc = editorSession.doc
         val line = floor((pos.y + vOffset.floatValue - metrics.padTop) / metrics.lineHeight)
@@ -300,6 +316,11 @@ fun CodeEditor(
     }
     var lastInputWasTouch by remember { mutableStateOf(false) }
     var handlesVisible by remember(path) { mutableStateOf(false) }
+    // triple-tap → select line: a double-tap "arms" this for a brief window; the next quick tap nearby then
+    // selects the whole line instead of placing the caret. Keeps detectTapGestures' single/double logic intact.
+    var tripleArmed by remember(path) { mutableStateOf(false) }
+    var tripleArmPos by remember(path) { mutableStateOf(Offset.Zero) }
+    var tripleArmJob by remember(path) { mutableStateOf<Job?>(null) }
 
     // ---- completion (same session/cache/filter machinery as before) ----
     var completion by remember(path) { mutableStateOf<CompletionSession?>(null) }
@@ -315,6 +336,44 @@ fun CodeEditor(
     var actions by remember(path) { mutableStateOf<List<UiAction>>(emptyList()) }
     var actionsOpen by remember(path) { mutableStateOf(false) }
     var actionSelected by remember(path) { mutableIntStateOf(0) }
+
+    // ---- diagnostic sheet: tap a gutter glyph / inline chip → full (scrollable) message + its fixes ----
+    var diagnosticSheet by remember(path) { mutableStateOf<UiDiagnostic?>(null) }
+    var sheetActions by remember(path) { mutableStateOf<List<UiAction>>(emptyList()) }
+
+    // ---- in-file find / replace (Ctrl-F / Ctrl-R; or the toolbar Find button via findEpoch) ----
+    var findOpen by remember(path) { mutableStateOf(false) }
+    var replaceMode by remember(path) { mutableStateOf(false) }
+    var findQuery by remember(path) { mutableStateOf("") }
+    var replaceText by remember(path) { mutableStateOf("") }
+    var findOptions by remember(path) { mutableStateOf(FindOptions()) }
+    var matches by remember(path) { mutableStateOf<List<Match>>(emptyList()) }
+    var currentMatch by remember(path) { mutableIntStateOf(0) }
+    var regexError by remember(path) { mutableStateOf(false) }
+
+    fun gotoMatch(index: Int) {
+        if (matches.isEmpty()) return
+        val i = ((index % matches.size) + matches.size) % matches.size
+        currentMatch = i
+        val m = matches[i]
+        editorSession.setSelectionRange(m.start, m.end) // selects + scrolls the match into view
+    }
+
+    fun replaceCurrent() {
+        val m = matches.getOrNull(currentMatch) ?: return
+        editorSession.applyEdits(
+            listOf(RangeEdit(m.start, m.end, replaceText, m.start + replaceText.length)),
+            TextRange(m.start + replaceText.length),
+        )
+        // matches recompute on the textRevision bump; currentMatch then points at the following occurrence
+    }
+
+    fun replaceAll() {
+        if (matches.isEmpty()) return
+        val edits = matches.map { RangeEdit(it.start, it.end, replaceText, it.start + replaceText.length) }
+        editorSession.applyEdits(edits, TextRange(matches.first().start + replaceText.length))
+        currentMatch = 0
+    }
 
     // ---- rename refactoring (F2 / Shift-F6): prompt for a new name, then a project-wide rename ----
     var rename by remember(path) { mutableStateOf<RenameUiState?>(null) }
@@ -435,26 +494,59 @@ fun CodeEditor(
         job?.cancel()
     }
 
-    // Apply the chosen code action: ask the backend for its edits over the current buffer + selection, then
+    // Apply [act]: ask the backend for its edits over the buffer at the context range [ctxStart,ctxEnd), then
     // splice them in (the editor round-trip — reparse + re-analyze follow the normal text path). The caret is
     // kept on its logical spot by shifting it by the net delta of edits that land at/before it.
-    fun applyActionAt(index: Int) {
-        val act = actions.getOrNull(index) ?: return
-        actionsOpen = false
+    fun runAction(act: UiAction, ctxStart: Int, ctxEnd: Int) {
         val text = editorSession.doc.text
-        val selAtCall = editorSession.selection
         scope.launch {
-            val raw = runCatching { backend.applyAction(path, text, selAtCall.min, selAtCall.max, act.id) }.getOrNull().orEmpty()
+            val raw = runCatching { backend.applyAction(path, text, ctxStart, ctxEnd, act.id) }.getOrNull().orEmpty()
             if (raw.isEmpty()) return@launch
             val len = editorSession.doc.length
             val edits = raw.map { e ->
                 val st = e.start.coerceIn(0, len)
                 RangeEdit(st, e.end.coerceIn(st, len), e.newText, st + e.newText.length)
             }
-            var caret = selAtCall.min
+            var caret = ctxStart
             for (e in edits) if (e.start <= caret) caret += e.text.length - (e.end - e.start)
             editorSession.applyEdits(edits, TextRange(caret.coerceAtLeast(0)))
         }
+    }
+
+    fun applyActionAt(index: Int) {
+        val act = actions.getOrNull(index) ?: return
+        actionsOpen = false
+        val sel = editorSession.selection
+        runAction(act, sel.min, sel.max)
+    }
+
+    // The most-severe diagnostic whose start sits on [line], or null — drives gutter-glyph and chip taps.
+    fun diagnosticOnLine(line: Int): UiDiagnostic? {
+        var best: UiDiagnostic? = null
+        for (d in editorSession.diagnostics) {
+            if (editorSession.doc.lineForOffset(d.startOffset.coerceIn(0, editorSession.doc.length)) != line) continue
+            val cur = best
+            if (cur == null || d.severity.ordinal < cur.severity.ordinal) best = d
+        }
+        return best
+    }
+
+    // Open the diagnostic sheet for [d] and fetch the quick-fixes registered for its range.
+    fun openDiagnosticSheet(d: UiDiagnostic) {
+        dismissed = true; job?.cancel(); actionsOpen = false
+        diagnosticSheet = d
+        sheetActions = emptyList()
+        val text = editorSession.doc.text
+        scope.launch {
+            sheetActions = runCatching { backend.actionsAt(path, text, d.startOffset, d.endOffset) }.getOrNull().orEmpty()
+        }
+    }
+
+    fun applySheetFix(index: Int) {
+        val d = diagnosticSheet ?: return
+        val act = sheetActions.getOrNull(index) ?: return
+        diagnosticSheet = null
+        runAction(act, d.startOffset, d.endOffset)
     }
 
     // keep the per-line render cache aligned with line splices (a render concern, owned by this surface)
@@ -521,6 +613,26 @@ fun CodeEditor(
         when {
             result.isEmpty() -> actionsOpen = false
             actionSelected >= result.size -> actionSelected = 0
+        }
+    }
+
+    // host (toolbar Find button) requested the find bar
+    LaunchedEffect(findEpoch) {
+        if (findEpoch > 0) { findOpen = true; replaceMode = false }
+    }
+
+    // recompute find matches when the query/options change or the buffer edits (debounced); select the match
+    // nearest the caret so it scrolls into view. Closed or empty query ⇒ no matches (nothing highlights).
+    LaunchedEffect(findOpen, findQuery, findOptions, editorSession.textRevision) {
+        if (!findOpen || findQuery.isEmpty()) { matches = emptyList(); regexError = false; return@LaunchedEffect }
+        delay(120.milliseconds)
+        regexError = findOptions.regex && runCatching { Regex(findQuery) }.isFailure
+        val found = findMatches(editorSession.doc.text, findQuery, findOptions)
+        matches = found
+        if (found.isEmpty()) currentMatch = 0
+        else {
+            currentMatch = matchIndexFrom(found, editorSession.selection.start).coerceIn(0, found.size - 1)
+            editorSession.setSelectionRange(found[currentMatch].start, found[currentMatch].end)
         }
     }
 
@@ -607,21 +719,24 @@ fun CodeEditor(
                     clipboard.getText()?.text?.let { if (it.isNotEmpty()) editorSession.commitText(it) }
                     return true
                 }
+                // Undo (⌘/Ctrl-Z), redo (⌘/Ctrl-Shift-Z or Ctrl-Y). Dismiss the popup/snippet first so they
+                // don't act on the reverted buffer.
+                Key.Z -> { dismissed = true; job?.cancel(); snippet = null; if (ev.isShiftPressed) editorSession.redo() else editorSession.undo(); return true }
+                Key.Y -> { dismissed = true; job?.cancel(); snippet = null; editorSession.redo(); return true }
+                // Zoom: ⌘/Ctrl with +/-/0 (mirrors the pinch gesture).
+                Key.Equals, Key.Plus, Key.NumPadAdd -> { onFontScaleChange(clampFontScale(fontScale * 1.1f)); return true }
+                Key.Minus, Key.NumPadSubtract -> { onFontScaleChange(clampFontScale(fontScale / 1.1f)); return true }
+                Key.Zero -> { onFontScaleChange(1f); return true }
             }
             return false
         }
 
-        when (ev.key) {
-            Key.ShiftLeft, Key.ShiftRight,
-            Key.CtrlLeft, Key.CtrlRight,
-            Key.AltLeft, Key.AltRight,
-            Key.MetaLeft, Key.MetaRight,
-            Key.CapsLock, Key.NumLock, Key.ScrollLock -> return false
-            else -> Unit
-        }
-
-        val cp = ev.utf16CodePoint
-        if (cp >= 32 && cp != 127) {
+        // Printable-character insert. Whether a key is text — versus a modifier/lock/function/navigation
+        // key or an unhandled command chord — is decided per-platform (Android consults the native
+        // KeyEvent's isModifierKey/unicodeChar, robust against Bluetooth keycodes Compose's Key enum doesn't
+        // name; desktop mirrors the utf16CodePoint path). Returns the code point to insert, or -1.
+        val cp = textInputCodePoint(ev)
+        if (cp >= 0) {
             editorSession.commitText(codePointToString(cp))
             return true
         }
@@ -649,6 +764,14 @@ fun CodeEditor(
                     if (ev.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                     if ((ev.isCtrlPressed || ev.isMetaPressed) && ev.key == Key.S) {
                         onSave(); return@onPreviewKeyEvent true
+                    }
+                    // Find (⌘/Ctrl-F) / find+replace (⌘/Ctrl-R); seed the query from the current selection.
+                    if ((ev.isCtrlPressed || ev.isMetaPressed) && (ev.key == Key.F || ev.key == Key.R)) {
+                        editorSession.selectedText()?.takeIf { it.isNotEmpty() && '\n' !in it }?.let { findQuery = it }
+                        replaceMode = ev.key == Key.R
+                        findOpen = true
+                        dismissed = true; job?.cancel()
+                        return@onPreviewKeyEvent true
                     }
                     // Go to definition (⌘/Ctrl-B): resolve the resource/symbol at the caret and jump to it.
                     if ((ev.isCtrlPressed || ev.isMetaPressed) && ev.key == Key.B) {
@@ -703,6 +826,23 @@ fun CodeEditor(
                     }
                 }
                 .onKeyEvent { handleKey(it) }
+                // pinch-to-zoom: a 2-finger gesture scales the editor font. Consumes ONLY when ≥2 fingers are
+                // down, so single-finger scroll/selection still flow to the detectors below.
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        do {
+                            val event = awaitPointerEvent()
+                            if (event.changes.count { it.pressed } >= 2) {
+                                val z = event.calculateZoom()
+                                if (z != 1f) {
+                                    onFontScaleChange(clampFontScale(liveScale.value * z))
+                                    event.changes.forEach { if (it.pressed) it.consume() }
+                                }
+                            }
+                        } while (event.changes.any { it.pressed })
+                    }
+                }
                 // selection-handle and mouse-selection drags claim the pointer before the scrollables
                 .pointerInput(editorSession) {
                     awaitEachGesture {
@@ -726,8 +866,11 @@ fun CodeEditor(
                         when {
                             hit != null -> {
                                 down.consume()
+                                // The handle sits ~a line below its anchor, so the finger covers the row below.
+                                // Lift the hit-point back up to the anchored line so dragging tracks what you see.
+                                val lift = metrics.lineHeight * 0.5f + handleRadius * 0.6f
                                 drag(down.id) { change ->
-                                    val off = offsetAt(change.position)
+                                    val off = offsetAt(change.position.copy(y = change.position.y - lift))
                                     when (hit) {
                                         'a' -> editorSession.setSelectionRange(editorSession.selection.max, off)
                                         'b' -> editorSession.setSelectionRange(editorSession.selection.min, off)
@@ -763,10 +906,25 @@ fun CodeEditor(
                             val released = tryAwaitRelease()
                             if (released && !longPressed) {
                                 focus.requestFocus()
-                                editorSession.setCaret(offsetAt(pos))
-                                if (lastInputWasTouch) {
-                                    handlesVisible = true
-                                    keyboard?.show()
+                                // Third quick tap near the double-tap → select the whole line.
+                                val triple = tripleArmed && (pos - tripleArmPos).getDistance() < 60f
+                                // A tap on a gutter error/warning glyph opens that line's diagnostic sheet
+                                // (full message + fixes) instead of moving the caret.
+                                val gutterDiag = if (pos.x < gutterWidthPx) diagnosticOnLine(lineAtY(pos.y)) else null
+                                when {
+                                    triple -> {
+                                        tripleArmed = false; tripleArmJob?.cancel()
+                                        editorSession.selectLineAt(offsetAt(pos))
+                                        if (lastInputWasTouch) handlesVisible = true
+                                    }
+                                    gutterDiag != null -> openDiagnosticSheet(gutterDiag)
+                                    else -> {
+                                        editorSession.setCaret(offsetAt(pos))
+                                        if (lastInputWasTouch) {
+                                            handlesVisible = true
+                                            keyboard?.show()
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -774,14 +932,34 @@ fun CodeEditor(
                             focus.requestFocus()
                             editorSession.selectWordAt(offsetAt(pos))
                             if (lastInputWasTouch) handlesVisible = true
+                            // arm triple-tap: a quick third tap nearby (within the window below) selects the line
+                            tripleArmed = true; tripleArmPos = pos
+                            tripleArmJob?.cancel()
+                            tripleArmJob = scope.launch { delay(320.milliseconds); tripleArmed = false }
                         },
                         onLongPress = { pos ->
                             longPressed = true
                             focus.requestFocus()
-                            editorSession.selectWordAt(offsetAt(pos))
-                            if (lastInputWasTouch) {
-                                handlesVisible = true
-                                keyboard?.show()
+                            // Long-press → caret-position intentions/fixes (Alt-Enter on a phone). Fetch the
+                            // actions for that spot; if there are none, fall back to selecting the word so the
+                            // gesture is never wasted.
+                            val off = offsetAt(pos)
+                            editorSession.setCaret(off)
+                            dismissed = true; job?.cancel()
+                            scope.launch {
+                                val text = editorSession.doc.text
+                                val acts = runCatching { backend.actionsAt(path, text, off, off) }.getOrNull().orEmpty()
+                                if (acts.isNotEmpty()) {
+                                    actions = acts
+                                    actionSelected = 0
+                                    actionsOpen = true
+                                } else {
+                                    editorSession.selectWordAt(off)
+                                    if (lastInputWasTouch) {
+                                        handlesVisible = true
+                                        keyboard?.show()
+                                    }
+                                }
                             }
                         },
                     )
@@ -798,6 +976,8 @@ fun CodeEditor(
                         numberLayout = ::numberLayout,
                         diagByLine = diagByLine,
                         bracketPair = bracketPair,
+                        findMatches = if (findOpen) matches else emptyList(),
+                        currentMatch = currentMatch,
                         colors = EditorDrawColors(
                             background = colors.editorBg,
                             currentLine = colors.currentLine,
@@ -811,6 +991,8 @@ fun CodeEditor(
                             muted = colors.textTertiary,
                             composing = colors.textSecondary,
                             indentGuide = colors.hairline,
+                            findMatch = colors.warning.copy(alpha = 0.28f),
+                            findCurrent = colors.accent.copy(alpha = 0.5f),
                         ),
                         caretVisible = isFocused && (blinkOn || !editorSession.selection.collapsed),
                         caretContent = caretAnim.value, // animated, content-space; read here → redraw per frame
@@ -839,7 +1021,8 @@ fun CodeEditor(
                     d.severity,
                     d.unused,
                     d.message,
-                    Modifier.offset {
+                    onClick = { openDiagnosticSheet(d) },
+                    modifier = Modifier.offset {
                         IntOffset(
                             (gutterWidthPx + metrics.padLeft + lineWidth + 24f - hOffset.floatValue).roundToInt(),
                             (metrics.padTop + ln * metrics.lineHeight - vOffset.floatValue).roundToInt(),
@@ -981,6 +1164,41 @@ fun CodeEditor(
                 modifier = Modifier.align(Alignment.TopCenter),
             )
         }
+
+        // diagnostic sheet — full (scrollable) message + that diagnostic's fixes, docked at the pane bottom
+        diagnosticSheet?.let { d ->
+            DiagnosticSheet(
+                severity = d.severity,
+                unused = d.unused,
+                message = d.message,
+                actions = sheetActions,
+                onPick = { applySheetFix(it) },
+                onDismiss = { diagnosticSheet = null },
+            )
+        }
+
+        // find / replace bar, docked at the top of the editor
+        if (findOpen) {
+            FindReplaceBar(
+                query = findQuery,
+                replace = replaceText,
+                replaceMode = replaceMode,
+                options = findOptions,
+                matchCount = matches.size,
+                currentIndex = if (matches.isEmpty()) -1 else currentMatch,
+                regexError = regexError,
+                onQueryChange = { findQuery = it },
+                onReplaceChange = { replaceText = it },
+                onToggleReplaceMode = { replaceMode = !replaceMode },
+                onOptionsChange = { findOptions = it },
+                onPrev = { gotoMatch(currentMatch - 1) },
+                onNext = { gotoMatch(currentMatch + 1) },
+                onReplaceOne = { replaceCurrent() },
+                onReplaceAll = { replaceAll() },
+                onClose = { findOpen = false; runCatching { focus.requestFocus() } },
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
+        }
     }
 }
 
@@ -1066,6 +1284,8 @@ private class EditorDrawColors(
     val muted: Color,
     val composing: Color,
     val indentGuide: Color,
+    val findMatch: Color,
+    val findCurrent: Color,
 )
 
 /**
@@ -1121,6 +1341,8 @@ private fun DrawScope.drawEditor(
     numberLayout: (Int) -> TextLayoutResult,
     diagByLine: Map<Int, List<DiagSeg>>,
     bracketPair: Pair<Int, Int>?,
+    findMatches: List<Match>,
+    currentMatch: Int,
     colors: EditorDrawColors,
     caretVisible: Boolean,
     caretContent: Offset,
@@ -1145,6 +1367,21 @@ private fun DrawScope.drawEditor(
     }
 
     clipRect(left = gutterWidth, top = 0f, right = size.width, bottom = size.height) {
+        // find-match highlights (under the selection/text): every match tinted, the current one stronger.
+        if (findMatches.isNotEmpty()) {
+            for ((idx, m) in findMatches.withIndex()) {
+                val sLine = doc.lineForOffset(m.start)
+                val eLine = doc.lineForOffset(m.end)
+                if (eLine < firstVisible || sLine > lastVisible) continue
+                val color = if (idx == currentMatch) colors.findCurrent else colors.findMatch
+                for (line in max(sLine, firstVisible)..min(eLine, lastVisible)) {
+                    val x0 = if (line == sLine) xOf(line, m.start) else textLeft
+                    val x1 = if (line == eLine) xOf(line, m.end) else textLeft + layoutFor(line).size.width
+                    if (x1 > x0) drawRect(color, Offset(x0, lineTop(line)), Size(x1 - x0, lineH))
+                }
+            }
+        }
+
         // selection background
         if (!sel.collapsed) {
             val sLine = doc.lineForOffset(sel.min)
@@ -1337,7 +1574,7 @@ private fun DrawScope.wavyUnderline(color: Color, x1: Float, x2: Float, y: Float
 /** The inline diagnostic chip: a pill at the right of a diagnostic line — severity-tinted fill, icon,
  *  message. Colour/icon follow [severity]; an [unused] warning is muted rather than alarming. */
 @Composable
-private fun DiagnosticChip(severity: UiSeverity, unused: Boolean, message: String, modifier: Modifier) {
+private fun DiagnosticChip(severity: UiSeverity, unused: Boolean, message: String, onClick: () -> Unit, modifier: Modifier) {
     val color = when (severity) {
         UiSeverity.Error -> Ca.colors.error
         UiSeverity.Warning -> if (unused) Ca.colors.textTertiary else Ca.colors.warning
@@ -1352,6 +1589,7 @@ private fun DiagnosticChip(severity: UiSeverity, unused: Boolean, message: Strin
     Row(
         modifier
             .background(color.copy(alpha = 0.16f), RoundedCornerShape(Ca.radius.pill))
+            .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 2.dp),
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(5.dp),
@@ -1469,6 +1707,11 @@ private fun paletteFor(syntax: SyntaxColors): Array<SpanStyle?> {
     palette[TokenType.PROPERTY.ordinal] = SpanStyle(color = syntax.property)
     return palette
 }
+
+/** Editor zoom limits (× the theme code size) and the clamp the pinch/keyboard zoom both go through. */
+private const val MIN_FONT_SCALE = 0.6f
+private const val MAX_FONT_SCALE = 2.6f
+private fun clampFontScale(s: Float): Float = s.coerceIn(MIN_FONT_SCALE, MAX_FONT_SCALE)
 
 private fun codePointToString(cp: Int): String = when {
     cp < 0x10000 -> cp.toChar().toString()

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeEditor.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/CodeEditor.kt
@@ -5,6 +5,11 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.Orientation
@@ -18,6 +23,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -38,8 +44,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -74,6 +83,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextOverflow
@@ -132,6 +142,7 @@ fun CodeEditor(
     modifier: Modifier = Modifier,
     onSave: () -> Unit = {},
     onNavigate: (path: String, offset: Int) -> Unit = { _, _ -> },
+    onRenamed: (newPath: String?) -> Unit = {},
     showInlayHints: Boolean = true,
 ) {
     val colors = Ca.colors
@@ -304,6 +315,35 @@ fun CodeEditor(
     var actions by remember(path) { mutableStateOf<List<UiAction>>(emptyList()) }
     var actionsOpen by remember(path) { mutableStateOf(false) }
     var actionSelected by remember(path) { mutableIntStateOf(0) }
+
+    // ---- rename refactoring (F2 / Shift-F6): prompt for a new name, then a project-wide rename ----
+    var rename by remember(path) { mutableStateOf<RenameUiState?>(null) }
+    var renameBusy by remember(path) { mutableStateOf(false) }
+    var renameError by remember(path) { mutableStateOf<String?>(null) }
+
+    fun startRename() {
+        if (renameBusy) return
+        val text = editorSession.doc.text
+        val caret = editorSession.selection.start
+        scope.launch {
+            val target = runCatching { backend.prepareRename(path, text, caret) }.getOrNull()
+            if (target != null) { renameError = null; rename = RenameUiState(caret, target.oldName, target.kind, target.oldName) }
+        }
+    }
+
+    fun commitRename() {
+        val r = rename ?: return
+        if (renameBusy || r.newName.isBlank() || r.newName == r.oldName) { rename = null; return }
+        renameBusy = true; renameError = null
+        val text = editorSession.doc.text
+        scope.launch {
+            val result = runCatching { backend.rename(path, text, r.offset, r.newName) }
+                .getOrElse { dev.ide.ui.backend.UiRenameResult(false, it.message ?: "Rename failed") }
+            renameBusy = false
+            if (result.success) { rename = null; onRenamed(result.newPath) }
+            else renameError = result.message
+        }
+    }
 
     // Read the document + selection straight off the session (snapshot reads → this body recomposes on
     // edit), but derive everything from the rope's O(log N) random access / small substrings — the body
@@ -623,6 +663,10 @@ fun CodeEditor(
                     if ((ev.isCtrlPressed || ev.isMetaPressed) && ev.key == Key.Spacebar) {
                         dismissed = false; refresh(immediate = true); return@onPreviewKeyEvent true
                     }
+                    // Rename (F2, or Shift-F6 a la IntelliJ): prompt for a new name → project-wide rename.
+                    if (ev.key == Key.F2 || (ev.isShiftPressed && ev.key == Key.F6)) {
+                        startRename(); return@onPreviewKeyEvent true
+                    }
                     // Code actions: Alt+Enter (or Ctrl/Cmd-.) opens the lightbulb menu; when it's open the
                     // arrows + Enter/Tab drive it and Esc closes it (checked before completion's own keys).
                     if ((ev.isAltPressed && ev.key == Key.Enter) || ((ev.isCtrlPressed || ev.isMetaPressed) && ev.key == Key.Period)) {
@@ -924,6 +968,77 @@ fun CodeEditor(
                 }
             }
         }
+
+        // rename prompt — a small centered card over the editor
+        rename?.let { r ->
+            RenamePopup(
+                state = r,
+                busy = renameBusy,
+                error = renameError,
+                onChange = { rename = r.copy(newName = it) },
+                onCommit = { commitRename() },
+                onCancel = { if (!renameBusy) { rename = null; renameError = null } },
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
+        }
+    }
+}
+
+/** What the rename prompt is editing: where the caret was, the symbol's old name + kind, and the typed name. */
+private data class RenameUiState(val offset: Int, val oldName: String, val kind: String, val newName: String)
+
+/** A centered prompt for the new identifier; Enter renames, Esc cancels. Auto-focused, with the name selected. */
+@Composable
+private fun RenamePopup(
+    state: RenameUiState,
+    busy: Boolean,
+    error: String?,
+    onChange: (String) -> Unit,
+    onCommit: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focus = remember { FocusRequester() }
+    // Prefill with the old name, fully selected, so typing replaces it (the IntelliJ rename feel).
+    var field by remember { mutableStateOf(TextFieldValue(state.newName, androidx.compose.ui.text.TextRange(0, state.newName.length))) }
+    LaunchedEffect(Unit) { focus.requestFocus() }
+    Column(
+        modifier.padding(top = 48.dp).width(320.dp)
+            .background(Ca.colors.glassThick, RoundedCornerShape(Ca.radius.lg))
+            .border(1.dp, Ca.colors.glassEdge, RoundedCornerShape(Ca.radius.lg))
+            .padding(16.dp),
+    ) {
+        Text("Rename ${state.kind}", color = Ca.colors.textSecondary, style = Ca.type.caption, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.size(8.dp))
+        Box(
+            Modifier.fillMaxWidth().background(Ca.colors.surface2, RoundedCornerShape(Ca.radius.control))
+                .border(1.dp, if (error != null) Ca.colors.error else Ca.colors.hairline, RoundedCornerShape(Ca.radius.control))
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        ) {
+            BasicTextField(
+                value = field,
+                onValueChange = { field = it; onChange(it.text) },
+                singleLine = true,
+                enabled = !busy,
+                textStyle = Ca.type.body.copy(color = Ca.colors.textPrimary, fontFamily = FontFamily.Monospace),
+                cursorBrush = SolidColor(Ca.colors.accent),
+                modifier = Modifier.fillMaxWidth().focusRequester(focus).onPreviewKeyEvent { ev ->
+                    if (ev.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when (ev.key) {
+                        Key.Enter -> { onCommit(); true }
+                        Key.Escape -> { onCancel(); true }
+                        else -> false
+                    }
+                },
+            )
+        }
+        if (error != null) {
+            Spacer(Modifier.size(6.dp))
+            Text(error, color = Ca.colors.error, style = Ca.type.caption2)
+        }
+        Spacer(Modifier.size(6.dp))
+        Text(if (busy) "Renaming…" else "Enter to rename '${state.oldName}', Esc to cancel",
+            color = Ca.colors.textTertiary, style = Ca.type.caption2)
     }
 }
 

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/FindReplace.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/FindReplace.kt
@@ -1,0 +1,54 @@
+package dev.ide.ui.editor
+
+/**
+ * In-file find/replace matching — pure and compose-free so it's unit-testable. A [Match] is a half-open
+ * `[start, end)` document range. [findMatches] supports case-insensitive (default), whole-word, and regex
+ * search; an invalid regex yields no matches (the bar surfaces that as a 0-count rather than throwing).
+ */
+data class Match(val start: Int, val end: Int)
+
+data class FindOptions(
+    val caseSensitive: Boolean = false,
+    val wholeWord: Boolean = false,
+    val regex: Boolean = false,
+)
+
+private fun isWordCh(c: Char?) = c != null && (c.isLetterOrDigit() || c == '_')
+
+/** True when `[start, end)` is bounded by non-word chars (or the buffer edges) on both sides. */
+private fun isWholeWord(s: CharSequence, start: Int, end: Int): Boolean =
+    !isWordCh(if (start > 0) s[start - 1] else null) && !isWordCh(if (end < s.length) s[end] else null)
+
+/** All non-overlapping matches of [query] in [text]. Empty when the query is blank or a regex won't compile. */
+fun findMatches(text: CharSequence, query: String, opts: FindOptions): List<Match> {
+    if (query.isEmpty()) return emptyList()
+    val s = text.toString() // find is an explicit action — one materialization is fine
+    val out = ArrayList<Match>()
+    if (opts.regex) {
+        val options = if (opts.caseSensitive) emptySet() else setOf(RegexOption.IGNORE_CASE)
+        val re = runCatching { Regex(query, options) }.getOrNull() ?: return emptyList()
+        for (m in re.findAll(s)) {
+            val start = m.range.first
+            val end = m.range.last + 1
+            if (end <= start) continue // skip zero-width matches (would not advance / not selectable)
+            if (!opts.wholeWord || isWholeWord(s, start, end)) out.add(Match(start, end))
+        }
+    } else {
+        var i = 0
+        while (i <= s.length) {
+            val idx = s.indexOf(query, i, ignoreCase = !opts.caseSensitive)
+            if (idx < 0) break
+            val end = idx + query.length
+            if (!opts.wholeWord || isWholeWord(s, idx, end)) out.add(Match(idx, end))
+            i = end // non-overlapping
+        }
+    }
+    return out
+}
+
+/** Index of the first match at/after [caret], wrapping to 0; -1 when there are none. Drives "find next from caret". */
+fun matchIndexFrom(matches: List<Match>, caret: Int): Int {
+    if (matches.isEmpty()) return -1
+    val i = matches.indexOfFirst { it.start >= caret }
+    return if (i >= 0) i else 0
+}

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/FindReplaceBar.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/FindReplaceBar.kt
@@ -1,0 +1,195 @@
+package dev.ide.ui.editor
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import dev.ide.ui.components.IconButtonCa
+import dev.ide.ui.icons.CaIcons
+import dev.ide.ui.theme.Ca
+
+/**
+ * The in-file find/replace bar, docked at the top of the editor. Find row: query field + match count +
+ * prev/next + the Aa (case) / W (whole-word) / .* (regex) toggles + close, and a chevron that reveals the
+ * replace row (replace field + Replace / Replace all). Enter = next match, Shift-Enter = prev, Esc = close.
+ * Pure UI over hoisted state; all match computation + editing lives in the editor.
+ */
+@Composable
+fun FindReplaceBar(
+    query: String,
+    replace: String,
+    replaceMode: Boolean,
+    options: FindOptions,
+    matchCount: Int,
+    currentIndex: Int,
+    regexError: Boolean,
+    onQueryChange: (String) -> Unit,
+    onReplaceChange: (String) -> Unit,
+    onToggleReplaceMode: () -> Unit,
+    onOptionsChange: (FindOptions) -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onReplaceOne: () -> Unit,
+    onReplaceAll: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { focus.requestFocus() } }
+    val shape = RoundedCornerShape(bottomStart = Ca.radius.md, bottomEnd = Ca.radius.md)
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(Ca.colors.glassThick, shape)
+            .border(1.dp, Ca.colors.separator, shape)
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            IconButtonCa(
+                if (replaceMode) CaIcons.chevronDown else CaIcons.chevronRight,
+                "Toggle replace", onClick = onToggleReplaceMode, iconSize = 16, boxSize = 30,
+            )
+            Box(Modifier.weight(1f)) {
+                FieldBox(
+                    value = query,
+                    onChange = onQueryChange,
+                    placeholder = "Find",
+                    focusRequester = focus,
+                    error = regexError,
+                    onEnter = { shift -> if (shift) onPrev() else onNext() },
+                    onEscape = onClose,
+                )
+            }
+            val countText = when {
+                query.isEmpty() -> ""
+                matchCount == 0 -> "0/0"
+                else -> "${currentIndex + 1}/$matchCount"
+            }
+            Text(
+                countText,
+                color = if (matchCount == 0 && query.isNotEmpty()) Ca.colors.error else Ca.colors.textTertiary,
+                style = Ca.type.caption2,
+                modifier = Modifier.widthIn(min = 34.dp),
+            )
+            OptionChip("Aa", options.caseSensitive) { onOptionsChange(options.copy(caseSensitive = !options.caseSensitive)) }
+            OptionChip("W", options.wholeWord) { onOptionsChange(options.copy(wholeWord = !options.wholeWord)) }
+            OptionChip(".*", options.regex) { onOptionsChange(options.copy(regex = !options.regex)) }
+            IconButtonCa(CaIcons.chevronUp, "Previous match", onClick = onPrev, iconSize = 16, boxSize = 30)
+            IconButtonCa(CaIcons.chevronDown, "Next match", onClick = onNext, iconSize = 16, boxSize = 30)
+            IconButtonCa(CaIcons.close, "Close", onClick = onClose, iconSize = 16, boxSize = 30)
+        }
+        if (replaceMode) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Box(Modifier.size(30.dp)) {} // align under the chevron
+                Box(Modifier.weight(1f)) {
+                    FieldBox(value = replace, onChange = onReplaceChange, placeholder = "Replace", error = false)
+                }
+                PillButton("Replace", enabled = matchCount > 0, onClick = onReplaceOne)
+                PillButton("All", enabled = matchCount > 0, onClick = onReplaceAll)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FieldBox(
+    value: String,
+    onChange: (String) -> Unit,
+    placeholder: String,
+    error: Boolean,
+    focusRequester: FocusRequester? = null,
+    onEnter: ((shift: Boolean) -> Unit)? = null,
+    onEscape: (() -> Unit)? = null,
+) {
+    // Keep a TextFieldValue locally; on an external change (e.g. a query seeded from the selection) reset the
+    // caret to the end so typing appends rather than inserting at column 0.
+    var field by remember { mutableStateOf(TextFieldValue(value, TextRange(value.length))) }
+    if (field.text != value) field = TextFieldValue(value, TextRange(value.length))
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .background(Ca.colors.surface2, RoundedCornerShape(Ca.radius.control))
+            .border(1.dp, if (error) Ca.colors.error else Ca.colors.hairline, RoundedCornerShape(Ca.radius.control))
+            .padding(horizontal = 10.dp, vertical = 7.dp),
+    ) {
+        if (value.isEmpty()) Text(placeholder, color = Ca.colors.textTertiary, style = Ca.type.code)
+        BasicTextField(
+            value = field,
+            onValueChange = { field = it; onChange(it.text) },
+            singleLine = true,
+            textStyle = Ca.type.code.copy(color = Ca.colors.textPrimary, fontFamily = FontFamily.Monospace),
+            cursorBrush = SolidColor(Ca.colors.accent),
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+                .onPreviewKeyEvent { ev ->
+                    if (ev.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when (ev.key) {
+                        Key.Enter, Key.NumPadEnter -> { onEnter?.invoke(ev.isShiftPressed); onEnter != null }
+                        Key.Escape -> { onEscape?.invoke(); onEscape != null }
+                        else -> false
+                    }
+                },
+        )
+    }
+}
+
+@Composable
+private fun OptionChip(label: String, active: Boolean, onClick: () -> Unit) {
+    Box(
+        Modifier
+            .size(30.dp)
+            .background(if (active) Ca.colors.accentSoft else Color.Transparent, RoundedCornerShape(Ca.radius.sm))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(label, color = if (active) Ca.colors.accent else Ca.colors.textSecondary, style = Ca.type.caption2, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+private fun PillButton(label: String, enabled: Boolean, onClick: () -> Unit) {
+    Box(
+        Modifier
+            .background(if (enabled) Ca.colors.surface2 else Color.Transparent, RoundedCornerShape(Ca.radius.sm))
+            .border(1.dp, Ca.colors.hairline, RoundedCornerShape(Ca.radius.sm))
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 7.dp),
+    ) {
+        Text(label, color = if (enabled) Ca.colors.textPrimary else Ca.colors.textTertiary, style = Ca.type.caption, fontWeight = FontWeight.Medium)
+    }
+}

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/EditorSession.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/EditorSession.kt
@@ -92,6 +92,23 @@ class EditorSession(
     private var pendingIme = false // an IME state push was deferred while a batch was open
     private var goalColumn = -1 // sticky column for consecutive vertical caret moves
 
+    // ---- undo / redo ----
+    // Each step stores the *inverse-able* edits (only the changed substrings, so memory is O(edited text), not
+    // O(document)) plus the selection before/after. A batch (completion accept, IME multi-delete) records into
+    // ONE step; consecutive single-char typing/backspacing coalesces into the step on top so undo removes a
+    // run, not one char. undo/redo replay through [replaceRange] with [applyingUndo] set so they don't re-record.
+    private val undoStack = ArrayDeque<UndoStep>()
+    private val redoStack = ArrayDeque<UndoStep>()
+    private var currentGroup: UndoStep? = null   // open while a batch accumulates into one step
+    private var applyingUndo = false             // suppress recording while undo/redo replays edits
+    private var coalesceTyping = false           // may the next 1-char edit merge into the top step?
+
+    /** Whether [undo]/[redo] would do something — observable so a toolbar can enable/disable its buttons. */
+    var canUndo by mutableStateOf(false)
+        private set
+    var canRedo by mutableStateOf(false)
+        private set
+
     init {
         styles.reset(doc)
         var m = 0
@@ -109,6 +126,8 @@ class EditorSession(
             updateSelectionAndComposing(newSelection, newComposing)
             return
         }
+        val removedText = if (applyingUndo) "" else doc.substring(s, e)
+        val selBefore = selection
         val firstLine = doc.lineForOffset(s)
         val lastLine = doc.lineForOffset(e)
         doc = doc.replace(s, e, text)
@@ -129,6 +148,7 @@ class EditorSession(
         // order (multi-edit ops re-map each diagnostic correctly), O(diagnostics), no String diff. Just like
         // the line index and token spans above, the buffer keeps its own decorations in sync.
         if (diagnostics.isNotEmpty()) diagnostics = shiftDiagnostics(diagnostics, edit, doc)
+        if (!applyingUndo) recordEdit(s, removedText, text, selBefore)
         // Host hook for save-state only (mark dirty); no String is built. Fires per edit, including in a batch.
         onTextEdit?.invoke(edit)
         onSnippetEdit?.invoke(edit)
@@ -147,6 +167,7 @@ class EditorSession(
         selection = ns
         composing = nc
         goalColumn = -1
+        coalesceTyping = false // a caret/selection move ends the current typing run → next type is a new undo step
         editCount++
         notifyIme()
     }
@@ -165,16 +186,126 @@ class EditorSession(
         imeListener?.onStateChanged()
     }
 
-    /** IME batch edits (and multi-edit completion accepts): one IME push for the whole group. */
+    /** IME batch edits (and multi-edit completion accepts): one IME push for the whole group, and ONE undo step. */
     fun beginBatch() {
+        if (batchDepth == 0 && !applyingUndo) {
+            currentGroup = UndoStep(ArrayList(), selection, selection)
+            coalesceTyping = false
+        }
         batchDepth++
     }
 
     fun endBatch() {
-        if (batchDepth > 0 && --batchDepth == 0 && pendingIme) {
-            pendingIme = false
-            imeListener?.onStateChanged()
+        if (batchDepth > 0 && --batchDepth == 0) {
+            val g = currentGroup
+            currentGroup = null
+            if (g != null && g.edits.isNotEmpty()) {
+                g.selAfter = selection
+                redoStack.clear()
+                undoStack.addLast(g)
+                trimUndo()
+                refreshUndoState()
+            }
+            if (pendingIme) {
+                pendingIme = false
+                imeListener?.onStateChanged()
+            }
         }
+    }
+
+    // ---- undo / redo ----
+
+    private fun recordEdit(start: Int, removed: String, inserted: String, selBefore: TextRange) {
+        val group = currentGroup
+        if (group != null) {
+            group.edits.add(UndoEdit(start, removed, inserted)) // inside a batch → one finalized step in endBatch
+            coalesceTyping = false
+            return
+        }
+        redoStack.clear()
+        val top = undoStack.lastOrNull()
+        if (!(coalesceTyping && top != null && tryCoalesce(top, start, removed, inserted))) {
+            undoStack.addLast(UndoStep(arrayListOf(UndoEdit(start, removed, inserted)), selBefore, selection))
+            trimUndo()
+        }
+        coalesceTyping = isCoalescable(removed, inserted)
+        refreshUndoState()
+    }
+
+    /** Merge a single-char edit into [top] if it continues a forward typing run or a backspace run. */
+    private fun tryCoalesce(top: UndoStep, start: Int, removed: String, inserted: String): Boolean {
+        if (top.edits.size != 1) return false
+        val ed = top.edits[0]
+        if (removed.isEmpty() && inserted.length == 1 && ed.removed.isEmpty() && start == ed.start + ed.inserted.length) {
+            ed.inserted += inserted // typing one more char right after the run
+            top.selAfter = selection
+            return true
+        }
+        if (inserted.isEmpty() && removed.length == 1 && ed.inserted.isEmpty() && start + removed.length == ed.start) {
+            ed.start = start // backspacing one more char right before the run
+            ed.removed = removed + ed.removed
+            top.selAfter = selection
+            return true
+        }
+        return false
+    }
+
+    private fun isCoalescable(removed: String, inserted: String): Boolean {
+        val pureInsert = removed.isEmpty() && inserted.length == 1 && inserted[0] != '\n'
+        val pureDelete = inserted.isEmpty() && removed.length == 1 && removed[0] != '\n'
+        return pureInsert || pureDelete
+    }
+
+    /** Revert the most recent edit step. Returns false if there's nothing to undo (or a batch is open). */
+    fun undo(): Boolean {
+        if (currentGroup != null || undoStack.isEmpty()) return false
+        val step = undoStack.removeLast()
+        replayStep(step, undoing = true)
+        redoStack.addLast(step)
+        coalesceTyping = false
+        refreshUndoState()
+        return true
+    }
+
+    /** Re-apply the most recently undone step. Returns false if there's nothing to redo. */
+    fun redo(): Boolean {
+        if (currentGroup != null || redoStack.isEmpty()) return false
+        val step = redoStack.removeLast()
+        replayStep(step, undoing = false)
+        undoStack.addLast(step)
+        coalesceTyping = false
+        refreshUndoState()
+        return true
+    }
+
+    private fun replayStep(step: UndoStep, undoing: Boolean) {
+        applyingUndo = true
+        beginBatch() // coalesces the IME push; records nothing while applyingUndo is set
+        composing = null
+        if (undoing) {
+            // invert edits in REVERSE application order: each stored start is valid in the state it restores
+            for (i in step.edits.indices.reversed()) {
+                val ed = step.edits[i]
+                replaceRange(ed.start, ed.start + ed.inserted.length, ed.removed, TextRange(ed.start + ed.removed.length))
+            }
+            updateSelectionAndComposing(step.selBefore.coercedIn(doc.length), null)
+        } else {
+            for (ed in step.edits) {
+                replaceRange(ed.start, ed.start + ed.removed.length, ed.inserted, TextRange(ed.start + ed.inserted.length))
+            }
+            updateSelectionAndComposing(step.selAfter.coercedIn(doc.length), null)
+        }
+        endBatch()
+        applyingUndo = false
+    }
+
+    private fun trimUndo() {
+        while (undoStack.size > MAX_UNDO_STEPS) undoStack.removeFirst()
+    }
+
+    private fun refreshUndoState() {
+        canUndo = undoStack.isNotEmpty()
+        canRedo = redoStack.isNotEmpty()
     }
 
     // ---- external replacement ----
@@ -194,6 +325,9 @@ class EditorSession(
         composing = null
         diagnostics = emptyList() // a wholesale replace invalidates the old anchors; re-analysis will refill
         goalColumn = -1
+        // a wholesale replace invalidates the inverse-edit history (offsets no longer mean anything)
+        undoStack.clear(); redoStack.clear(); currentGroup = null; coalesceTyping = false
+        refreshUndoState()
         editCount++
         textRevision++
         imeListener?.onRestartInput()
@@ -309,6 +443,12 @@ class EditorSession(
         else setCaret(offset)
     }
 
+    /** Select the whole line containing [offset] (excluding the trailing newline) — the triple-tap gesture. */
+    fun selectLineAt(offset: Int) {
+        val line = doc.lineForOffset(offset.coerceIn(0, doc.length))
+        updateSelectionAndComposing(TextRange(doc.lineStart(line), doc.lineEnd(line)), null)
+    }
+
     fun selectedText(): String? =
         if (selection.collapsed) null else doc.substring(selection.min, selection.max)
 
@@ -404,8 +544,17 @@ class EditorSession(
     private companion object {
         /** Cap for IME text queries — never ship megabytes across the binder (sora's maxIPCTextLength). */
         const val MAX_IPC_TEXT = 4096
+
+        /** Undo-stack depth cap. With coalescing each step can be a whole run, so this is generous. */
+        const val MAX_UNDO_STEPS = 300
     }
 }
+
+/** One reversible change: at [start], the [removed] text was replaced by [inserted]. Coalescing mutates these. */
+private class UndoEdit(var start: Int, var removed: String, var inserted: String)
+
+/** One undo unit: its edits in application order, plus the selection to restore before ([selBefore]) and after. */
+private class UndoStep(val edits: MutableList<UndoEdit>, val selBefore: TextRange, var selAfter: TextRange)
 
 private fun TextRange.coercedIn(length: Int): TextRange =
     TextRange(start.coerceIn(0, length), end.coerceIn(0, length))

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.kt
@@ -1,6 +1,7 @@
 package dev.ide.ui.editor.core
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEvent
 
 /**
  * Platform IME integration for the custom editor surface.
@@ -18,3 +19,16 @@ import androidx.compose.ui.Modifier
  * focus target's events.
  */
 expect fun Modifier.editorTextInput(session: EditorSession): Modifier
+
+/**
+ * The Unicode code point to insert for a hardware key-down [event], or **-1** when the event is not text
+ * input — a modifier/lock/function/navigation key, or a command-key chord (Ctrl/⌘). The editor's key
+ * handler calls this for the printable-character fall-through.
+ *
+ * Platform-specific because classifying a modifier key robustly needs the native event: Compose's
+ * [androidx.compose.ui.input.key.Key] doesn't expose "is this a modifier", and Bluetooth keyboards can
+ * report key codes its enum leaves as `Key.Unknown`. Android defers to `android.view.KeyEvent.isModifierKey`
+ * (which knows every modifier keycode regardless of Compose's mapping); desktop mirrors the old
+ * `utf16CodePoint` path with a modifier blocklist.
+ */
+expect fun textInputCodePoint(event: KeyEvent): Int

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/LineRenderCache.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/core/LineRenderCache.kt
@@ -34,30 +34,27 @@ class LineRenderCache(
     private val cache = HashMap<Int, Entry>()
     private var tick = 0L
 
-    private var inlays: Map<Int, List<InlayPiece>> = emptyMap()
+    private val inlayRevs = InlayRevisions()
     private var inlayStyle: SpanStyle = SpanStyle()
-    private var inlayRev = 0
 
     /** Widest line laid out so far, px — feeds the horizontal scroll range as lines get measured. */
     var measuredMaxWidth = 0f
         private set
 
     /**
-     * Set the inlay hints to weave into lines (document-column keyed) and their span style. A no-op when the
-     * content is unchanged; otherwise bumps the inlay revision so affected lines re-shape lazily on next draw.
+     * Set the inlay hints to weave into lines (document-column keyed) and their span style. Delegates to
+     * [InlayRevisions], which bumps a per-line stamp only for lines whose pieces changed, so only those
+     * re-shape on the next draw. A theme change (the [style]) rebuilds this whole cache instance (it's
+     * remembered on the palette/style), so we don't track style for invalidation here — only inlay content.
      */
     fun setInlays(newInlays: Map<Int, List<InlayPiece>>, style: SpanStyle) {
-        if (newInlays == inlays && style == inlayStyle) return
-        inlays = newInlays
         inlayStyle = style
-        inlayRev++
+        inlayRevs.update(newInlays)
     }
-
-    private fun piecesFor(line: Int): List<InlayPiece> = inlays[line]?.sortedBy { it.col } ?: emptyList()
 
     /** Document column → visual (laid-out) column for [line] — accounts for inlays inserted before [rawCol]. */
     fun rawToVisual(line: Int, rawCol: Int): Int {
-        val pieces = piecesFor(line)
+        val pieces = inlayRevs.piecesFor(line)
         if (pieces.isEmpty()) return rawCol
         var add = 0
         for (p in pieces) if (p.col < rawCol) add += p.text.length
@@ -66,7 +63,7 @@ class LineRenderCache(
 
     /** Visual (laid-out) column → document column for [line]; a hit inside an inlay snaps to its anchor. */
     fun visualToRaw(line: Int, visualCol: Int): Int {
-        val pieces = piecesFor(line)
+        val pieces = inlayRevs.piecesFor(line)
         if (pieces.isEmpty()) return visualCol
         var add = 0
         for (p in pieces) {
@@ -80,15 +77,16 @@ class LineRenderCache(
 
     fun layoutFor(line: Int, doc: EditorDocument, styles: LineStyles): TextLayoutResult {
         val rev = styles.revOf(line)
+        val irev = inlayRevs.stampOf(line)
         cache[line]?.let { e ->
-            if (e.rev == rev && e.inlayRev == inlayRev) {
+            if (e.rev == rev && e.inlayRev == irev) {
                 e.lastUsed = ++tick
                 return e.layout
             }
         }
         val text = doc.lineText(line)
         val spans = styles.spansFor(line)
-        val pieces = piecesFor(line)
+        val pieces = inlayRevs.piecesFor(line)
         val annotated = when {
             pieces.isEmpty() && spans.isEmpty() -> AnnotatedString(text)
             pieces.isEmpty() -> AnnotatedString(
@@ -101,7 +99,7 @@ class LineRenderCache(
         }
         val layout = measurer.measure(annotated, style = baseStyle, softWrap = false, maxLines = 1)
         if (layout.size.width > measuredMaxWidth) measuredMaxWidth = layout.size.width.toFloat()
-        cache[line] = Entry(rev, inlayRev, layout, ++tick)
+        cache[line] = Entry(rev, irev, layout, ++tick)
         if (cache.size > MAX_ENTRIES) evict()
         return layout
     }
@@ -140,20 +138,17 @@ class LineRenderCache(
         return rawCol + add
     }
 
-    /** Mirror a document splice: cache keys at/after [fromOldLine] move by [delta] (Enter stays O(1)-ish). */
+    /** Mirror a document splice: keys at/after [fromOldLine] move by [delta] (Enter stays O(1)-ish). Both the
+     *  layout cache and the per-line inlay stamps shift together so a moved line keeps its validation pair. */
     fun shiftKeys(fromOldLine: Int, delta: Int) {
-        if (delta == 0 || cache.isEmpty()) return
-        val moved = cache.entries.filter { it.key >= fromOldLine }
-        if (moved.isEmpty()) return
-        for (e in moved) cache.remove(e.key)
-        for (e in moved) {
-            val k = e.key + delta
-            if (k >= 0) cache[k] = e.value
-        }
+        if (delta == 0) return
+        shiftIntKeyed(cache, fromOldLine, delta)
+        inlayRevs.shift(fromOldLine, delta)
     }
 
     fun clear() {
         cache.clear()
+        inlayRevs.clear()
         measuredMaxWidth = 0f
     }
 
@@ -166,5 +161,60 @@ class LineRenderCache(
     private companion object {
         /** ~4 viewports of lines; beyond this, scroll-back re-measures (µs per line). */
         const val MAX_ENTRIES = 512
+    }
+}
+
+/** Shift the [Int]-keyed [map]'s entries at/after [fromOldLine] by [delta], dropping any that go negative. */
+internal fun <V> shiftIntKeyed(map: HashMap<Int, V>, fromOldLine: Int, delta: Int) {
+    if (map.isEmpty()) return
+    val moved = map.entries.filter { it.key >= fromOldLine }.map { it.key to it.value }
+    if (moved.isEmpty()) return
+    for ((k, _) in moved) map.remove(k)
+    for ((k, v) in moved) { val nk = k + delta; if (nk >= 0) map[nk] = v }
+}
+
+/**
+ * Per-line inlay revision tracking, split out of [LineRenderCache] so it's testable without a `TextMeasurer`
+ * (which can't be constructed headlessly). Holds the current inlay map and a **unique-forever stamp per
+ * line**, bumped ONLY for lines whose pieces actually change.
+ *
+ * The point: a single global counter (the old design) invalidated EVERY cached line on any inlay edit — and
+ * the host re-anchors inlay offsets on every keystroke, so that re-shaped the whole viewport on each key.
+ * With a per-line stamp, a hint change re-shapes only its own line; lines after the caret stay cached.
+ */
+internal class InlayRevisions {
+    private var inlays: Map<Int, List<InlayPiece>> = emptyMap()
+    private val stampByLine = HashMap<Int, Int>()
+    private var stamp = 0
+
+    /** The unique stamp for [line]; 0 when the line has never carried an inlay. */
+    fun stampOf(line: Int): Int = stampByLine[line] ?: 0
+
+    fun piecesFor(line: Int): List<InlayPiece> = inlays[line]?.sortedBy { it.col } ?: emptyList()
+
+    /** Adopt [newInlays], bumping the stamp for each line whose pieces changed, were added, or were removed. */
+    fun update(newInlays: Map<Int, List<InlayPiece>>) {
+        if (newInlays == inlays) return
+        // lines present before whose pieces changed (or were removed: newInlays[line] becomes null)
+        for ((line, pieces) in inlays) if (newInlays[line] != pieces) stampByLine[line] = ++stamp
+        // lines newly present
+        for (line in newInlays.keys) if (line !in inlays) stampByLine[line] = ++stamp
+        inlays = newInlays
+    }
+
+    /** Mirror a line splice so a moved line keeps its stamp (paired with the layout cache shift). */
+    fun shift(fromOldLine: Int, delta: Int) {
+        if (delta == 0) return
+        shiftIntKeyed(stampByLine, fromOldLine, delta)
+        // The inlay map is document-column keyed by line; the host rebuilds it post-edit, so we only need the
+        // stamps to move. Drop the stale map so a moved line's pieces aren't read from the wrong line until then.
+        if (inlays.isNotEmpty()) inlays = inlays.mapKeys { (k, _) -> if (k >= fromOldLine) k + delta else k }
+            .filterKeys { it >= 0 }
+    }
+
+    fun clear() {
+        inlays = emptyMap()
+        stampByLine.clear()
+        stamp = 0
     }
 }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/preview/LayoutPreviewPane.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/editor/preview/LayoutPreviewPane.kt
@@ -1,0 +1,23 @@
+package dev.ide.ui.editor.preview
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.ide.ui.backend.IdeBackend
+
+/**
+ * True for an Android layout XML (`res/layout/…`), which the Preview view renders through the owned layout
+ * engine (built-in widgets + system chrome), distinct from the drawable/colour/bitmap resource previews.
+ */
+fun isLayoutPreviewable(path: String): Boolean {
+    val p = path.replace('\\', '/')
+    return p.contains("/res/layout") && p.endsWith(".xml")
+}
+
+/**
+ * Renders a layout XML preview. The actual lives in the `jvmShared` source set (it needs `layout-preview-api`,
+ * a plain-JVM artifact commonMain can't depend on) and drives the owned `PreviewEngine` over a Compose-backed
+ * `RCanvas`; the backend is cast to `LayoutPreviewBackend` to fetch the inflated tree. A host without Android
+ * support renders an empty state.
+ */
+@Composable
+expect fun LayoutPreviewPane(path: String, text: String, backend: IdeBackend, modifier: Modifier)

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/icons/CaIcons.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/icons/CaIcons.kt
@@ -117,6 +117,8 @@ object CaIcons {
         s("M9.7 19.5h4.6M10.3 21.5h3.4"),
     )
     val refresh = build("refresh", s("M19 7a8 8 0 1 0 1.5 5M19 4v3.5h-3.5"))
+    val undo = build("undo", s("M4 12h8.5a5.5 5.5 0 0 1 5.5 5.5"), s("M8 8l-4 4 4 4"))
+    val redo = build("redo", s("M20 12h-8.5a5.5 5.5 0 0 0-5.5 5.5"), s("M16 8l4 4-4 4"))
     val arrowRight = build("arrow-right", s("M5 12h13M13 6l6 6-6 6"))
     /** Arrow into a tray — import files from outside the app. */
     val download = build("download", s("M12 4v10M8 10.5l4 4 4-4"), s("M5 18.5h14"))

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/DependenciesScreen.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/DependenciesScreen.kt
@@ -85,6 +85,13 @@ private enum class DepView(val label: String, val icon: ImageVector) {
     List("List", CaIcons.resources), Tree("Tree", CaIcons.layers), Graph("Graph", CaIcons.gitBranch)
 }
 
+/** The Add flow can add a normal library/AAR or import a BOM as a platform (Gradle `platform(...)`). */
+private enum class AddMode(val label: String) { Library("Library"), Platform("Platform (BOM)") }
+
+/** A typed string is treated as a direct coordinate when it carries a `:` — `group:name[:version]`. */
+private fun looksLikeCoordinate(s: String): Boolean =
+    s.split(":").let { it.size in 2..3 && it.all { p -> p.isNotBlank() } }
+
 /** A transient confirmation/result toast. */
 private data class ToastMsg(val text: String, val error: Boolean)
 
@@ -131,7 +138,7 @@ fun DependenciesScreen(
     BoxWithConstraints(Modifier.fillMaxSize().background(Ca.colors.bg)) {
         val expanded = maxWidth >= DEPS_EXPANDED_BREAKPOINT
         Column(Modifier.fillMaxSize()) {
-            DepsHeader(onBack, view, { view = it }, { addOpen = true }, resolving, resolveState.message)
+            DepsHeader(onBack, view, { view = it }, { addOpen = true }, resolving, resolveState.message, compact = !expanded)
             Box(Modifier.fillMaxWidth().height(1.dp).background(Ca.colors.separator))
 
             if (expanded) {
@@ -198,6 +205,7 @@ private fun DepsHeader(
     onAdd: () -> Unit,
     resolving: Boolean,
     resolveMessage: String,
+    compact: Boolean,
 ) {
     GlassSurface(Modifier.fillMaxWidth(), GlassMaterial.Regular) {
         Row(
@@ -206,9 +214,12 @@ private fun DepsHeader(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             IconButtonCa(CaIcons.chevronLeft, "Back", onBack)
-            Icon(CaIcons.layers, null, Modifier.size(20.dp), tint = Ca.colors.accent)
-            Text("Dependencies", color = Ca.colors.textPrimary, style = Ca.type.headline, fontWeight = FontWeight.SemiBold)
-            AnimatedVisibility(resolving, enter = fadeIn(tween(Motion.FAST)), exit = fadeOut(tween(Motion.FAST))) {
+            if (!compact) Icon(CaIcons.layers, null, Modifier.size(20.dp), tint = Ca.colors.accent)
+            // On compact widths the title yields space (ellipsizes) so the toggle + Add never clip off-screen.
+            Text("Dependencies", color = Ca.colors.textPrimary, style = Ca.type.headline, fontWeight = FontWeight.SemiBold,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                modifier = if (compact) Modifier.weight(1f, fill = false) else Modifier)
+            AnimatedVisibility(resolving && !compact, enter = fadeIn(tween(Motion.FAST)), exit = fadeOut(tween(Motion.FAST))) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp),
                     modifier = Modifier.padding(start = 4.dp).background(Ca.colors.accentSoft, RoundedCornerShape(Ca.radius.pill)).padding(horizontal = 10.dp, vertical = 4.dp)) {
                     CircularProgressIndicator(Modifier.size(12.dp), color = Ca.colors.accent, strokeWidth = 2.dp)
@@ -216,9 +227,11 @@ private fun DepsHeader(
                 }
             }
             Spacer(Modifier.weight(1f))
-            ViewToggle(view, onView)
+            // Compact: a spinning indicator stands in for the resolving pill (which is hidden to save room).
+            if (compact && resolving) CircularProgressIndicator(Modifier.size(16.dp), color = Ca.colors.accent, strokeWidth = 2.dp)
+            ViewToggle(view, onView, compact = compact)
             Spacer(Modifier.width(4.dp))
-            PrimaryButton("Add", onClick = onAdd, icon = CaIcons.plus)
+            PrimaryButton("Add", onClick = onAdd, icon = CaIcons.plus, iconOnly = compact)
         }
     }
 }
@@ -491,6 +504,7 @@ private fun AddDependencyContent(
     onResult: (UiAddResult) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var mode by remember { mutableStateOf(AddMode.Library) }
     var query by remember { mutableStateOf("") }
     var results by remember { mutableStateOf<List<UiArtifactHit>>(emptyList()) }
     var searching by remember { mutableStateOf(false) }
@@ -502,7 +516,7 @@ private fun AddDependencyContent(
     val scopeOptions = listOf("implementation", "api", "compileOnly", "runtimeOnly", "testImplementation")
     val coroutine = rememberCoroutineScope()
 
-    LaunchedEffect(query) {
+    LaunchedEffect(query, mode) {
         val q = query.trim()
         if (q.length < 2 || moduleName == null) { results = emptyList(); return@LaunchedEffect }
         searching = true
@@ -511,8 +525,25 @@ private fun AddDependencyContent(
         searching = false
     }
 
+    // Add either a versioned library/AAR or, in Platform mode, import a BOM via addPlatform.
+    val performAdd: (String) -> Unit = add@{ coordinate ->
+        if (moduleName == null) return@add
+        busy = true; error = null; adding = coordinate
+        coroutine.launch {
+            val result = if (mode == AddMode.Platform) backend.addPlatform(moduleName, coordinate)
+                else backend.addDependency(moduleName, coordinate, scope)
+            busy = false; adding = null
+            if (result.success) onResult(result) else error = result.message
+        }
+    }
+
     Column(modifier) {
         Text("Add dependency", color = Ca.colors.textPrimary, style = Ca.type.title3, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(bottom = 12.dp))
+
+        // Library vs Platform (BOM) toggle
+        Row(Modifier.fillMaxWidth().padding(bottom = 12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AddMode.entries.forEach { m -> ModeChip(m.label, m == mode) { if (!busy) { mode = m; error = null } } }
+        }
 
         // search field
         Row(
@@ -522,7 +553,9 @@ private fun AddDependencyContent(
         ) {
             Icon(CaIcons.search, null, Modifier.size(18.dp), tint = Ca.colors.accent)
             Box(Modifier.weight(1f)) {
-                if (query.isEmpty()) Text("Search Maven Central — e.g. okhttp, com.google.guava…", color = Ca.colors.textTertiary, style = Ca.type.subhead)
+                val hint = if (mode == AddMode.Platform) "Search a BOM, or type group:name:version — e.g. androidx.compose:compose-bom:…"
+                    else "Search Maven Central, or type group:name[:version]…"
+                if (query.isEmpty()) Text(hint, color = Ca.colors.textTertiary, style = Ca.type.subhead, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 BasicTextField(query, { query = it; error = null }, singleLine = true, enabled = !busy,
                     textStyle = Ca.type.subhead.copy(color = Ca.colors.textPrimary, fontFamily = codeFont),
                     cursorBrush = SolidColor(Ca.colors.accent), modifier = Modifier.fillMaxWidth())
@@ -530,11 +563,11 @@ private fun AddDependencyContent(
             if (searching) CircularProgressIndicator(Modifier.size(14.dp), color = Ca.colors.textTertiary, strokeWidth = 2.dp)
         }
 
-        // scope selector
-        Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 10.dp), horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+        // scope selector — libraries only (a platform carries no scope)
+        if (mode == AddMode.Library) Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 10.dp), horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
             Text("scope", color = Ca.colors.textTertiary, style = Ca.type.caption, modifier = Modifier.padding(end = 4.dp))
             scopeOptions.forEach { s -> ScopeChip(s, s == scope) { if (!busy) scope = s } }
-        }
+        } else Spacer(Modifier.height(10.dp))
 
         error?.let { msg ->
             Row(Modifier.fillMaxWidth().padding(bottom = 8.dp).background(Ca.colors.error.copy(alpha = 0.10f), RoundedCornerShape(Ca.radius.sm)).padding(10.dp),
@@ -555,23 +588,57 @@ private fun AddDependencyContent(
                     ResolveBar(resolveState.fraction)
                 }
             } else {
+                val typed = query.trim()
                 LazyColumn(Modifier.fillMaxWidth().heightIn(max = 360.dp)) {
-                    items(results, key = { it.coordinate }) { hit ->
-                        AddResultRow(hit, codeFont, Modifier.animateItem()) {
-                            if (moduleName == null) return@AddResultRow
-                            busy = true; error = null; adding = hit.coordinate
-                            coroutine.launch {
-                                val result = backend.addDependency(moduleName, hit.coordinate, scope)
-                                busy = false; adding = null
-                                if (result.success) onResult(result) else error = result.message
-                            }
-                        }
+                    // Direct add of a typed coordinate — the only way to add a versionless `group:name`
+                    // (resolved against the module's imported platforms) or a coordinate not in the index.
+                    if (looksLikeCoordinate(typed)) item("direct:$typed") {
+                        DirectAddRow(typed, mode, codeFont, Modifier.animateItem()) { performAdd(typed) }
                     }
-                    if (query.trim().length >= 2 && results.isEmpty() && !searching) item { EmptyRow("No results.") }
-                    if (query.trim().length < 2) item { EmptyRow("Type at least 2 characters to search.") }
+                    items(results, key = { it.coordinate }) { hit ->
+                        AddResultRow(hit, codeFont, Modifier.animateItem()) { performAdd(hit.coordinate) }
+                    }
+                    if (typed.length >= 2 && results.isEmpty() && !searching && !looksLikeCoordinate(typed)) item { EmptyRow("No results.") }
+                    if (typed.length < 2) item { EmptyRow("Type at least 2 characters to search, or a full group:name[:version].") }
                 }
             }
         }
+    }
+}
+
+/** A row offering to add the literally-typed coordinate (handles versionless `group:name` + BOMs). */
+@Composable
+private fun DirectAddRow(coordinate: String, mode: AddMode, codeFont: FontFamily, modifier: Modifier, onAdd: () -> Unit) {
+    val versionless = coordinate.count { it == ':' } == 1
+    val color = if (mode == AddMode.Platform) Ca.colors.info else Ca.colors.accent
+    Row(
+        modifier.fillMaxWidth().height(52.dp).clickable(remember { MutableInteractionSource() }, null, onClick = onAdd).padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        LetterBox(if (mode == AddMode.Platform) "B" else "+", color)
+        Column(Modifier.weight(1f)) {
+            Text(coordinate, color = Ca.colors.textPrimary, style = Ca.type.footnote.copy(fontFamily = codeFont), maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(
+                when {
+                    mode == AddMode.Platform -> "Import as a platform (BOM)"
+                    versionless -> "Add versionless — version from a platform"
+                    else -> "Add this exact coordinate"
+                },
+                color = Ca.colors.textTertiary, style = Ca.type.caption2,
+            )
+        }
+        IconButtonCa(CaIcons.plus, "Add $coordinate", onClick = onAdd, active = true, boxSize = 32, iconSize = 18)
+    }
+}
+
+@Composable
+private fun ModeChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    val bg by animateColorAsState(if (selected) Ca.colors.accentSoft else Ca.colors.surface2, tween(Motion.FAST), label = "modeBg")
+    Box(
+        Modifier.background(bg, RoundedCornerShape(Ca.radius.pill)).clickable(remember { MutableInteractionSource() }, null, onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 7.dp),
+    ) {
+        Text(label, color = if (selected) Ca.colors.accent else Ca.colors.textSecondary, style = Ca.type.caption, fontWeight = FontWeight.SemiBold)
     }
 }
 
@@ -659,14 +726,14 @@ private fun ToastHost(toast: ToastMsg?, modifier: Modifier) {
 // ---- small shared pieces ------------------------------------------------------------------------
 
 @Composable
-private fun ViewToggle(view: DepView, onSelect: (DepView) -> Unit) {
+private fun ViewToggle(view: DepView, onSelect: (DepView) -> Unit, compact: Boolean = false) {
     Row(Modifier.background(Ca.colors.surface2, RoundedCornerShape(Ca.radius.sm)).padding(2.dp), horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-        DepView.entries.forEach { v -> SegItem(v.icon, v.label, v == view) { onSelect(v) } }
+        DepView.entries.forEach { v -> SegItem(v.icon, v.label, v == view, compact) { onSelect(v) } }
     }
 }
 
 @Composable
-private fun SegItem(icon: ImageVector, label: String, active: Boolean, onClick: () -> Unit) {
+private fun SegItem(icon: ImageVector, label: String, active: Boolean, compact: Boolean, onClick: () -> Unit) {
     val bg by animateColorAsState(if (active) Ca.colors.accentSoft else Color.Transparent, tween(Motion.FAST), label = "segBg")
     Row(
         Modifier.background(bg, RoundedCornerShape(Ca.radius.xs)).clickable(remember { MutableInteractionSource() }, null, onClick = onClick)
@@ -674,7 +741,7 @@ private fun SegItem(icon: ImageVector, label: String, active: Boolean, onClick: 
         horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(icon, label, Modifier.size(14.dp), tint = if (active) Ca.colors.accent else Ca.colors.textSecondary)
-        Text(label, color = if (active) Ca.colors.accent else Ca.colors.textSecondary, style = Ca.type.caption, fontWeight = FontWeight.Medium)
+        if (!compact) Text(label, color = if (active) Ca.colors.accent else Ca.colors.textSecondary, style = Ca.type.caption, fontWeight = FontWeight.Medium)
     }
 }
 
@@ -696,6 +763,7 @@ private fun DepBadge(node: UiDependencyNode, small: Boolean = false) {
         UiDepKind.Aar -> "A" to Ca.colors.run
         UiDepKind.Module -> "M" to Ca.colors.accent
         UiDepKind.Sdk -> "S" to Ca.colors.info
+        UiDepKind.Platform -> "B" to Ca.colors.info   // a BOM (bill of materials) — version source, no artifact
     }
     LetterBox(letter, if (node.compatible) color else Ca.colors.error, size = if (small) 16 else 20)
 }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorScreen.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorScreen.kt
@@ -311,7 +311,7 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(Modifier.weight(1f)) { Breadcrumb(crumbs) }
-                ViewModeToggle(active.viewMode, dev.ide.ui.editor.preview.isPreviewable(active.path)) { active.viewMode = it }
+                ViewModeToggle(active.viewMode, dev.ide.ui.editor.preview.isPreviewable(active.path) || dev.ide.ui.editor.preview.isLayoutPreviewable(active.path)) { active.viewMode = it }
             }
             AndroidSourcesBanner(state)
             when (active.viewMode) {
@@ -321,12 +321,21 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
                     backend = state.backend,
                     modifier = Modifier.weight(1f).fillMaxWidth(),
                 )
-                dev.ide.ui.EditorViewMode.Preview -> dev.ide.ui.editor.preview.ResourcePreviewPane(
-                    path = active.path,
-                    text = active.text,
-                    backend = state.backend,
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
-                )
+                dev.ide.ui.EditorViewMode.Preview -> if (dev.ide.ui.editor.preview.isLayoutPreviewable(active.path)) {
+                    dev.ide.ui.editor.preview.LayoutPreviewPane(
+                        path = active.path,
+                        text = active.text,
+                        backend = state.backend,
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                    )
+                } else {
+                    dev.ide.ui.editor.preview.ResourcePreviewPane(
+                        path = active.path,
+                        text = active.text,
+                        backend = state.backend,
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                    )
+                }
                 else -> CodeEditor(
                     path = active.path,
                     session = active.session,
@@ -334,6 +343,7 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
                     modifier = Modifier.weight(1f).fillMaxWidth(),
                     onSave = { state.save(active) },
                     onNavigate = { p, o -> state.openAt(p, o) },
+                    onRenamed = { newPath -> state.reloadAfterRename(active.path, newPath) },
                     showInlayHints = state.inlayHintsEnabled,
                 )
             }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorScreen.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorScreen.kt
@@ -2,6 +2,8 @@ package dev.ide.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -47,6 +49,10 @@ import dev.ide.ui.components.CommandPalette
 import dev.ide.ui.components.DropdownOverlay
 import dev.ide.ui.components.EditorTopBar
 import dev.ide.ui.components.FileNavigator
+import dev.ide.ui.components.FileOpKind
+import dev.ide.ui.components.FileOpRequest
+import dev.ide.ui.components.FileOperationDialog
+import dev.ide.ui.components.fileOpPath
 import dev.ide.ui.components.GlassMaterial
 import dev.ide.ui.components.GlassSurface
 import dev.ide.ui.components.IconButtonCa
@@ -84,18 +90,21 @@ fun EditorScreen(
 ) {
     val indexStatus by state.backend.indexStatus.collectAsState()
     val buildState by state.backend.buildState.collectAsState()
+    val scope = rememberCoroutineScope()
     var newFileTarget by remember { mutableStateOf<NewFileTarget?>(null) }
     var newXmlTarget by remember { mutableStateOf<NewXmlTarget?>(null) }
+    var fileOp by remember { mutableStateOf<FileOpRequest?>(null) }
     // A res/ folder node opens the XML resource dialog; a Java source/package node opens New-Class.
     val onNewFile: (TreeNode) -> Unit = { node ->
         val xml = xmlTargetOf(node)
         if (xml != null) newXmlTarget = xml else newFileTargetOf(node)?.let { newFileTarget = it }
     }
     val onNewFileRoot: () -> Unit = { state.defaultNewFileTarget()?.let { newFileTarget = it } }
+    val onFileOp: (TreeNode, FileOpKind) -> Unit = { node, kind -> fileOp = FileOpRequest(node, kind) }
     Box(Modifier.fillMaxSize()) {
         BoxWithConstraints(Modifier.fillMaxSize()) {
-            if (maxWidth < COMPACT_BREAKPOINT) CompactLayout(state, onToggleTheme, indexStatus, buildState, onNewFile, onNewFileRoot, onOpenDependencies, onOpenModuleConfig, onOpenSdkManager, onCloseProject, fileActions)
-            else ExpandedLayout(state, onToggleTheme, indexStatus, buildState, onNewFile, onNewFileRoot, onOpenDependencies, onOpenModuleConfig, onOpenSdkManager, onCloseProject, fileActions)
+            if (maxWidth < COMPACT_BREAKPOINT) CompactLayout(state, onToggleTheme, indexStatus, buildState, onNewFile, onNewFileRoot, onFileOp, onOpenDependencies, onOpenModuleConfig, onOpenSdkManager, onCloseProject, fileActions)
+            else ExpandedLayout(state, onToggleTheme, indexStatus, buildState, onNewFile, onNewFileRoot, onFileOp, onOpenDependencies, onOpenModuleConfig, onOpenSdkManager, onCloseProject, fileActions)
         }
         NewFileDialog(
             visible = newFileTarget != null,
@@ -110,6 +119,15 @@ fun EditorScreen(
             onCreate = { dir, fileName, content -> state.createFile(dir, fileName, content) },
             onCreateDir = { parent, dirName -> state.createDirectory(parent, dirName) },
         )
+        FileOperationDialog(
+            request = fileOp,
+            tree = state.tree,
+            onRename = { node, newName -> node.fileOpPath()?.let { p -> scope.launch { state.renamePath(p, newName) } } },
+            onMove = { node, dest -> node.fileOpPath()?.let { state.movePath(it, dest) } },
+            onCopy = { node, dest -> node.fileOpPath()?.let { state.copyPath(it, dest) } },
+            onDelete = { node -> node.fileOpPath()?.let { state.deletePath(it) } },
+            onDismiss = { fileOp = null },
+        )
     }
 }
 
@@ -121,6 +139,7 @@ private fun ExpandedLayout(
     buildState: BuildState,
     onNewFile: (TreeNode) -> Unit,
     onNewFileRoot: () -> Unit,
+    onFileOp: (TreeNode, FileOpKind) -> Unit,
     onOpenDependencies: (String?) -> Unit,
     onOpenModuleConfig: (String?) -> Unit,
     onOpenSdkManager: () -> Unit,
@@ -153,6 +172,11 @@ private fun ExpandedLayout(
                         onImport = { doImport(state, fileActions) },
                         canShare = fileActions.canShare,
                         onShare = { node -> node.filePath?.let { fileActions.share(it) } },
+                        canModify = true,
+                        onRename = { onFileOp(it, FileOpKind.Rename) },
+                        onMove = { onFileOp(it, FileOpKind.Move) },
+                        onCopy = { onFileOp(it, FileOpKind.Copy) },
+                        onDelete = { onFileOp(it, FileOpKind.Delete) },
                     )
                 }
                 VerticalDivider()
@@ -196,6 +220,7 @@ private fun CompactLayout(
     buildState: BuildState,
     onNewFile: (TreeNode) -> Unit,
     onNewFileRoot: () -> Unit,
+    onFileOp: (TreeNode, FileOpKind) -> Unit,
     onOpenDependencies: (String?) -> Unit,
     onOpenModuleConfig: (String?) -> Unit,
     onOpenSdkManager: () -> Unit,
@@ -299,6 +324,8 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
             // Breadcrumb tracks the caret: module › enclosing type(s) › method. Debounced (a reparse), and
             // falls back to the file path when the caret is outside any declaration (imports, blank lines).
             var crumbs by remember(active.path) { mutableStateOf(breadcrumbFor(state, active)) }
+            // Bumped by the Find button to open the editor's in-file find bar (Ctrl/⌘-F is the keyboard path).
+            var findEpoch by remember(active.path) { mutableStateOf(0) }
             val caretOffset = active.session.selection.start
             LaunchedEffect(active.path, active.session.textRevision, caretOffset) {
                 delay(200)
@@ -311,6 +338,14 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(Modifier.weight(1f)) { Breadcrumb(crumbs) }
+                // Undo/redo — a touch affordance for the history that Ctrl/⌘-Z also drives; reads the
+                // session's observable canUndo/canRedo so the glyphs dim when there's nothing to do.
+                val canUndo = active.session.canUndo
+                val canRedo = active.session.canRedo
+                val dim = Ca.colors.textTertiary.copy(alpha = 0.35f)
+                IconButtonCa(CaIcons.undo, "Undo", onClick = { active.session.undo() }, iconSize = 18, boxSize = 32, tint = if (canUndo) null else dim)
+                IconButtonCa(CaIcons.redo, "Redo", onClick = { active.session.redo() }, iconSize = 18, boxSize = 32, tint = if (canRedo) null else dim)
+                IconButtonCa(CaIcons.search, "Find / replace", onClick = { findEpoch++ }, iconSize = 18, boxSize = 32)
                 ViewModeToggle(active.viewMode, dev.ide.ui.editor.preview.isPreviewable(active.path) || dev.ide.ui.editor.preview.isLayoutPreviewable(active.path)) { active.viewMode = it }
             }
             AndroidSourcesBanner(state)
@@ -345,6 +380,9 @@ private fun EditorCenter(state: IdeUiState, indexStatus: IndexUiStatus, compact:
                     onNavigate = { p, o -> state.openAt(p, o) },
                     onRenamed = { newPath -> state.reloadAfterRename(active.path, newPath) },
                     showInlayHints = state.inlayHintsEnabled,
+                    findEpoch = findEpoch,
+                    fontScale = state.editorFontScale,
+                    onFontScaleChange = { state.editorFontScale = it },
                 )
             }
         } else {
@@ -473,7 +511,9 @@ private fun MoreSheetContent(
     onCloseProject: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier.padding(horizontal = 12.dp, vertical = 4.dp)) {
+    // Scrollable so every row (incl. "Close project") is reachable when the sheet is short — e.g. the soft
+    // keyboard is up and the sheet has been lifted above it (issue #994).
+    Column(modifier.verticalScroll(rememberScrollState()).padding(horizontal = 12.dp, vertical = 4.dp)) {
         Text("More", color = Ca.colors.textPrimary, style = Ca.type.headline, fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 10.dp))
         MoreRow(CaIcons.gear, "Module Settings", "Java version, Android config, source sets", onModuleSettings)

--- a/ide-ui/src/desktopMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.desktop.kt
+++ b/ide-ui/src/desktopMain/kotlin/dev/ide/ui/editor/core/EditorTextInput.desktop.kt
@@ -1,6 +1,13 @@
 package dev.ide.ui.editor.core
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.utf16CodePoint
 
 /**
  * Desktop: typing arrives through the editor's common key-event handler (printable chars via
@@ -9,3 +16,17 @@ import androidx.compose.ui.Modifier
  * (value/state/onEditCommand) from an `establishTextInputSession` here, mirroring the Android actual.
  */
 actual fun Modifier.editorTextInput(session: EditorSession): Modifier = this
+
+actual fun textInputCodePoint(event: KeyEvent): Int {
+    // Ctrl/⌘ chords are shortcuts. Ctrl+Alt is AltGr on some layouts and DOES produce text, so don't
+    // suppress it.
+    if ((event.isCtrlPressed || event.isMetaPressed) && !event.isAltPressed) return -1
+    when (event.key) {
+        Key.ShiftLeft, Key.ShiftRight, Key.CtrlLeft, Key.CtrlRight,
+        Key.AltLeft, Key.AltRight, Key.MetaLeft, Key.MetaRight,
+        Key.CapsLock, Key.NumLock, Key.ScrollLock, Key.Function -> return -1
+        else -> {}
+    }
+    val cp = event.utf16CodePoint
+    return if (cp in 32..0x10FFFF && cp != 127) cp else -1
+}

--- a/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/FindReplaceTest.kt
+++ b/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/FindReplaceTest.kt
@@ -1,0 +1,68 @@
+package dev.ide.ui.editor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** [findMatches]/[matchIndexFrom] semantics: case, whole-word, regex, non-overlap, find-from-caret. */
+class FindReplaceTest {
+
+    @Test
+    fun caseInsensitiveByDefault() {
+        val m = findMatches("Foo foo FOO", "foo", FindOptions())
+        assertEquals(listOf(Match(0, 3), Match(4, 7), Match(8, 11)), m)
+    }
+
+    @Test
+    fun caseSensitiveWhenAsked() {
+        val m = findMatches("Foo foo FOO", "foo", FindOptions(caseSensitive = true))
+        assertEquals(listOf(Match(4, 7)), m)
+    }
+
+    @Test
+    fun nonOverlapping() {
+        // "aa" in "aaaa" → matches at 0 and 2, not 1 (editors don't overlap)
+        assertEquals(listOf(Match(0, 2), Match(2, 4)), findMatches("aaaa", "aa", FindOptions()))
+    }
+
+    @Test
+    fun wholeWordRespectsBoundaries() {
+        val text = "in int print in"
+        val m = findMatches(text, "in", FindOptions(wholeWord = true))
+        // "in" (0..2) and the trailing "in" (13..15); not the "in" inside "int" or "print"
+        assertEquals(listOf(Match(0, 2), Match(13, 15)), m)
+    }
+
+    @Test
+    fun regexMatches() {
+        val m = findMatches("a1 b22 c333", "[a-z][0-9]+", FindOptions(regex = true))
+        assertEquals(listOf(Match(0, 2), Match(3, 6), Match(7, 11)), m)
+    }
+
+    @Test
+    fun invalidRegexYieldsNoMatches() {
+        assertTrue(findMatches("abc", "(", FindOptions(regex = true)).isEmpty())
+    }
+
+    @Test
+    fun emptyQueryYieldsNoMatches() {
+        assertTrue(findMatches("abc", "", FindOptions()).isEmpty())
+    }
+
+    @Test
+    fun zeroWidthRegexIsSkipped() {
+        // "a*" can match empty; we must not emit zero-width matches (they'd be unselectable / stall navigation)
+        val m = findMatches("baab", "a*", FindOptions(regex = true))
+        assertTrue(m.all { it.end > it.start })
+        assertEquals(listOf(Match(1, 3)), m)
+    }
+
+    @Test
+    fun findFromCaretWraps() {
+        val matches = listOf(Match(2, 4), Match(10, 12), Match(20, 22))
+        assertEquals(1, matchIndexFrom(matches, caret = 5))   // first at/after 5 → index 1
+        assertEquals(0, matchIndexFrom(matches, caret = 25))  // past the last → wrap to 0
+        assertEquals(0, matchIndexFrom(matches, caret = 0))
+        assertEquals(-1, matchIndexFrom(emptyList(), caret = 0))
+    }
+}

--- a/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/core/EditorSessionUndoTest.kt
+++ b/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/core/EditorSessionUndoTest.kt
@@ -1,0 +1,120 @@
+package dev.ide.ui.editor.core
+
+import androidx.compose.ui.text.TextRange
+import dev.ide.ui.editor.CodeLanguage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Undo/redo semantics of [EditorSession]: coalescing, batch grouping, selection restore, redo invalidation. */
+class EditorSessionUndoTest {
+
+    private fun session(text: String, caret: Int = text.length) =
+        EditorSession(text, CodeLanguage.Plain, TextRange(caret))
+
+    @Test
+    fun consecutiveTypingUndoesAndRedoesAsOneRun() {
+        val s = session("", 0)
+        s.commitText("a"); s.commitText("b"); s.commitText("c")
+        assertEquals("abc", s.doc.text)
+        assertTrue(s.canUndo)
+
+        assertTrue(s.undo())
+        assertEquals("", s.doc.text, "one undo removes the whole typed run")
+        assertEquals(TextRange(0), s.selection)
+        assertFalse(s.canUndo)
+
+        assertTrue(s.redo())
+        assertEquals("abc", s.doc.text)
+        assertEquals(TextRange(3), s.selection)
+    }
+
+    @Test
+    fun caretMoveStartsANewUndoStep() {
+        val s = session("", 0)
+        s.commitText("a"); s.commitText("b")
+        s.setCaret(0)          // breaks the typing run
+        s.commitText("x")
+        assertEquals("xab", s.doc.text)
+
+        assertTrue(s.undo())
+        assertEquals("ab", s.doc.text, "first undo reverts only the post-move char")
+        assertEquals(TextRange(0), s.selection)
+        assertTrue(s.undo())
+        assertEquals("", s.doc.text, "second undo reverts the earlier run")
+    }
+
+    @Test
+    fun backspaceRunCoalesces() {
+        val s = session("hello", 5)
+        s.backspace(); s.backspace(); s.backspace() // delete o, l, l → "he"
+        assertEquals("he", s.doc.text)
+
+        assertTrue(s.undo())
+        assertEquals("hello", s.doc.text, "one undo restores the whole deleted run")
+        assertEquals(TextRange(5), s.selection)
+    }
+
+    @Test
+    fun multiEditBatchIsASingleUndoStep() {
+        val s = session("foo", 3)
+        s.applyEdits(listOf(RangeEdit(0, 0, "x", 1), RangeEdit(3, 3, "y", 4)), TextRange(5))
+        assertEquals("xfooy", s.doc.text)
+
+        assertTrue(s.undo())
+        assertEquals("foo", s.doc.text, "both edits of the batch revert together")
+        assertTrue(s.redo())
+        assertEquals("xfooy", s.doc.text)
+    }
+
+    @Test
+    fun typingAfterUndoDiscardsRedo() {
+        val s = session("", 0)
+        s.commitText("a")
+        assertTrue(s.undo())
+        assertTrue(s.canRedo)
+        s.commitText("b")
+        assertFalse(s.canRedo, "a fresh edit invalidates the redo branch")
+        assertFalse(s.redo())
+        assertEquals("b", s.doc.text)
+    }
+
+    @Test
+    fun setTextClearsHistory() {
+        val s = session("hello", 5)
+        s.commitText("!")
+        assertTrue(s.canUndo)
+        s.setText("brand new")
+        assertFalse(s.canUndo)
+        assertFalse(s.canRedo)
+        assertFalse(s.undo())
+    }
+
+    @Test
+    fun nothingToUndoOrRedoOnAFreshSession() {
+        val s = session("x", 1)
+        assertFalse(s.canUndo)
+        assertFalse(s.canRedo)
+        assertFalse(s.undo())
+        assertFalse(s.redo())
+    }
+
+    @Test
+    fun undoRedoRoundTripsAcrossManySteps() {
+        val s = session("", 0)
+        s.commitText("hello")          // run 1
+        s.setCaret(0); s.commitText("X") // run 2 (separate)
+        s.setCaret(s.doc.length); s.commitText("!") // run 3
+        val full = s.doc.text
+        // unwind everything, then redo everything
+        var undos = 0
+        while (s.undo()) undos++
+        assertEquals("", s.doc.text)
+        assertTrue(undos >= 3)
+        var redos = 0
+        while (s.redo()) redos++
+        assertEquals(full, s.doc.text)
+        assertEquals(undos, redos)
+    }
+}

--- a/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/core/LineRenderCacheTest.kt
+++ b/ide-ui/src/desktopTest/kotlin/dev/ide/ui/editor/core/LineRenderCacheTest.kt
@@ -1,0 +1,78 @@
+package dev.ide.ui.editor.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the per-line inlay invalidation that backs [LineRenderCache]. The cache keys each line's shaped
+ * layout on (style revision, inlay revision); the inlay revision used to be a single global counter, so
+ * *any* inlay change re-shaped every cached line. Because the host shifts inlay offsets on every keystroke,
+ * that re-shaped the whole viewport per key — the exact mobile typing hotspot. [InlayRevisions] now stamps
+ * each line independently, so changing one line's inlay leaves the others' stamps (and thus cached layouts)
+ * untouched. Tested here without a `TextMeasurer` (it can't be constructed headlessly).
+ */
+class LineRenderCacheTest {
+
+    @Test
+    fun inlayChangeBumpsOnlyTheChangedLine() {
+        val revs = InlayRevisions()
+        revs.update(mapOf(0 to listOf(InlayPiece(1, "a")), 1 to listOf(InlayPiece(1, "b")), 2 to listOf(InlayPiece(1, "c"))))
+        val before = intArrayOf(revs.stampOf(0), revs.stampOf(1), revs.stampOf(2))
+
+        // change only line 1's pieces
+        revs.update(mapOf(0 to listOf(InlayPiece(1, "a")), 1 to listOf(InlayPiece(1, "B!")), 2 to listOf(InlayPiece(1, "c"))))
+
+        assertEquals(before[0], revs.stampOf(0), "line 0 unchanged ⇒ same stamp ⇒ stays cached")
+        assertNotEquals(before[1], revs.stampOf(1), "line 1 changed ⇒ bumped ⇒ re-shapes")
+        assertEquals(before[2], revs.stampOf(2), "line 2 unchanged ⇒ same stamp ⇒ stays cached")
+    }
+
+    @Test
+    fun reapplyingIdenticalInlaysBumpsNothing() {
+        val revs = InlayRevisions()
+        val hints = mapOf(2 to listOf(InlayPiece(1, "x")), 5 to listOf(InlayPiece(0, "y")))
+        revs.update(hints)
+        val s2 = revs.stampOf(2); val s5 = revs.stampOf(5)
+        revs.update(mapOf(2 to listOf(InlayPiece(1, "x")), 5 to listOf(InlayPiece(0, "y")))) // equal content
+        assertEquals(s2, revs.stampOf(2))
+        assertEquals(s5, revs.stampOf(5))
+    }
+
+    @Test
+    fun addingAndRemovingLinesBumpsThoseLines() {
+        val revs = InlayRevisions()
+        revs.update(mapOf(1 to listOf(InlayPiece(0, "a"))))
+        val s1 = revs.stampOf(1)
+        // remove line 1's hint, add line 3
+        revs.update(mapOf(3 to listOf(InlayPiece(0, "b"))))
+        assertNotEquals(s1, revs.stampOf(1), "removed line must bump (its woven text disappears)")
+        assertTrue(revs.stampOf(3) > 0, "newly hinted line must bump")
+    }
+
+    @Test
+    fun stampsAreUniqueForeverAcrossUpdates() {
+        // unique-forever stamps are what make stale cache hits impossible; assert they strictly increase.
+        val revs = InlayRevisions()
+        revs.update(mapOf(0 to listOf(InlayPiece(0, "a"))))
+        val first = revs.stampOf(0)
+        revs.update(mapOf(0 to listOf(InlayPiece(0, "b"))))
+        val second = revs.stampOf(0)
+        revs.update(mapOf(0 to listOf(InlayPiece(0, "c"))))
+        val third = revs.stampOf(0)
+        assertTrue(first < second && second < third, "stamps must strictly increase ($first < $second < $third)")
+    }
+
+    @Test
+    fun shiftMovesStampsWithTheirLines() {
+        val revs = InlayRevisions()
+        revs.update(mapOf(2 to listOf(InlayPiece(0, "a")), 5 to listOf(InlayPiece(0, "b"))))
+        val s2 = revs.stampOf(2); val s5 = revs.stampOf(5)
+        // a newline inserted above line 2 pushes lines >=2 down by one
+        revs.shift(fromOldLine = 2, delta = 1)
+        assertEquals(s2, revs.stampOf(3), "old line 2's stamp moved to line 3")
+        assertEquals(s5, revs.stampOf(6), "old line 5's stamp moved to line 6")
+        assertEquals(0, revs.stampOf(2), "line 2 now holds no stamp")
+    }
+}

--- a/ide-ui/src/jvmShared/kotlin/dev/ide/ui/editor/preview/ComposeRenderBackend.kt
+++ b/ide-ui/src/jvmShared/kotlin/dev/ide/ui/editor/preview/ComposeRenderBackend.kt
@@ -1,0 +1,189 @@
+package dev.ide.ui.editor.preview
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.sp
+import dev.ide.preview.FontMetrics
+import dev.ide.preview.PreviewResources
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ValueFormat
+import dev.ide.preview.PaintStyle
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RGraphics
+import dev.ide.preview.RImage
+import dev.ide.preview.RPaint
+import dev.ide.preview.RPath
+
+/** A mutable [RPaint] holder mapped to a Compose [Paint] per draw call. */
+internal class ComposePaint : RPaint {
+    override var color: Int = 0xFF000000.toInt()
+    override var style: PaintStyle = PaintStyle.FILL
+    override var strokeWidth: Float = 0f
+    override var antiAlias: Boolean = true
+    override var textSizePx: Float = 14f
+    override var bold: Boolean = false
+    override var gradient: dev.ide.preview.Gradient? = null
+}
+
+/** Wraps a Compose [androidx.compose.ui.graphics.Path] parsed from Android `pathData`. */
+internal class ComposePath(val path: androidx.compose.ui.graphics.Path) : RPath
+
+/** Wraps a decoded Compose image. */
+internal class ComposeImage(val bitmap: androidx.compose.ui.graphics.ImageBitmap) : RImage {
+    override val width: Int get() = bitmap.width
+    override val height: Int get() = bitmap.height
+}
+
+/**
+ * Wraps the engine's [PreviewResources] (resolve = colours/dimensions, delegated) with image decoding the UI
+ * side owns: a `@drawable/@mipmap` reference is mapped to a file path by the backend, read, and decoded to a
+ * Compose [ComposeImage] via the platform [decodeImageBytes].
+ */
+internal class UiPreviewResources(
+    private val delegate: PreviewResources,
+    private val imageFile: (String) -> String?,
+) : PreviewResources {
+    override fun resolve(raw: String, format: ValueFormat): ResolvedValue? = delegate.resolve(raw, format)
+
+    override fun image(ref: String): RImage? {
+        val path = imageFile(ref) ?: return null
+        val bytes = runCatching { java.io.File(path).readBytes() }.getOrNull() ?: return null
+        return decodeImageBytes(bytes)?.let { ComposeImage(it) }
+    }
+}
+
+/**
+ * [RGraphics] backed by Compose: paints map to `androidx.compose.ui.graphics.Paint`, and text metrics use a
+ * [TextMeasurer] (real line breaking / advance widths). A paint's `textSizePx` is converted to `sp` via the
+ * previewed [density] so the measured pixel size matches what the engine laid out.
+ */
+internal class ComposeGraphics(private val measurer: TextMeasurer) : RGraphics {
+    override fun newPaint(): RPaint = ComposePaint()
+
+    override fun parsePath(pathData: String): RPath? =
+        runCatching { ComposePath(AndroidPathParser.parse(pathData)) }.getOrNull()
+
+    // The measurer is built with Density(1f) so `textSizePx.sp` measures to exactly `textSizePx` pixels —
+    // the engine works in device pixels throughout, independent of the host display density.
+    override fun measureText(text: CharSequence, paint: RPaint): Float =
+        measurer.measure(text.toString(), styleOf(paint)).size.width.toFloat()
+
+    override fun fontMetrics(paint: RPaint): FontMetrics {
+        val r = measurer.measure("Ag", styleOf(paint))
+        return FontMetrics(lineHeight = r.size.height.toFloat(), ascent = r.firstBaseline)
+    }
+
+    private fun styleOf(paint: RPaint) = TextStyle(
+        fontSize = paint.textSizePx.sp,
+        fontWeight = if (paint.bold) FontWeight.Bold else FontWeight.Normal,
+    )
+}
+
+/**
+ * [RCanvas] over a Compose [DrawScope]: vector ops go through the underlying canvas (so manual
+ * save/restore/translate compose with the scope), and text goes through [DrawScope.drawText] with the same
+ * [TextMeasurer] the metrics used. This is the surface both built-in renderers and (later) a custom view's
+ * unwrapped native canvas composite into.
+ */
+internal class ComposeRCanvas(
+    private val ds: DrawScope,
+    private val measurer: TextMeasurer,
+) : RCanvas, dev.ide.preview.NativeCanvasHolder {
+    private val canvas = ds.drawContext.canvas
+
+    // The platform-native canvas (android.graphics.Canvas / skia.Canvas) a custom view's onDraw draws into.
+    override fun nativeCanvas(): Any? = canvas.nativeCanvas
+
+    private fun paint(p: RPaint): Paint = Paint().also {
+        it.color = Color(p.color)
+        it.style = if (p.style == PaintStyle.STROKE) PaintingStyle.Stroke else PaintingStyle.Fill
+        it.strokeWidth = p.strokeWidth
+        it.isAntiAlias = p.antiAlias
+    }
+
+    /** Like [paint], but installs a gradient shader sized to the drawn rect when the paint carries one. */
+    private fun paintFor(p: RPaint, l: Float, t: Float, r: Float, b: Float): Paint = paint(p).also {
+        val g = p.gradient ?: return@also
+        val colors = g.colors.map { c -> Color(c) }
+        it.shader = when (g.type) {
+            dev.ide.preview.GradientType.RADIAL -> androidx.compose.ui.graphics.RadialGradientShader(
+                center = Offset(l + (r - l) * g.centerX, t + (b - t) * g.centerY),
+                radius = minOf(r - l, b - t) * g.radiusFraction,
+                colors = colors,
+            )
+            dev.ide.preview.GradientType.SWEEP -> androidx.compose.ui.graphics.SweepGradientShader(
+                center = Offset(l + (r - l) * g.centerX, t + (b - t) * g.centerY), colors = colors,
+            )
+            else -> {
+                val rad = g.angleDeg * (kotlin.math.PI.toFloat() / 180f)
+                val dx = kotlin.math.cos(rad); val dy = -kotlin.math.sin(rad)
+                val cx = (l + r) / 2f; val cy = (t + b) / 2f
+                androidx.compose.ui.graphics.LinearGradientShader(
+                    from = Offset(cx - dx * (r - l) / 2f, cy - dy * (b - t) / 2f),
+                    to = Offset(cx + dx * (r - l) / 2f, cy + dy * (b - t) / 2f),
+                    colors = colors,
+                )
+            }
+        }
+    }
+
+    override fun save(): Int { canvas.save(); return 0 }
+    override fun restore() { canvas.restore() }
+    override fun translate(dx: Float, dy: Float) { canvas.translate(dx, dy) }
+    override fun clipRect(l: Float, t: Float, r: Float, b: Float) { canvas.clipRect(l, t, r, b) }
+
+    override fun drawRect(l: Float, t: Float, r: Float, b: Float, paint: RPaint) =
+        canvas.drawRect(l, t, r, b, paintFor(paint, l, t, r, b))
+
+    override fun drawRoundRect(l: Float, t: Float, r: Float, b: Float, rx: Float, ry: Float, paint: RPaint) =
+        canvas.drawRoundRect(l, t, r, b, rx, ry, paintFor(paint, l, t, r, b))
+
+    override fun drawCircle(cx: Float, cy: Float, radius: Float, paint: RPaint) =
+        canvas.drawCircle(Offset(cx, cy), radius, paintFor(paint, cx - radius, cy - radius, cx + radius, cy + radius))
+
+    override fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: RPaint) =
+        canvas.drawLine(Offset(x0, y0), Offset(x1, y1), paint(paint))
+
+    override fun drawPath(path: RPath, paint: RPaint) {
+        if (path is ComposePath) canvas.drawPath(path.path, paint(paint))
+    }
+
+    override fun drawImage(img: RImage, l: Float, t: Float, r: Float, b: Float, tintArgb: Int?) {
+        if (img !is ComposeImage) return
+        val p = Paint()
+        if (tintArgb != null) p.colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(Color(tintArgb))
+        canvas.drawImageRect(
+            image = img.bitmap,
+            srcOffset = IntOffset.Zero,
+            srcSize = IntSize(img.bitmap.width, img.bitmap.height),
+            dstOffset = IntOffset(l.toInt(), t.toInt()),
+            dstSize = IntSize((r - l).toInt(), (b - t).toInt()),
+            paint = p,
+        )
+    }
+
+    override fun drawText(text: CharSequence, x: Float, y: Float, paint: RPaint) {
+        // The DrawScope renders sp at the host density; divide so `textSizePx` lands as raw pixels — the
+        // same pixel size the Density(1f) measurer reported during layout.
+        ds.drawText(
+            textMeasurer = measurer,
+            text = text.toString(),
+            topLeft = Offset(x, y),
+            style = TextStyle(
+                color = Color(paint.color),
+                fontSize = (paint.textSizePx / ds.density).sp,
+                fontWeight = if (paint.bold) FontWeight.Bold else FontWeight.Normal,
+            ),
+        )
+    }
+}

--- a/ide-ui/src/jvmShared/kotlin/dev/ide/ui/editor/preview/LayoutPreviewPane.jvm.kt
+++ b/ide-ui/src/jvmShared/kotlin/dev/ide/ui/editor/preview/LayoutPreviewPane.jvm.kt
@@ -1,0 +1,307 @@
+package dev.ide.ui.editor.preview
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import dev.ide.preview.LayoutPreviewBackend
+import dev.ide.preview.LayoutPreviewResult
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.PreviewRequest
+import dev.ide.preview.RenderNode
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.ui.backend.IdeBackend
+import dev.ide.ui.icons.CaIcons
+import dev.ide.ui.theme.Ca
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/** A previewed device profile (logical size in dp + density). Landscape swaps width/height. */
+private data class DeviceProfile(val label: String, val wdp: Int, val hdp: Int, val density: Float)
+
+private val DEVICES = listOf(
+    DeviceProfile("Phone", 360, 800, 2f),
+    DeviceProfile("Compact", 320, 568, 2f),
+    DeviceProfile("Tablet", 600, 960, 2f),
+)
+
+/**
+ * The layout Preview view: renders the layout on a device card floating over the editor surface with free
+ * pan + pinch/zoom (drag to scroll, pinch or the toolbar to zoom, double-tap to fit). A top bar switches
+ * device / orientation / night; the bottom bar holds zoom + the System-UI toggle. Tapping a view selects it
+ * (highlight + attribute inspector); render problems surface in a chip. Styled with CodeAssist tokens.
+ */
+@Composable
+actual fun LayoutPreviewPane(path: String, text: String, backend: IdeBackend, modifier: Modifier) {
+    var deviceIndex by remember { mutableStateOf(0) }
+    var landscape by remember { mutableStateOf(false) }
+    var night by remember { mutableStateOf(false) }
+    var showChrome by remember { mutableStateOf(true) }
+
+    val device = DEVICES[deviceIndex]
+    val wdp = if (landscape) device.hdp else device.wdp
+    val hdp = if (landscape) device.wdp else device.hdp
+    val widthPx = (wdp * device.density).toInt()
+    val heightPx = (hdp * device.density).toInt()
+    val request = PreviewRequest(widthPx, heightPx, device.density, showChrome, night)
+
+    val lpBackend = backend as? LayoutPreviewBackend
+    var result by remember { mutableStateOf<LayoutPreviewResult?>(null) }
+    LaunchedEffect(path, text, request, lpBackend) {
+        result = lpBackend?.layoutPreview(path, text, request)
+    }
+
+    val fontResolver = LocalFontFamilyResolver.current
+    val measurer = remember(fontResolver) { TextMeasurer(fontResolver, Density(1f), LayoutDirection.Ltr) }
+    val gfx = remember(measurer) { ComposeGraphics(measurer) }
+
+    var selected by remember(path) { mutableStateOf<RenderNode?>(null) }
+    var showProblems by remember { mutableStateOf(false) }
+
+    Box(modifier.fillMaxSize().background(Ca.colors.editorBg)) {
+        val r = result
+        if (lpBackend == null || r == null) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    if (lpBackend == null) "Layout preview isn't available for this project" else "No layout preview for this file",
+                    color = Ca.colors.textTertiary, style = Ca.type.footnote,
+                )
+            }
+            return@Box
+        }
+
+        val resources = remember(r) { UiPreviewResources(r.resources, r.imageFile) }
+        val engine = remember(r) { PreviewEngine(SimpleRenderContext(gfx, resources, device.density, device.density)) }
+        val accent = Ca.colors.accent
+
+        BoxWithConstraints(Modifier.fillMaxSize().clipToBounds()) {
+            val hostDensity = LocalDensity.current.density
+            val devWdp = widthPx / hostDensity
+            val devHdp = heightPx / hostDensity
+            val fit = min((maxWidth.value * 0.9f) / devWdp, (maxHeight.value * 0.86f) / devHdp).coerceIn(0.1f, 4f)
+
+            var userScale by remember(path) { mutableStateOf(0f) }
+            var offset by remember(path) { mutableStateOf(Offset.Zero) }
+            val scale = if (userScale <= 0f) fit else userScale
+
+            // Re-fit (and recentre) whenever the device viewport changes — rotation or device switch.
+            LaunchedEffect(widthPx, heightPx) { userScale = 0f; offset = Offset.Zero }
+
+            Box(
+                Modifier.fillMaxSize()
+                    .pointerInput(path) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            val base = if (userScale <= 0f) fit else userScale
+                            userScale = (base * zoom).coerceIn(0.2f, 5f)
+                            offset += pan
+                        }
+                    }
+                    .pointerInput(path) { detectTapGestures(onTap = { selected = null }) },
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    Modifier
+                        .graphicsLayer {
+                            scaleX = scale; scaleY = scale; translationX = offset.x; translationY = offset.y
+                        }
+                        .size(devWdp.dp, devHdp.dp)
+                        .shadow(16.dp, RoundedCornerShape(Ca.radius.lg))
+                        .clip(RoundedCornerShape(Ca.radius.lg))
+                        .background(Color.White)
+                        .border(1.dp, Ca.colors.separator, RoundedCornerShape(Ca.radius.lg))
+                        .pointerInput(r) {
+                            detectTapGestures(
+                                onTap = { p -> selected = engine.hitTest(r.root, p.x, p.y) },
+                                onDoubleTap = { if (userScale <= 0f) userScale = 1f else { userScale = 0f; offset = Offset.Zero } },
+                            )
+                        },
+                ) {
+                    Canvas(Modifier.fillMaxSize()) {
+                        val rc = ComposeRCanvas(this, measurer)
+                        engine.render(r.root, widthPx, heightPx, rc)
+                        selected?.let { n ->
+                            drawRect(
+                                color = accent,
+                                topLeft = Offset(n.left.toFloat(), n.top.toFloat()),
+                                size = Size(n.width.toFloat(), n.height.toFloat()),
+                                style = Stroke(width = 2f * device.density),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Top bar: device / orientation / night.
+            GlassBar(Modifier.align(Alignment.TopCenter).padding(Ca.spacing.s3)) {
+                PillButton({ deviceIndex = (deviceIndex + 1) % DEVICES.size }) {
+                    Text("${device.label} · ${wdp}×$hdp", color = Ca.colors.textSecondary, style = Ca.type.caption, modifier = Modifier.padding(horizontal = Ca.spacing.s2))
+                }
+                Divider()
+                PillButton({ landscape = !landscape }) {
+                    Icon(CaIcons.refresh, "Rotate", Modifier.size(15.dp), tint = if (landscape) Ca.colors.accent else Ca.colors.textSecondary)
+                }
+                Divider()
+                PillButton({ night = !night }) {
+                    Text("Night", color = if (night) Ca.colors.accent else Ca.colors.textTertiary, style = Ca.type.caption, modifier = Modifier.padding(horizontal = Ca.spacing.s1))
+                }
+            }
+
+            // Bottom bar: zoom / fit / chrome.
+            GlassBar(Modifier.align(Alignment.BottomCenter).padding(Ca.spacing.s4)) {
+                PillButton({ val b = if (userScale <= 0f) fit else userScale; userScale = (b / 1.25f).coerceIn(0.2f, 5f) }) { MinusGlyph() }
+                Text("${(scale * 100f).roundToInt()}%", color = Ca.colors.textSecondary, style = Ca.type.caption, modifier = Modifier.width(44.dp), textAlign = TextAlign.Center)
+                PillButton({ val b = if (userScale <= 0f) fit else userScale; userScale = (b * 1.25f).coerceIn(0.2f, 5f) }) { Icon(CaIcons.plus, "Zoom in", Modifier.size(16.dp), tint = Ca.colors.textPrimary) }
+                Divider()
+                PillButton({ userScale = 0f; offset = Offset.Zero }) { Icon(CaIcons.refresh, "Fit", Modifier.size(15.dp), tint = Ca.colors.textSecondary) }
+                Divider()
+                PillButton({ showChrome = !showChrome }) { Icon(CaIcons.eye, "Toggle system UI", Modifier.size(16.dp), tint = if (showChrome) Ca.colors.accent else Ca.colors.textTertiary) }
+            }
+
+            // Problem chip (top-start), expandable.
+            if (r.problems.isNotEmpty()) {
+                Column(Modifier.align(Alignment.TopStart).padding(Ca.spacing.s3), horizontalAlignment = Alignment.Start) {
+                    GlassBar(Modifier) {
+                        PillButton({ showProblems = !showProblems }) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Icon(CaIcons.warning, "Render problems", Modifier.size(15.dp), tint = Ca.colors.warning)
+                                Text(" ${r.problems.size}", color = Ca.colors.warning, style = Ca.type.caption)
+                            }
+                        }
+                    }
+                    if (showProblems) {
+                        Column(
+                            Modifier.padding(top = Ca.spacing.s2).widthIn(max = 320.dp)
+                                .clip(RoundedCornerShape(Ca.radius.md)).background(Ca.colors.surface)
+                                .border(1.dp, Ca.colors.separator, RoundedCornerShape(Ca.radius.md))
+                                .padding(Ca.spacing.s3),
+                            verticalArrangement = Arrangement.spacedBy(Ca.spacing.s1),
+                        ) {
+                            for (p in r.problems) Text("<${p.tag.substringAfterLast('.')}> — ${p.message}", color = Ca.colors.textSecondary, style = Ca.type.caption2)
+                        }
+                    }
+                }
+            }
+
+            // Inspector (top-end), when a node is selected.
+            selected?.let { node ->
+                InspectorPanel(
+                    node = node, density = device.density,
+                    modifier = Modifier.align(Alignment.TopEnd).padding(Ca.spacing.s3),
+                    onClose = { selected = null },
+                )
+            }
+        }
+    }
+}
+
+/** A floating attribute inspector for the selected node. */
+@Composable
+private fun InspectorPanel(node: RenderNode, density: Float, modifier: Modifier, onClose: () -> Unit) {
+    fun dp(px: Int) = "${(px / density).roundToInt()}dp"
+    val rows = buildList {
+        add("Tag" to node.tag.substringAfterLast('.'))
+        node.props.id?.let { add("id" to it) }
+        add("Bounds" to "${dp(node.left)}, ${dp(node.top)}")
+        add("Size" to "${dp(node.width)} × ${dp(node.height)}")
+        if (node.props.hPadding != 0 || node.props.vPadding != 0) add("Padding" to "${dp(node.props.paddingLeft)} ${dp(node.props.paddingTop)} ${dp(node.props.paddingRight)} ${dp(node.props.paddingBottom)}")
+        if (node.props.text.isNotEmpty()) add("Text" to node.props.text.toString().take(60))
+        node.props.backgroundColor?.let { add("Background" to "#%08X".format(it)) }
+    }
+    Column(
+        modifier.widthIn(min = 200.dp, max = 280.dp)
+            .shadow(10.dp, RoundedCornerShape(Ca.radius.md))
+            .clip(RoundedCornerShape(Ca.radius.md)).background(Ca.colors.surface)
+            .border(1.dp, Ca.colors.separator, RoundedCornerShape(Ca.radius.md)),
+    ) {
+        Row(Modifier.fillMaxWidth().padding(start = Ca.spacing.s3, end = Ca.spacing.s1, top = Ca.spacing.s1, bottom = Ca.spacing.s1), verticalAlignment = Alignment.CenterVertically) {
+            Text(node.tag.substringAfterLast('.'), color = Ca.colors.textPrimary, style = Ca.type.subhead, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+            PillButton(onClose) { Icon(CaIcons.close, "Close", Modifier.size(14.dp), tint = Ca.colors.textTertiary) }
+        }
+        Box(Modifier.fillMaxWidth().height(1.dp).background(Ca.colors.separator))
+        Column(Modifier.verticalScroll(rememberScrollState()).padding(Ca.spacing.s3), verticalArrangement = Arrangement.spacedBy(Ca.spacing.s2)) {
+            for ((label, value) in rows) Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(Ca.spacing.s2)) {
+                Text(label, color = Ca.colors.textTertiary, style = Ca.type.caption, modifier = Modifier.width(72.dp))
+                Text(value, color = Ca.colors.textPrimary, style = Ca.type.caption)
+            }
+        }
+    }
+}
+
+/** A horizontal glass pill container for control clusters. */
+@Composable
+private fun GlassBar(modifier: Modifier, content: @Composable () -> Unit) {
+    Row(
+        modifier.shadow(8.dp, RoundedCornerShape(Ca.radius.pill)).clip(RoundedCornerShape(Ca.radius.pill))
+            .background(Ca.colors.glassReg).border(1.dp, Ca.colors.glassEdge, RoundedCornerShape(Ca.radius.pill))
+            .padding(horizontal = Ca.spacing.s2, vertical = Ca.spacing.s1),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Ca.spacing.s1),
+        content = { content() },
+    )
+}
+
+@Composable
+private fun PillButton(onClick: () -> Unit, content: @Composable () -> Unit) {
+    // Stable gesture key (Unit) + always-current handler, so the tap detector isn't restarted every
+    // recomposition (which could drop the tap — the cause of rotate/device taps not registering).
+    val current by androidx.compose.runtime.rememberUpdatedState(onClick)
+    Box(
+        Modifier.height(32.dp).widthIn(min = 32.dp).clip(RoundedCornerShape(Ca.radius.sm))
+            .pointerInput(Unit) { detectTapGestures { current() } },
+        contentAlignment = Alignment.Center,
+        content = { content() },
+    )
+}
+
+@Composable
+private fun MinusGlyph() {
+    Box(Modifier.width(12.dp).height(2.dp).clip(RoundedCornerShape(1.dp)).background(Ca.colors.textPrimary))
+}
+
+@Composable
+private fun Divider() {
+    Box(Modifier.width(1.dp).height(18.dp).background(Ca.colors.separator))
+}

--- a/lang-jdt/src/main/kotlin/dev/ide/lang/jdt/context/ModuleCompilationContext.kt
+++ b/lang-jdt/src/main/kotlin/dev/ide/lang/jdt/context/ModuleCompilationContext.kt
@@ -12,6 +12,7 @@ import dev.ide.model.Module
 import dev.ide.model.ModuleDependency
 import dev.ide.model.ModuleId
 import dev.ide.model.Sdk
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 import dev.ide.model.Workspace
 import dev.ide.platform.ContentHash
@@ -87,6 +88,7 @@ object ModuleCompilationContext {
                         collect(workspace, it, isRoot = false, sources, libraries, sourceAttachments, sdkNames, libIndex, visited)
                     }
                 }
+                is PlatformDependency -> { /* a BOM contributes no classes to the compile classpath */ }
             }
         }
     }

--- a/lang-jdt/src/main/kotlin/dev/ide/lang/jdt/rename/JdtRename.kt
+++ b/lang-jdt/src/main/kotlin/dev/ide/lang/jdt/rename/JdtRename.kt
@@ -1,0 +1,101 @@
+package dev.ide.lang.jdt.rename
+
+import dev.ide.lang.dom.TextRange
+import dev.ide.lang.jdt.dom.JdtParsedFile
+import org.eclipse.jdt.core.dom.ASTVisitor
+import org.eclipse.jdt.core.dom.IBinding
+import org.eclipse.jdt.core.dom.IMethodBinding
+import org.eclipse.jdt.core.dom.ITypeBinding
+import org.eclipse.jdt.core.dom.IVariableBinding
+import org.eclipse.jdt.core.dom.NodeFinder
+import org.eclipse.jdt.core.dom.SimpleName
+
+/**
+ * The symbol a rename is about, distilled from JDT bindings into something stable enough to match across
+ * separately-parsed compilation units. [bindingKey] is JDT's cross-unit binding key (a `Lpkg/Type;`-style
+ * identifier); [isType] turns on the constructor special-case (a class rename must also retouch constructor
+ * declaration name tokens, whose own binding is the constructor, not the type); [fileLocal] marks symbols
+ * (locals, parameters, type parameters) whose references can only live in the declaring file, so the
+ * orchestrator skips the project-wide sweep.
+ */
+data class RenameTarget(
+    val oldName: String,
+    val kind: String,
+    val bindingKey: String,
+    val fileLocal: Boolean,
+    val isType: Boolean,
+    val declRange: TextRange,
+)
+
+/** Find the renameable symbol under the caret and all of its references within a parsed file. */
+object JdtRename {
+
+    /** The renameable symbol whose name token contains [offset], or null if the caret isn't on one. */
+    fun targetAt(parsed: JdtParsedFile, offset: Int): RenameTarget? {
+        val found = NodeFinder.perform(parsed.cu, offset.coerceIn(0, parsed.text().length), 0) ?: return null
+        val name = found as? SimpleName ?: found.parent as? SimpleName ?: return null
+        val binding = name.resolveBinding() ?: return null
+        val d = describe(binding) ?: return null
+        return RenameTarget(name.identifier, d.kind, d.key, d.fileLocal, d.isType,
+            TextRange(name.startPosition, name.startPosition + name.length))
+    }
+
+    private data class Described(val key: String, val kind: String, val fileLocal: Boolean, val isType: Boolean)
+
+    /** Map a binding to its rename identity. A constructor renames the *class*; an override is not chased. */
+    private fun describe(b: IBinding): Described? = when (b) {
+        is ITypeBinding -> when {
+            b.isTypeVariable -> b.key?.let { Described(it, "type parameter", fileLocal = true, isType = false) }
+            b.isAnonymous || b.isWildcardType || b.isCapture || b.isArray -> null
+            else -> b.typeDeclaration.key?.let { Described(it, typeKindLabel(b), fileLocal = false, isType = true) }
+        }
+        is IMethodBinding ->
+            if (b.isConstructor) b.declaringClass?.typeDeclaration?.key?.let { Described(it, "class", fileLocal = false, isType = true) }
+            else b.methodDeclaration.key?.let { Described(it, "method", fileLocal = false, isType = false) }
+        is IVariableBinding -> when {
+            b.isField -> b.variableDeclaration.key?.let { Described(it, "field", fileLocal = false, isType = false) }
+            b.isParameter -> b.key?.let { Described(it, "parameter", fileLocal = true, isType = false) }
+            else -> b.key?.let { Described(it, "local variable", fileLocal = true, isType = false) }
+        }
+        else -> null
+    }
+
+    private fun typeKindLabel(b: ITypeBinding): String = when {
+        b.isInterface -> "interface"
+        b.isEnum -> "enum"
+        b.isRecord -> "record"
+        b.isAnnotation -> "annotation"
+        else -> "class"
+    }
+
+    /**
+     * Every identifier token in [parsed] that refers to [target], as source ranges. Matches on the binding
+     * key (so qualified uses, imports and the declaration are all caught), with a guard that the token text
+     * equals the old name. For a type, constructor declaration names (`Foo() {}`) are matched too — their
+     * binding is the constructor, whose declaring class is the renamed type.
+     */
+    fun referencesIn(parsed: JdtParsedFile, target: RenameTarget): List<TextRange> {
+        val out = ArrayList<TextRange>()
+        parsed.cu.accept(object : ASTVisitor() {
+            override fun visit(node: SimpleName): Boolean {
+                if (node.identifier == target.oldName && matches(node.resolveBinding(), target)) {
+                    out += TextRange(node.startPosition, node.startPosition + node.length)
+                }
+                return true
+            }
+        })
+        return out.distinctBy { it.start }.sortedBy { it.start }
+    }
+
+    private fun matches(binding: IBinding?, target: RenameTarget): Boolean = when (binding) {
+        null -> false
+        is ITypeBinding ->
+            (if (binding.isTypeVariable) binding.key else binding.typeDeclaration.key) == target.bindingKey
+        is IMethodBinding ->
+            if (binding.isConstructor) target.isType && binding.declaringClass?.typeDeclaration?.key == target.bindingKey
+            else binding.methodDeclaration.key == target.bindingKey
+        is IVariableBinding ->
+            (if (binding.isField) binding.variableDeclaration.key else binding.key) == target.bindingKey
+        else -> false
+    }
+}

--- a/lang-jdt/src/test/kotlin/dev/ide/lang/jdt/JdtRenameTest.kt
+++ b/lang-jdt/src/test/kotlin/dev/ide/lang/jdt/JdtRenameTest.kt
@@ -1,0 +1,79 @@
+package dev.ide.lang.jdt
+
+import dev.ide.lang.jdt.rename.JdtRename
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class JdtRenameTest {
+
+    private fun parse(analyzer: JdtSourceAnalyzer, file: Path): Pair<dev.ide.lang.jdt.dom.JdtParsedFile, String> {
+        val text = Files.readString(file)
+        return analyzer.parse(StubFile(file.toString(), text), text) to text
+    }
+
+    @Test
+    fun findsFieldDeclarationAndAllUses() {
+        val (analyzer, dir) = workspaceWith(
+            "Foo.java" to "class Foo {\n  int count = 0;\n  int next() { count = count + 1; return count; }\n}",
+        )
+        val (parsed, text) = parse(analyzer, dir.resolve("Foo.java"))
+        val target = JdtRename.targetAt(parsed, text.indexOf("count"))
+        assertNotNull(target)
+        assertEquals("field", target.kind)
+        assertEquals("count", target.oldName)
+        assertTrue(!target.fileLocal && !target.isType)
+        val refs = JdtRename.referencesIn(parsed, target)
+        assertEquals(4, refs.size) // declaration + 3 uses
+        refs.forEach { assertEquals("count", text.substring(it.start, it.end)) }
+    }
+
+    @Test
+    fun findsClassUsesAcrossFilesIncludingConstructor() {
+        val (analyzer, dir) = workspaceWith(
+            "Foo.java" to "public class Foo {\n  Foo() {}\n  void hi() {}\n}",
+            "Bar.java" to "class Bar {\n  void use() { Foo f = new Foo(); f.hi(); }\n}",
+        )
+        val (parsedFoo, fooText) = parse(analyzer, dir.resolve("Foo.java"))
+        val target = JdtRename.targetAt(parsedFoo, fooText.indexOf("Foo"))
+        assertNotNull(target)
+        assertTrue(target.isType)
+        assertEquals("class", target.kind)
+        // the class-declaration name + the constructor-declaration name (both spelled "Foo")
+        assertEquals(2, JdtRename.referencesIn(parsedFoo, target).size)
+
+        val (parsedBar, barText) = parse(analyzer, dir.resolve("Bar.java"))
+        val barRefs = JdtRename.referencesIn(parsedBar, target)
+        assertEquals(2, barRefs.size) // the `Foo` type + the `new Foo()` type
+        barRefs.forEach { assertEquals("Foo", barText.substring(it.start, it.end)) }
+    }
+
+    @Test
+    fun localVariableRenameIsFileLocalAndDoesNotTouchAShadowedField() {
+        val (analyzer, dir) = workspaceWith(
+            "A.java" to "class A {\n  int x;\n  void m() { int x = 1; int y = x + x; }\n}",
+        )
+        val (parsed, text) = parse(analyzer, dir.resolve("A.java"))
+        // caret on the local `x` declaration (inside m), not the field
+        val target = JdtRename.targetAt(parsed, text.indexOf("int x = 1") + 4)
+        assertNotNull(target)
+        assertTrue(target.fileLocal)
+        assertEquals("local variable", target.kind)
+        assertEquals(3, JdtRename.referencesIn(parsed, target).size) // local decl + 2 uses; field untouched
+    }
+
+    @Test
+    fun findsMethodDeclarationAndInvocations() {
+        val (analyzer, dir) = workspaceWith(
+            "S.java" to "class S {\n  int sum(int a) { return a; }\n  int run() { return sum(1) + sum(2); }\n}",
+        )
+        val (parsed, text) = parse(analyzer, dir.resolve("S.java"))
+        val target = JdtRename.targetAt(parsed, text.indexOf("sum"))
+        assertNotNull(target)
+        assertEquals("method", target.kind)
+        assertEquals(3, JdtRename.referencesIn(parsed, target).size) // declaration + 2 invocations
+    }
+}

--- a/lang-jdt/src/test/kotlin/dev/ide/lang/jdt/synthetic/SyntheticStyleableEmitTest.kt
+++ b/lang-jdt/src/test/kotlin/dev/ide/lang/jdt/synthetic/SyntheticStyleableEmitTest.kt
@@ -1,0 +1,37 @@
+package dev.ide.lang.jdt.synthetic
+
+import dev.ide.lang.synthetic.SyntheticClass
+import dev.ide.lang.synthetic.SyntheticField
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Guards the `R.styleable` emit shape the layout-preview's custom-view path depends on: an `int[]` array
+ * field with a brace initializer, plus the `int` per-attr index constants. User code's
+ * `obtainStyledAttributes(attrs, R.styleable.MyChart, …)` only compiles if this is valid Java.
+ */
+class SyntheticStyleableEmitTest {
+
+    @Test fun `styleable int array and index constants emit valid java`() {
+        val cls = SyntheticClass(
+            fqName = "com.example.app.R.styleable",
+            fields = listOf(
+                SyntheticField("MyChart", type = "int[]", constant = "{ 0x7f020000, 0x7f020001 }"),
+                SyntheticField("MyChart_barColor", constant = "0"),
+                SyntheticField("MyChart_maxValue", constant = "1"),
+            ),
+        )
+        val java = SyntheticJavaSource.emit(cls)
+        assertTrue("public static final int[] MyChart = { 0x7f020000, 0x7f020001 };" in java, java)
+        assertTrue("public static final int MyChart_barColor = 0;" in java, java)
+        assertTrue("public static final int MyChart_maxValue = 1;" in java, java)
+    }
+
+    @Test fun `regular R fields carry their stable hex id constant`() {
+        val cls = SyntheticClass(
+            fqName = "com.example.app.R.color",
+            fields = listOf(SyntheticField("primary", constant = "0x7f010000")),
+        )
+        assertTrue("public static final int primary = 0x7f010000;" in SyntheticJavaSource.emit(cls))
+    }
+}

--- a/lang-xml/src/main/kotlin/dev/ide/lang/xml/completion/XmlCompletionService.kt
+++ b/lang-xml/src/main/kotlin/dev/ide/lang/xml/completion/XmlCompletionService.kt
@@ -44,9 +44,10 @@ class XmlCompletionService(
     companion object {
         /**
          * Namespace-aware prefix match: the candidate matches if it starts with [prefix], OR its **local
-         * name** does — the part after a namespace `:` (so `layout_w` matches `android:layout_width`) or a
-         * resource `/` (so `home` matches `@string/home`). This is what lets the user complete an attribute
-         * without typing the `android:` prefix every time. Case-insensitive.
+         * name** does — the part after a namespace `:` (so `layout_w` matches `android:layout_width`), a
+         * resource `/` (so `home` matches `@string/home`), or a package `.` (so `MaterialButton` matches
+         * the fully-qualified custom view `com.google.android.material.button.MaterialButton`). This is what
+         * lets the user complete an attribute or a custom view by its short name. Case-insensitive.
          */
         fun nameMatches(candidate: String, prefix: String): Boolean {
             if (prefix.isEmpty()) return true
@@ -54,7 +55,9 @@ class XmlCompletionService(
             val afterColon = candidate.substringAfter(':', "")
             if (afterColon.isNotEmpty() && afterColon.startsWith(prefix, ignoreCase = true)) return true
             val afterSlash = candidate.substringAfterLast('/', "")
-            return afterSlash.isNotEmpty() && afterSlash.startsWith(prefix, ignoreCase = true)
+            if (afterSlash.isNotEmpty() && afterSlash.startsWith(prefix, ignoreCase = true)) return true
+            val afterDot = candidate.substringAfterLast('.', "")
+            return afterDot.isNotEmpty() && afterDot.startsWith(prefix, ignoreCase = true)
         }
     }
 }

--- a/layout-preview-api/build.gradle.kts
+++ b/layout-preview-api/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    `java-library`
+}
+
+// layout-preview-api — the owned XML-layout-preview contracts. Deliberately android-free and
+// dependency-free (stdlib only): the render tree (RenderNode/Renderer/RendererRegistry), the graphics
+// abstraction (RCanvas/RPaint/RPath/RImage), pure MeasureSpec math, the resolved-value model, and the
+// neutral resource/attribute seams. Renderers are written once against RCanvas; each platform supplies a
+// backend (Compose DrawScope, android.graphics, Skiko). The owned view base (ViewHost) is the contract the
+// device Bridge and the desktop shim both implement, so the custom-view renderer drives them identically.

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/Geometry.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/Geometry.kt
@@ -1,0 +1,25 @@
+package dev.ide.preview
+
+/** A measured size in pixels. */
+data class Size(val width: Int, val height: Int)
+
+/**
+ * Bit-compatible reimplementation of `android.view.View.MeasureSpec` — the size+mode packing the layout
+ * pass speaks. Pure integer math, no native dependency, so the engine runs identically on desktop and ART
+ * (and in a headless test). Mirrors the framework constants exactly so a custom view that does its own
+ * `MeasureSpec.getMode(...)` math sees the values it expects.
+ */
+object MeasureSpec {
+    const val UNSPECIFIED = 0
+    const val EXACTLY = 1 shl 30
+    const val AT_MOST = 2 shl 30
+    private const val MODE_MASK = 0x3 shl 30
+
+    fun makeMeasureSpec(size: Int, mode: Int): Int = (size and MODE_MASK.inv()) or (mode and MODE_MASK)
+    fun getMode(spec: Int): Int = spec and MODE_MASK
+    fun getSize(spec: Int): Int = spec and MODE_MASK.inv()
+
+    fun exactly(size: Int): Int = makeMeasureSpec(size, EXACTLY)
+    fun atMost(size: Int): Int = makeMeasureSpec(size, AT_MOST)
+    fun unspecified(): Int = makeMeasureSpec(0, UNSPECIFIED)
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/Graphics.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/Graphics.kt
@@ -1,0 +1,97 @@
+package dev.ide.preview
+
+/** Paint fill mode, mirroring `android.graphics.Paint.Style`. */
+enum class PaintStyle { FILL, STROKE, FILL_AND_STROKE }
+
+/** A gradient fill for a paint. Colors are `0xAARRGGBB`; geometry is relative to the drawn rect. */
+enum class GradientType { LINEAR, RADIAL, SWEEP }
+
+data class Gradient(
+    val type: GradientType,
+    val colors: IntArray,
+    val angleDeg: Int = 0,
+    val centerX: Float = 0.5f,
+    val centerY: Float = 0.5f,
+    val radiusFraction: Float = 0.5f,
+) {
+    override fun equals(other: Any?): Boolean = other is Gradient && type == other.type && colors.contentEquals(other.colors) &&
+        angleDeg == other.angleDeg && centerX == other.centerX && centerY == other.centerY && radiusFraction == other.radiusFraction
+    override fun hashCode(): Int = type.hashCode() * 31 + colors.contentHashCode()
+}
+
+/**
+ * A mutable paint. Colors are `0xAARRGGBB` ints (the same packing as `android.graphics.Color`). Created by
+ * [RGraphics.newPaint]; the platform backend owns the concrete instance (a Compose/Skia `Paint`, or an
+ * `android.graphics.Paint`).
+ */
+interface RPaint {
+    var color: Int
+    var style: PaintStyle
+    var strokeWidth: Float
+    var antiAlias: Boolean
+    /** Text size in pixels (already scaled from sp). */
+    var textSizePx: Float
+    var bold: Boolean
+    /** When set, fill shapes with this gradient instead of the flat [color]. */
+    var gradient: Gradient?
+}
+
+/** An opaque platform path (parsed from `pathData`, or built by the backend). */
+interface RPath
+
+/**
+ * Implemented by a platform [RCanvas] that wraps a native canvas, so a custom view's `onDraw` can draw into
+ * the same surface: the device Bridge unwraps this to an `android.graphics.Canvas`, the desktop shim to a
+ * Skiko canvas. Returns null when there's no native canvas (e.g. a headless recording canvas).
+ */
+interface NativeCanvasHolder {
+    fun nativeCanvas(): Any?
+}
+
+/** An opaque platform image with its intrinsic pixel size. */
+interface RImage {
+    val width: Int
+    val height: Int
+}
+
+/** Vertical text metrics for a paint, in pixels. [ascent] is the baseline offset from the line top. */
+data class FontMetrics(val lineHeight: Float, val ascent: Float)
+
+/**
+ * The owned drawing surface. Renderers paint into this and nothing else — there is no `android.graphics`
+ * import in a renderer. A platform backend implements it over Compose `DrawScope`, `android.graphics.Canvas`,
+ * or Skiko, and the same backend instance is what a custom view's `onDraw` ultimately composites into (the
+ * device backend hands the underlying `android.graphics.Canvas` to user code). Coordinates are pixels.
+ */
+interface RCanvas {
+    fun save(): Int
+    fun restore()
+    fun translate(dx: Float, dy: Float)
+    fun clipRect(l: Float, t: Float, r: Float, b: Float)
+
+    fun drawRect(l: Float, t: Float, r: Float, b: Float, paint: RPaint)
+    fun drawRoundRect(l: Float, t: Float, r: Float, b: Float, rx: Float, ry: Float, paint: RPaint)
+    fun drawCircle(cx: Float, cy: Float, radius: Float, paint: RPaint)
+    fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: RPaint)
+    fun drawPath(path: RPath, paint: RPaint)
+    /** Draw [img] into the rect, optionally tinted with [tintArgb] (`android:tint`). */
+    fun drawImage(img: RImage, l: Float, t: Float, r: Float, b: Float, tintArgb: Int? = null)
+    /** Draw [text] with its top-left at ([x],[y]) (not the baseline), matching Compose's `drawText`. */
+    fun drawText(text: CharSequence, x: Float, y: Float, paint: RPaint)
+}
+
+/**
+ * The factory the platform backend supplies for the pieces a renderer must *create* or *measure* (rather than
+ * draw): a paint, a parsed path from Android `pathData`, and text metrics. Text metrics live here (not on
+ * [RCanvas]) because the measure pass needs them and runs before any canvas exists. Image loading is
+ * resource-driven and lives on [PreviewResources] instead.
+ */
+interface RGraphics {
+    fun newPaint(): RPaint
+    /** Parse Android vector `pathData` into a path; null if unparseable. */
+    fun parsePath(pathData: String): RPath?
+    /** Advance width in pixels of [text] in [paint]. */
+    fun measureText(text: CharSequence, paint: RPaint): Float
+    /** Line height + ascent in pixels for [paint]. */
+    fun fontMetrics(paint: RPaint): FontMetrics
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/PlaceholderRenderer.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/PlaceholderRenderer.kt
@@ -1,0 +1,48 @@
+package dev.ide.preview
+
+/**
+ * The never-fail fallback: a translucent box outlined and labelled with the widget tag. Any unknown tag or a
+ * renderer that threw degrades to this for that one node, so a single bad widget can't blank the whole
+ * preview (§12, "always fall back, never crash the tree"). It honours an explicit layout size and otherwise
+ * takes a small default footprint.
+ */
+object PlaceholderRenderer : Renderer {
+    private const val DEFAULT_DP = 64
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val def = (DEFAULT_DP * ctx.density).toInt()
+        val w = resolveDim(node.props.layoutWidth, widthSpec, def)
+        val h = resolveDim(node.props.layoutHeight, heightSpec, def)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        val l = node.left.toFloat(); val t = node.top.toFloat()
+        val rr = node.right.toFloat(); val bb = node.bottom.toFloat()
+        val fill = ctx.gfx.newPaint().apply { color = 0x22808080; style = PaintStyle.FILL }
+        canvas.drawRect(l, t, rr, bb, fill)
+        val stroke = ctx.gfx.newPaint().apply { color = 0x66808080; style = PaintStyle.STROKE; strokeWidth = ctx.density }
+        canvas.drawRect(l, t, rr, bb, stroke)
+
+        val label = node.tag.substringAfterLast('.').ifEmpty { "view" }
+        val textPaint = ctx.gfx.newPaint().apply {
+            color = 0xFF606060.toInt(); style = PaintStyle.FILL; textSizePx = 11f * ctx.scaledDensity; antiAlias = true
+        }
+        val tw = ctx.gfx.measureText(label, textPaint)
+        val fm = ctx.gfx.fontMetrics(textPaint)
+        val tx = l + ((rr - l) - tw) / 2f
+        val ty = t + ((bb - t) - fm.lineHeight) / 2f
+        if (rr - l > tw) canvas.drawText(label, tx, ty, textPaint)
+    }
+
+    /** A WRAP/MATCH/explicit layout dim resolved against the parent spec, with a fallback default. */
+    private fun resolveDim(layoutDim: Int, spec: Int, default: Int): Int = when (layoutDim) {
+        Props.MATCH_PARENT -> if (MeasureSpec.getMode(spec) == MeasureSpec.UNSPECIFIED) default else MeasureSpec.getSize(spec)
+        Props.WRAP_CONTENT -> default
+        else -> layoutDim
+    }
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/PreviewEngine.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/PreviewEngine.kt
@@ -1,0 +1,82 @@
+package dev.ide.preview
+
+/** A plain [RenderContext]: the graphics factory, the resource resolver, and the previewed density. */
+class SimpleRenderContext(
+    override val gfx: RGraphics,
+    override val res: PreviewResources,
+    override val density: Float = 1f,
+    override val scaledDensity: Float = density,
+) : RenderContext
+
+/**
+ * The owned measure → layout → draw driver. Snapshot and live mode share the same passes over the same tree
+ * (§8.4) — only the [RCanvas] differs (a bitmap-backed canvas vs. a live surface). The engine, not any
+ * framework view tree, recurses; each container renderer drives its own children. Lives in the api (it uses
+ * only api types) so the Compose UI layer can drive a [RenderNode] tree handed to it by the backend.
+ */
+class PreviewEngine(val ctx: RenderContext) {
+
+    /** Measure (width exact, height bounded) then position the tree at the origin. */
+    fun measureAndLayout(root: RenderNode, widthPx: Int, heightPx: Int) {
+        root.renderer.measure(root, MeasureSpec.exactly(widthPx), MeasureSpec.atMost(heightPx), ctx)
+        root.renderer.layout(root, 0, 0, root.measured.width, root.measured.height, ctx)
+    }
+
+    fun draw(root: RenderNode, canvas: RCanvas) {
+        root.renderer.draw(root, canvas, ctx)
+    }
+
+    /** Full pass into [canvas]; returns the measured root size (e.g. to size the snapshot bitmap). */
+    fun render(root: RenderNode, widthPx: Int, heightPx: Int, canvas: RCanvas): Size {
+        measureAndLayout(root, widthPx, heightPx)
+        draw(root, canvas)
+        return root.measured
+    }
+
+    /** Deepest node whose laid-out bounds contain ([x],[y]) — for selection/hit-testing in the editor. */
+    fun hitTest(root: RenderNode, x: Float, y: Float): RenderNode? {
+        if (x < root.left || x >= root.right || y < root.top || y >= root.bottom) return null
+        for (i in root.children.indices.reversed()) {
+            hitTest(root.children[i], x, y)?.let { return it }
+        }
+        return root
+    }
+}
+
+/**
+ * What the backend hands the UI layer to render: the inflated [root] tree (resources resolved, custom views
+ * instantiated), the [resources] (for image loading at draw time), and the previewed device density. The UI
+ * builds a [RenderContext] with its own platform [RGraphics] (real text metrics) and drives [PreviewEngine]
+ * over this tree into a Compose-backed [RCanvas].
+ */
+class LayoutPreviewResult(
+    val root: RenderNode,
+    val resources: PreviewResources,
+    val density: Float,
+    val scaledDensity: Float,
+    /** Resolve a `@drawable/@mipmap` reference to its backing file path; the UI decodes it to an [RImage]. */
+    val imageFile: (ref: String) -> String? = { null },
+    /** Nodes that couldn't be rendered as intended (unknown tag, unresolved include, custom view) — surfaced in the pane. */
+    val problems: List<PreviewProblem> = emptyList(),
+)
+
+/** A node the preview couldn't render as intended; [tag] is the widget/structural tag, [message] the reason. */
+data class PreviewProblem(val tag: String, val message: String)
+
+/** The previewed device configuration the UI requests: viewport pixels, density, and config toggles. */
+data class PreviewRequest(
+    val widthPx: Int,
+    val heightPx: Int,
+    val density: Float,
+    val showChrome: Boolean = true,
+    val night: Boolean = false,
+)
+
+/**
+ * The backend capability the preview pane needs, kept in the api so both the engine host (ide-core) and the
+ * Compose UI layer can name [LayoutPreviewResult] without ide-ui taking an android-laden dependency. The UI
+ * casts its `IdeBackend` to this; a host without Android support simply doesn't implement it.
+ */
+interface LayoutPreviewBackend {
+    suspend fun layoutPreview(path: String, text: String, request: PreviewRequest): LayoutPreviewResult?
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/Props.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/Props.kt
@@ -1,0 +1,73 @@
+package dev.ide.preview
+
+/**
+ * The resolved standard attributes a built-in renderer reads. Layout dimensions use the framework sentinels
+ * ([MATCH_PARENT]/[WRAP_CONTENT]) or a positive pixel size. Custom views don't use this — they read their
+ * own attributes in their constructor — but the engine still fills the layout/padding/background fields on a
+ * custom view's node so the owned base honours `layout_*`, padding, and background (§7 of the design).
+ */
+class Props {
+    var id: String? = null
+
+    var layoutWidth: Int = WRAP_CONTENT
+    var layoutHeight: Int = WRAP_CONTENT
+    var weight: Float = 0f
+    var orientation: Int = HORIZONTAL
+    /** This view's `android:layout_gravity` — how it aligns *within its parent*. */
+    var gravity: Int = GRAVITY_NONE
+    /** This view's own `android:gravity` — how it aligns *its content/children*. */
+    var contentGravity: Int = GRAVITY_NONE
+
+    var paddingLeft: Int = 0
+    var paddingTop: Int = 0
+    var paddingRight: Int = 0
+    var paddingBottom: Int = 0
+
+    var marginLeft: Int = 0
+    var marginTop: Int = 0
+    var marginRight: Int = 0
+    var marginBottom: Int = 0
+
+    var backgroundColor: Int? = null
+    var visibility: Int = VISIBLE
+
+    // Text widgets
+    var text: CharSequence = ""
+    var textSizePx: Float = 0f
+    var textColor: Int = 0xFF000000.toInt()
+    var bold: Boolean = false
+    /** 0 = unlimited. `singleLine` maps to 1. */
+    var maxLines: Int = 0
+    /** Append an ellipsis to the last visible line when text is truncated by [maxLines]. */
+    var ellipsize: Boolean = false
+
+    // Image widgets — a @drawable/@mipmap reference, resolved lazily by the renderer.
+    var imageRef: String? = null
+
+    /** Anything a renderer needs to stash between passes (e.g. a computed text layout). */
+    val extras: MutableMap<String, Any?> = HashMap()
+
+    val hPadding: Int get() = paddingLeft + paddingRight
+    val vPadding: Int get() = paddingTop + paddingBottom
+
+    companion object {
+        const val MATCH_PARENT = -1
+        const val WRAP_CONTENT = -2
+
+        const val HORIZONTAL = 0
+        const val VERTICAL = 1
+
+        const val GRAVITY_NONE = 0
+        const val GRAVITY_START = 1
+        const val GRAVITY_END = 2
+        const val GRAVITY_CENTER_HORIZONTAL = 4
+        const val GRAVITY_TOP = 8
+        const val GRAVITY_BOTTOM = 16
+        const val GRAVITY_CENTER_VERTICAL = 32
+        const val GRAVITY_CENTER = GRAVITY_CENTER_HORIZONTAL or GRAVITY_CENTER_VERTICAL
+
+        const val VISIBLE = 0
+        const val INVISIBLE = 1
+        const val GONE = 2
+    }
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/RenderNode.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/RenderNode.kt
@@ -1,0 +1,50 @@
+package dev.ide.preview
+
+/**
+ * One node of the owned render tree — a built-in widget, a custom view, or a container. The engine (not any
+ * framework view-tree traversal) drives [measure]/[layout]/[draw] over these. For a custom view, [host] is
+ * the owned-base instance whose `onMeasure`/`onLayout`/`onDraw` run the user's code; for a built-in it is null
+ * and [renderer] does all the work.
+ */
+class RenderNode(val host: ViewHost? = null) {
+    /** The XML tag or fully-qualified class name this node came from (placeholder labels, debugging). */
+    var tag: String = ""
+
+    val props: Props = Props()
+    val children: MutableList<RenderNode> = ArrayList()
+    var renderer: Renderer = Renderer.FALLBACK
+
+    var measured: Size = Size(0, 0)
+    var left: Int = 0
+    var top: Int = 0
+    var right: Int = 0
+    var bottom: Int = 0
+
+    val width: Int get() = right - left
+    val height: Int get() = bottom - top
+
+    fun setBounds(l: Int, t: Int, r: Int, b: Int) {
+        left = l; top = t; right = r; bottom = b
+    }
+
+    /** Set by the host (live mode); a built-in [invalidate] / a custom view's `invalidate()` routes here. */
+    var onDirty: (() -> Unit)? = null
+
+    fun markDirty() {
+        onDirty?.invoke()
+    }
+}
+
+/**
+ * The owned view base, abstracted. Both the on-device `BridgeView` (which `extends android.view.View`) and
+ * the desktop `android.view.View` shim implement this, so [CustomViewRenderer] drives a custom view the same
+ * way on either platform. `drawContent` runs the user view's `onDraw` against the owned [RCanvas] (the device
+ * impl unwraps the backing `android.graphics.Canvas` to hand to user code).
+ */
+interface ViewHost {
+    fun measure(widthSpec: Int, heightSpec: Int)
+    val measuredWidth: Int
+    val measuredHeight: Int
+    fun layout(l: Int, t: Int, r: Int, b: Int)
+    fun drawContent(canvas: RCanvas)
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/Renderer.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/Renderer.kt
@@ -1,0 +1,72 @@
+package dev.ide.preview
+
+/**
+ * The ambient services a renderer pass needs: the graphics factory, the resource resolver, and the previewed
+ * device density (px-per-dp / px-per-sp). Threaded through every [Renderer] call so renderers stay stateless.
+ */
+interface RenderContext {
+    val gfx: RGraphics
+    val res: PreviewResources
+    /** Pixels per dp for the previewed configuration. */
+    val density: Float
+    /** Pixels per sp (scaled density). */
+    val scaledDensity: Float
+}
+
+/**
+ * A neutral, namespace-aware view of one element's attributes — what the inflater hands a built-in renderer
+ * instead of an `android.util.AttributeSet`. The custom-view path uses a real `AttributeSet` (the bridge);
+ * this keeps the built-in path android-free.
+ */
+interface AttrReader {
+    val count: Int
+    fun name(i: Int): String
+    fun namespace(i: Int): String?
+    fun value(i: Int): String
+
+    /** The `android:`-namespaced attribute [localName], or null. */
+    fun android(localName: String): String?
+    /** The `app:` (res-auto) attribute [localName], or null. */
+    fun app(localName: String): String?
+    /** Any-namespace lookup by local name (android: preferred). */
+    fun local(localName: String): String?
+}
+
+/**
+ * Owned measure/layout/draw for one widget type. Built-ins map XML attributes into [RenderNode.props] in
+ * [applyAttrs] and do their own layout; [CustomViewRenderer] delegates the three passes to the node's
+ * [ViewHost]. A renderer must never touch a framework view tree — the engine drives traversal (§8).
+ */
+interface Renderer {
+    /** Map neutral attributes into `node.props`. Built-ins override; the custom-view renderer leaves it empty. */
+    fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {}
+
+    fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size
+    fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext)
+    fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext)
+
+    companion object {
+        /** The stable fallback for unknown widgets / failed renderers — a labelled placeholder box (§12). */
+        val FALLBACK: Renderer get() = PlaceholderRenderer
+    }
+}
+
+/** Registry of built-in renderers keyed by simple tag name (e.g. `TextView`, `LinearLayout`). */
+class RendererRegistry {
+    private val byTag = HashMap<String, Renderer>()
+
+    fun register(tag: String, renderer: Renderer): RendererRegistry {
+        byTag[tag] = renderer
+        return this
+    }
+
+    fun register(tags: List<String>, renderer: Renderer): RendererRegistry {
+        for (t in tags) byTag[t] = renderer
+        return this
+    }
+
+    /** A built-in renderer for an XML tag (the simple name of a fully-qualified tag), or null if none. */
+    fun forTag(tag: String): Renderer? = byTag[tag.substringAfterLast('.')]
+
+    fun has(tag: String): Boolean = forTag(tag) != null
+}

--- a/layout-preview-api/src/main/kotlin/dev/ide/preview/ResolvedValue.kt
+++ b/layout-preview-api/src/main/kotlin/dev/ide/preview/ResolvedValue.kt
@@ -1,0 +1,36 @@
+package dev.ide.preview
+
+/**
+ * A resource/attribute value after resolution — the typed payload a renderer reads instead of a raw string.
+ * Colors are `0xAARRGGBB` ints; dimensions are already converted to pixels for the previewed device config.
+ */
+sealed interface ResolvedValue {
+    data class Color(val argb: Int) : ResolvedValue
+    data class Dimension(val px: Float) : ResolvedValue
+    data class Str(val text: CharSequence) : ResolvedValue
+    data class IntV(val v: Int) : ResolvedValue
+    data class FloatV(val v: Float) : ResolvedValue
+    data class BoolV(val v: Boolean) : ResolvedValue
+    /** A reference that resolves to another resource rather than a scalar (e.g. `@drawable/x`, `@id/y`). */
+    data class Ref(val resType: String, val name: String) : ResolvedValue
+}
+
+/**
+ * The expected shape of an attribute value, so the resolver can parse a raw string correctly. The
+ * preview-local mirror of an attribute's `format` (`color|dimension|reference|...`); the impl maps
+ * android-support's `AttrFormat` onto this so this module stays android-free.
+ */
+enum class ValueFormat { ANY, COLOR, DIMENSION, STRING, INTEGER, BOOLEAN, FLOAT, REFERENCE, FLAG, ENUM }
+
+/**
+ * The neutral resource seam the renderers (and the bridge's styled-attribute path) read through. The impl is
+ * backed by the project's merged resources + the SDK attr metadata; this contract carries no android types so
+ * the api stays portable.
+ */
+interface PreviewResources {
+    /** Resolve a raw attribute string ("@color/x", "#fff", "16dp", "true") under a [format] hint; null if unresolved. */
+    fun resolve(raw: String, format: ValueFormat): ResolvedValue?
+
+    /** Load the image a `@drawable/@mipmap` reference (or a file path) points at; null if unavailable. */
+    fun image(ref: String): RImage?
+}

--- a/layout-preview-impl/build.gradle.kts
+++ b/layout-preview-impl/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    `java-library`
+}
+
+// layout-preview-impl — the owned layout-preview engine behind layout-preview-api. Pure kotlin/jvm (never
+// links android.jar): the resource value resolver (over android-support's merged ResourceRepository + SDK
+// attr metadata), the tolerant XML → RenderNode inflater (over lang-xml), the built-in renderers, the
+// PreviewEngine, and the ASM BridgeRemapper that reparents a user view onto the owned base. The platform
+// Bridge bases (device android.view.View subclasses; the desktop Robolectric/Skiko shim) live in the IDE
+// shells, which is where android.jar / the shim are on the classpath.
+dependencies {
+    api(project(":layout-preview-api"))
+    implementation(project(":android-support"))     // ResourceRepository, AndroidSdkMetadata, AndroidColor
+    implementation(project(":lang-xml"))             // tolerant XmlTreeParser → neutral XML DOM
+    implementation(project(":project-model-api"))    // Module / Workspace for resource discovery
+    implementation(libs.ow2.asm)                     // BridgeRemapper: reparent + remap user bytecode
+    implementation(libs.ow2.asm.tree)
+    implementation(libs.ow2.asm.commons)             // ClassRemapper / Remapper
+
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/BuiltinRenderers.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/BuiltinRenderers.kt
@@ -1,0 +1,380 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.AttrReader
+import dev.ide.preview.MeasureSpec
+import dev.ide.preview.PaintStyle
+import dev.ide.preview.Props
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.Renderer
+import dev.ide.preview.RendererRegistry
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.Size
+import dev.ide.preview.ValueFormat
+import kotlin.math.max
+import kotlin.math.min
+
+/** Paints the node's resolved background (a colour, or a `@drawable` shape/layer-list) over its bounds. */
+internal fun drawBackground(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+    val l = node.left.toFloat(); val t = node.top.toFloat(); val r = node.right.toFloat(); val b = node.bottom.toFloat()
+    node.props.backgroundColor?.let { bg ->
+        canvas.drawRect(l, t, r, b, ctx.gfx.newPaint().apply { color = bg; style = PaintStyle.FILL })
+        return
+    }
+    (node.props.extras["bgDrawable"] as? dev.ide.android.support.preview.DrawablePreview)?.let {
+        DrawableBackgroundRenderer.draw(it, l, t, r, b, canvas, ctx)
+    }
+}
+
+/**
+ * Resolve a `layout_*` dimension against the parent spec into a concrete content size. An `EXACTLY` spec
+ * always wins (the parent dictates — e.g. a `match_parent` cross axis, or a weighted `0dp` main axis the
+ * LinearLayout forces during weight distribution), regardless of the requested layout dimension.
+ */
+internal fun resolveSize(layoutDim: Int, spec: Int, contentSize: Int): Int {
+    val mode = MeasureSpec.getMode(spec)
+    val size = MeasureSpec.getSize(spec)
+    return when (layoutDim) {
+        Props.MATCH_PARENT -> if (mode == MeasureSpec.UNSPECIFIED) contentSize else size
+        Props.WRAP_CONTENT -> when (mode) {
+            MeasureSpec.EXACTLY -> size
+            MeasureSpec.AT_MOST -> min(contentSize, size)
+            else -> contentSize
+        }
+        else -> if (mode == MeasureSpec.EXACTLY) size else layoutDim
+    }
+}
+
+/** A child MeasureSpec from the parent spec, the parent's padding on that axis, and the child's layout dim. */
+internal fun containerChildSpec(parentSpec: Int, padding: Int, layoutDim: Int): Int {
+    val avail = max(0, MeasureSpec.getSize(parentSpec) - padding)
+    return when (layoutDim) {
+        Props.MATCH_PARENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.EXACTLY)
+        Props.WRAP_CONTENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.AT_MOST)
+        else -> MeasureSpec.makeMeasureSpec(min(layoutDim, avail), MeasureSpec.EXACTLY)
+    }
+}
+
+/** A paint configured from a node's text props. */
+private fun RenderNode.textPaint(ctx: RenderContext): dev.ide.preview.RPaint = ctx.gfx.newPaint().apply {
+    color = props.textColor
+    style = PaintStyle.FILL
+    antiAlias = true
+    bold = props.bold
+    textSizePx = if (props.textSizePx > 0f) props.textSizePx else 14f * ctx.scaledDensity
+}
+
+/** `TextView` / `Button` / `EditText`: greedy word-wrapped text via the backend's text metrics. */
+object TextRenderer : Renderer {
+    override fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        val p = node.props
+        // textAppearance first (lowest precedence); explicit/style attrs below override it.
+        attrs.android("textAppearance")?.let { ta ->
+            (ctx.res as? ProjectPreviewResources)?.styleItems(ta.substringAfterLast('/'))?.let { items ->
+                items["android:textSize"]?.let { p.textSizePx = (ctx.res.resolve(it, ValueFormat.DIMENSION) as? ResolvedValue.Dimension)?.px ?: p.textSizePx }
+                items["android:textColor"]?.let { c -> CommonAttrs.colorOf(c, ctx)?.let { p.textColor = it } }
+                items["android:textStyle"]?.let { p.bold = it.contains("bold") }
+            }
+        }
+        attrs.android("text")?.let { p.text = (ctx.res.resolve(it, ValueFormat.STRING) as? ResolvedValue.Str)?.text ?: it }
+        attrs.android("textSize")?.let { p.textSizePx = (ctx.res.resolve(it, ValueFormat.DIMENSION) as? ResolvedValue.Dimension)?.px ?: p.textSizePx }
+        attrs.android("textColor")?.let { c -> CommonAttrs.colorOf(c, ctx)?.let { p.textColor = it } }
+        attrs.android("textStyle")?.let { p.bold = it.contains("bold") }
+        attrs.android("hint")?.let { h -> if (p.text.isEmpty()) p.text = (ctx.res.resolve(h, ValueFormat.STRING) as? ResolvedValue.Str)?.text ?: h }
+        if (attrs.android("singleLine") == "true") p.maxLines = 1
+        attrs.android("maxLines")?.toIntOrNull()?.let { p.maxLines = it }
+        attrs.android("ellipsize")?.let { p.ellipsize = it.isNotEmpty() && it != "none" }
+    }
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val paint = node.textPaint(ctx)
+        val avail = when (MeasureSpec.getMode(widthSpec)) {
+            MeasureSpec.UNSPECIFIED -> Float.MAX_VALUE
+            else -> (MeasureSpec.getSize(widthSpec) - node.props.hPadding).toFloat()
+        }
+        val lines = wrap(node, paint, avail, ctx)
+        node.props.extras["lines"] = lines
+        val fm = ctx.gfx.fontMetrics(paint)
+        val widest = lines.maxOfOrNull { ctx.gfx.measureText(it, paint) } ?: 0f
+        val contentW = widest.toInt() + node.props.hPadding
+        val contentH = (lines.size * fm.lineHeight).toInt() + node.props.vPadding
+        val w = resolveSize(node.props.layoutWidth, widthSpec, contentW)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, contentH)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) = node.setBounds(l, t, r, b)
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        val paint = node.textPaint(ctx)
+        val fm = ctx.gfx.fontMetrics(paint)
+        @Suppress("UNCHECKED_CAST")
+        val lines = node.props.extras["lines"] as? List<CharSequence>
+            ?: wrap(node, paint, (node.width - node.props.hPadding).toFloat(), ctx)
+
+        // android:gravity aligns the text block within the view's content box (default top-start).
+        val g = node.props.contentGravity
+        val availW = node.width - node.props.hPadding
+        val availH = node.height - node.props.vPadding
+        val blockH = (lines.size * fm.lineHeight).toInt()
+        val baseX = node.left + node.props.paddingLeft
+        var y = node.top + node.props.paddingTop + GravityUtil.vertical(g, availH, blockH, 0, 0).toFloat()
+        for (line in lines) {
+            val lineW = ctx.gfx.measureText(line, paint).toInt()
+            val x = baseX + GravityUtil.horizontal(g, availW, lineW, 0, 0)
+            canvas.drawText(line, x.toFloat(), y, paint)
+            y += fm.lineHeight
+        }
+    }
+
+    private fun wrap(node: RenderNode, paint: dev.ide.preview.RPaint, maxWidth: Float, ctx: RenderContext): List<CharSequence> {
+        val text = node.props.text
+        val maxLines = node.props.maxLines
+        if (text.isEmpty()) return listOf("")
+        val lines: List<CharSequence> = if (maxWidth <= 0f || maxWidth == Float.MAX_VALUE) {
+            text.toString().split('\n')
+        } else {
+            val out = ArrayList<CharSequence>()
+            for (paragraph in text.toString().split('\n')) {
+                val words = paragraph.split(' ')
+                var line = StringBuilder()
+                for (w in words) {
+                    val candidate = if (line.isEmpty()) w else "$line $w"
+                    if (line.isEmpty() || ctx.gfx.measureText(candidate, paint) <= maxWidth) {
+                        line = StringBuilder(candidate)
+                    } else {
+                        out.add(line.toString()); line = StringBuilder(w)
+                    }
+                }
+                out.add(line.toString())
+            }
+            out
+        }
+        if (maxLines <= 0 || lines.size <= maxLines) return lines
+        val kept = lines.take(maxLines).toMutableList()
+        if (node.props.ellipsize) kept[maxLines - 1] = ellipsizeLine(kept[maxLines - 1], paint, maxWidth, ctx)
+        return kept
+    }
+
+    /** Trim [line] so `line…` fits in [maxWidth]. */
+    private fun ellipsizeLine(line: CharSequence, paint: dev.ide.preview.RPaint, maxWidth: Float, ctx: RenderContext): CharSequence {
+        if (maxWidth == Float.MAX_VALUE) return "$line…"
+        var s = line.toString()
+        while (s.isNotEmpty() && ctx.gfx.measureText("$s…", paint) > maxWidth) s = s.dropLast(1)
+        return "$s…"
+    }
+}
+
+/** `ImageView`: draws the resolved `src` drawable/bitmap into the content box honouring `scaleType`. */
+object ImageRenderer : Renderer {
+    override fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        node.props.imageRef = attrs.android("src") ?: attrs.app("srcCompat")
+        node.props.extras["scaleType"] = attrs.android("scaleType") ?: "fitCenter"
+        (attrs.android("tint") ?: attrs.app("tint"))?.let { t -> CommonAttrs.colorOf(t, ctx)?.let { node.props.extras["tint"] = it } }
+    }
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val img = node.props.imageRef?.let { ctx.res.image(it) }
+        val iw = (img?.width ?: (24 * ctx.density).toInt()) + node.props.hPadding
+        val ih = (img?.height ?: (24 * ctx.density).toInt()) + node.props.vPadding
+        val w = resolveSize(node.props.layoutWidth, widthSpec, iw)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, ih)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) = node.setBounds(l, t, r, b)
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        val img = node.props.imageRef?.let { ctx.res.image(it) } ?: return
+        val bl = (node.left + node.props.paddingLeft).toFloat()
+        val bt = (node.top + node.props.paddingTop).toFloat()
+        val bw = (node.width - node.props.hPadding).toFloat()
+        val bh = (node.height - node.props.vPadding).toFloat()
+        val scaleType = node.props.extras["scaleType"] as? String ?: "fitCenter"
+        val (dl, dt, dr, db) = fit(scaleType, img.width.toFloat(), img.height.toFloat(), bl, bt, bw, bh)
+        val tint = node.props.extras["tint"] as? Int
+        val clip = scaleType == "centerCrop"
+        if (clip) { canvas.save(); canvas.clipRect(bl, bt, bl + bw, bt + bh) }
+        canvas.drawImage(img, dl, dt, dr, db, tint)
+        if (clip) canvas.restore()
+    }
+
+    /** Destination rect (l,t,r,b) for the image in the box per [scaleType]. */
+    private fun fit(scaleType: String, iw: Float, ih: Float, bl: Float, bt: Float, bw: Float, bh: Float): List<Float> {
+        if (iw <= 0f || ih <= 0f) return listOf(bl, bt, bl + bw, bt + bh)
+        fun centered(w: Float, h: Float) = listOf(bl + (bw - w) / 2f, bt + (bh - h) / 2f, bl + (bw + w) / 2f, bt + (bh + h) / 2f)
+        return when (scaleType) {
+            "fitXY" -> listOf(bl, bt, bl + bw, bt + bh)
+            "center" -> centered(iw, ih)
+            "centerCrop" -> (max(bw / iw, bh / ih)).let { centered(iw * it, ih * it) }
+            "centerInside" -> (min(min(bw / iw, bh / ih), 1f)).let { centered(iw * it, ih * it) }
+            else -> (min(bw / iw, bh / ih)).let { centered(iw * it, ih * it) } // fitCenter
+        }
+    }
+}
+
+/** `LinearLayout`: sequential placement along the orientation, distributing `layout_weight` over slack. */
+object LinearLayoutRenderer : Renderer {
+    override fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        node.props.orientation = if (attrs.android("orientation") == "vertical") Props.VERTICAL else Props.HORIZONTAL
+    }
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val vertical = node.props.orientation == Props.VERTICAL
+        val mainPad = if (vertical) node.props.vPadding else node.props.hPadding
+        val crossPad = if (vertical) node.props.hPadding else node.props.vPadding
+        val visible = node.children.filter { it.props.visibility != Props.GONE }
+
+        var mainUsed = 0; var crossMax = 0; var totalWeight = 0f
+        for (c in visible) {
+            totalWeight += c.props.weight
+            val s = c.renderer.measure(c, childSpec(widthSpec, node.props.hPadding, c.props.layoutWidth), childSpec(heightSpec, node.props.vPadding, c.props.layoutHeight), ctx)
+            mainUsed += mainOf(s, vertical) + mainMargin(c, vertical)
+            crossMax = max(crossMax, crossOf(s, vertical) + crossMargin(c, vertical))
+        }
+
+        // Distribute slack along the main axis to weighted children (re-measure each at its new main size).
+        val mainSpec = if (vertical) heightSpec else widthSpec
+        if (totalWeight > 0f && MeasureSpec.getMode(mainSpec) != MeasureSpec.UNSPECIFIED) {
+            val slack = MeasureSpec.getSize(mainSpec) - mainPad - mainUsed
+            if (slack != 0) {
+                for (c in visible) if (c.props.weight > 0f) {
+                    val share = (slack * (c.props.weight / totalWeight)).toInt()
+                    val newMain = max(0, mainOf(c.measured, vertical) + share)
+                    val crossSpec = childSpec(if (vertical) widthSpec else heightSpec, crossPad, if (vertical) c.props.layoutWidth else c.props.layoutHeight)
+                    c.renderer.measure(c,
+                        if (vertical) crossSpec else MeasureSpec.exactly(newMain),
+                        if (vertical) MeasureSpec.exactly(newMain) else crossSpec, ctx)
+                }
+                mainUsed = MeasureSpec.getSize(mainSpec) - mainPad
+                crossMax = max(crossMax, visible.maxOfOrNull { crossOf(it.measured, vertical) + crossMargin(it, vertical) } ?: 0)
+            }
+        }
+
+        val contentMain = mainUsed + mainPad
+        val contentCross = crossMax + crossPad
+        val w = resolveSize(node.props.layoutWidth, widthSpec, if (vertical) contentCross else contentMain)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, if (vertical) contentMain else contentCross)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    private fun mainOf(s: Size, vertical: Boolean) = if (vertical) s.height else s.width
+    private fun crossOf(s: Size, vertical: Boolean) = if (vertical) s.width else s.height
+    private fun mainMargin(c: RenderNode, vertical: Boolean) = if (vertical) c.props.marginTop + c.props.marginBottom else c.props.marginLeft + c.props.marginRight
+    private fun crossMargin(c: RenderNode, vertical: Boolean) = if (vertical) c.props.marginLeft + c.props.marginRight else c.props.marginTop + c.props.marginBottom
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        val vertical = node.props.orientation == Props.VERTICAL
+        val visible = node.children.filter { it.props.visibility != Props.GONE }
+
+        // The whole run is offset along the main axis by the container's gravity (center/end) over the slack.
+        val mainAvail = if (vertical) node.height - node.props.vPadding else node.width - node.props.hPadding
+        val usedMain = visible.sumOf { mainOf(it.measured, vertical) + mainMargin(it, vertical) }
+        val mainStart = (if (vertical) t + node.props.paddingTop else l + node.props.paddingLeft) +
+            mainGravityOffset(node.props.contentGravity, vertical, mainAvail, usedMain)
+        val crossBase = if (vertical) l + node.props.paddingLeft else t + node.props.paddingTop
+        val crossAvail = if (vertical) node.width - node.props.hPadding else node.height - node.props.vPadding
+
+        var cursor = mainStart
+        for (c in visible) {
+            val g = GravityUtil.effective(c.props.gravity, node.props.contentGravity)
+            if (vertical) {
+                val cl = crossBase + GravityUtil.horizontal(g, crossAvail, c.measured.width, c.props.marginLeft, c.props.marginRight)
+                val ct = cursor + c.props.marginTop
+                c.renderer.layout(c, cl, ct, cl + c.measured.width, ct + c.measured.height, ctx)
+                cursor = ct + c.measured.height + c.props.marginBottom
+            } else {
+                val cl = cursor + c.props.marginLeft
+                val ct = crossBase + GravityUtil.vertical(g, crossAvail, c.measured.height, c.props.marginTop, c.props.marginBottom)
+                c.renderer.layout(c, cl, ct, cl + c.measured.width, ct + c.measured.height, ctx)
+                cursor = cl + c.measured.width + c.props.marginRight
+            }
+        }
+    }
+
+    /** Main-axis start shift for the whole child run, per the container's gravity over the leftover space. */
+    private fun mainGravityOffset(gravity: Int, vertical: Boolean, available: Int, used: Int): Int {
+        val slack = (available - used).coerceAtLeast(0)
+        val centered = if (vertical) gravity and Props.GRAVITY_CENTER_VERTICAL != 0 else gravity and Props.GRAVITY_CENTER_HORIZONTAL != 0
+        val end = if (vertical) gravity and Props.GRAVITY_BOTTOM != 0 else gravity and Props.GRAVITY_END != 0
+        return when {
+            centered -> slack / 2
+            end -> slack
+            else -> 0
+        }
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        for (c in node.children) if (c.props.visibility != Props.GONE) c.renderer.draw(c, canvas, ctx)
+    }
+
+    private fun childSpec(parentSpec: Int, padding: Int, layoutDim: Int): Int {
+        val avail = max(0, MeasureSpec.getSize(parentSpec) - padding)
+        return when (layoutDim) {
+            Props.MATCH_PARENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.EXACTLY)
+            Props.WRAP_CONTENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.AT_MOST)
+            else -> MeasureSpec.makeMeasureSpec(layoutDim, MeasureSpec.EXACTLY)
+        }
+    }
+}
+
+/** `FrameLayout` (and the default container): children stacked at the top-left, sized to the largest. */
+object FrameLayoutRenderer : Renderer {
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        var cw = 0; var ch = 0
+        for (c in node.children) {
+            if (c.props.visibility == Props.GONE) continue
+            val s = c.renderer.measure(c, childSpec(widthSpec, node.props.hPadding, c.props.layoutWidth), childSpec(heightSpec, node.props.vPadding, c.props.layoutHeight), ctx)
+            cw = max(cw, s.width); ch = max(ch, s.height)
+        }
+        val w = resolveSize(node.props.layoutWidth, widthSpec, cw + node.props.hPadding)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, ch + node.props.vPadding)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        val cl = l + node.props.paddingLeft; val ct = t + node.props.paddingTop
+        val availW = node.width - node.props.hPadding
+        val availH = node.height - node.props.vPadding
+        for (c in node.children) {
+            if (c.props.visibility == Props.GONE) continue
+            val g = GravityUtil.effective(c.props.gravity, node.props.contentGravity)
+            val x = cl + GravityUtil.horizontal(g, availW, c.measured.width, c.props.marginLeft, c.props.marginRight)
+            val y = ct + GravityUtil.vertical(g, availH, c.measured.height, c.props.marginTop, c.props.marginBottom)
+            c.renderer.layout(c, x, y, x + c.measured.width, y + c.measured.height, ctx)
+        }
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        for (c in node.children) if (c.props.visibility != Props.GONE) c.renderer.draw(c, canvas, ctx)
+    }
+
+    private fun childSpec(parentSpec: Int, padding: Int, layoutDim: Int): Int {
+        val avail = max(0, MeasureSpec.getSize(parentSpec) - padding)
+        return when (layoutDim) {
+            Props.MATCH_PARENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.EXACTLY)
+            Props.WRAP_CONTENT -> MeasureSpec.makeMeasureSpec(avail, MeasureSpec.AT_MOST)
+            else -> MeasureSpec.makeMeasureSpec(min(layoutDim, avail), MeasureSpec.EXACTLY)
+        }
+    }
+}
+
+/** The built-in renderer set for the MVP: text family, image, linear + frame containers. */
+object DefaultRenderers {
+    fun registry(): RendererRegistry = RendererRegistry()
+        .register(listOf("TextView", "EditText", "CheckBox", "RadioButton", "TextClock", "Switch"), TextRenderer)
+        .register(listOf("ImageView", "ImageButton"), ImageRenderer)
+        .register(listOf("LinearLayout"), LinearLayoutRenderer)
+        .register(listOf("RelativeLayout"), RelativeLayoutRenderer)
+        .register(listOf("ScrollView", "NestedScrollView"), ScrollRenderer(horizontal = false))
+        .register(listOf("HorizontalScrollView"), ScrollRenderer(horizontal = true))
+        .register(listOf("FrameLayout"), FrameLayoutRenderer)
+        .withMaterial() // Button family, Material/AppCompat aliases, Card/FAB/Chip, ConstraintLayout
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CommonAttrs.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CommonAttrs.kt
@@ -1,0 +1,113 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.AttrReader
+import dev.ide.preview.Props
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ValueFormat
+
+/**
+ * Maps the standard `View` attributes (`id`, `layout_*`, padding, margins, background, visibility) onto a
+ * node's [Props]. Applied by the inflater to *every* node — built-in or custom — so the owned base honours
+ * them even when a custom view never reads them itself (§7). Widget-specific attributes are added by the
+ * individual renderer's `applyAttrs`.
+ */
+internal object CommonAttrs {
+
+    fun apply(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        val p = node.props
+        attrs.android("id")?.let { p.id = it.substringAfterLast('/') }
+
+        p.layoutWidth = layoutDim(attrs.android("layout_width"), ctx)
+        p.layoutHeight = layoutDim(attrs.android("layout_height"), ctx)
+        attrs.android("layout_weight")?.toFloatOrNull()?.let { p.weight = it }
+        attrs.android("layout_gravity")?.let { p.gravity = parseGravity(it) }
+        attrs.android("gravity")?.let { p.contentGravity = parseGravity(it) }
+
+        // Padding: the all-edges value first, then per-edge overrides.
+        dimenPx(attrs.android("padding"), ctx)?.let { p.paddingLeft = it; p.paddingTop = it; p.paddingRight = it; p.paddingBottom = it }
+        dimenPx(attrs.android("paddingLeft"), ctx)?.let { p.paddingLeft = it }
+        dimenPx(attrs.android("paddingTop"), ctx)?.let { p.paddingTop = it }
+        dimenPx(attrs.android("paddingRight"), ctx)?.let { p.paddingRight = it }
+        dimenPx(attrs.android("paddingBottom"), ctx)?.let { p.paddingBottom = it }
+        dimenPx(attrs.android("paddingStart"), ctx)?.let { p.paddingLeft = it }
+        dimenPx(attrs.android("paddingEnd"), ctx)?.let { p.paddingRight = it }
+
+        dimenPx(attrs.android("layout_margin"), ctx)?.let { p.marginLeft = it; p.marginTop = it; p.marginRight = it; p.marginBottom = it }
+        dimenPx(attrs.android("layout_marginLeft"), ctx)?.let { p.marginLeft = it }
+        dimenPx(attrs.android("layout_marginTop"), ctx)?.let { p.marginTop = it }
+        dimenPx(attrs.android("layout_marginRight"), ctx)?.let { p.marginRight = it }
+        dimenPx(attrs.android("layout_marginBottom"), ctx)?.let { p.marginBottom = it }
+        dimenPx(attrs.android("layout_marginStart"), ctx)?.let { p.marginLeft = it }
+        dimenPx(attrs.android("layout_marginEnd"), ctx)?.let { p.marginRight = it }
+
+        attrs.android("background")?.let { bg ->
+            colorOf(bg, ctx)?.let { p.backgroundColor = it }
+                ?: (ctx.res as? ProjectPreviewResources)?.backgroundDrawable(bg)?.let { p.extras["bgDrawable"] = it }
+        }
+        attrs.android("visibility")?.let {
+            p.visibility = when (it) { "gone" -> Props.GONE; "invisible" -> Props.INVISIBLE; else -> Props.VISIBLE }
+        }
+
+        // RelativeLayout child rules — captured here (every node) for RelativeLayoutRenderer to consume.
+        var rules: HashMap<String, String>? = null
+        for (rule in RELATIVE_RULES) attrs.android(rule)?.let {
+            (rules ?: HashMap<String, String>().also { m -> rules = m })[rule] = it
+        }
+        rules?.let { p.extras["relativeRules"] = it }
+
+        // ConstraintLayout child constraints (app:-namespaced) — captured for ConstraintLayoutRenderer.
+        var cons: HashMap<String, String>? = null
+        for (c in CONSTRAINT_ATTRS) attrs.app(c)?.let {
+            (cons ?: HashMap<String, String>().also { m -> cons = m })[c] = it
+        }
+        cons?.let { p.extras["constraints"] = it }
+    }
+
+    private val CONSTRAINT_ATTRS = listOf(
+        "layout_constraintLeft_toLeftOf", "layout_constraintLeft_toRightOf",
+        "layout_constraintRight_toLeftOf", "layout_constraintRight_toRightOf",
+        "layout_constraintStart_toStartOf", "layout_constraintStart_toEndOf",
+        "layout_constraintEnd_toStartOf", "layout_constraintEnd_toEndOf",
+        "layout_constraintTop_toTopOf", "layout_constraintTop_toBottomOf",
+        "layout_constraintBottom_toTopOf", "layout_constraintBottom_toBottomOf",
+        "layout_constraintBaseline_toBaselineOf",
+        "layout_constraintHorizontal_bias", "layout_constraintVertical_bias",
+    )
+
+    private val RELATIVE_RULES = listOf(
+        "layout_toRightOf", "layout_toLeftOf", "layout_toStartOf", "layout_toEndOf",
+        "layout_above", "layout_below", "layout_alignTop", "layout_alignBottom",
+        "layout_alignLeft", "layout_alignRight", "layout_alignStart", "layout_alignEnd",
+        "layout_alignParentTop", "layout_alignParentBottom", "layout_alignParentLeft",
+        "layout_alignParentRight", "layout_alignParentStart", "layout_alignParentEnd",
+        "layout_centerInParent", "layout_centerHorizontal", "layout_centerVertical",
+    )
+
+    private fun layoutDim(raw: String?, ctx: RenderContext): Int = when (raw) {
+        null -> Props.WRAP_CONTENT
+        "match_parent", "fill_parent" -> Props.MATCH_PARENT
+        "wrap_content" -> Props.WRAP_CONTENT
+        else -> dimenPx(raw, ctx) ?: Props.WRAP_CONTENT
+    }
+
+    fun dimenPx(raw: String?, ctx: RenderContext): Int? =
+        raw?.let { (ctx.res.resolve(it, ValueFormat.DIMENSION) as? ResolvedValue.Dimension)?.px?.toInt() }
+
+    fun colorOf(raw: String?, ctx: RenderContext): Int? =
+        raw?.let { (ctx.res.resolve(it, ValueFormat.COLOR) as? ResolvedValue.Color)?.argb }
+
+    fun parseGravity(raw: String): Int = raw.split('|').fold(0) { acc, token ->
+        acc or when (token.trim()) {
+            "start", "left" -> Props.GRAVITY_START
+            "end", "right" -> Props.GRAVITY_END
+            "top" -> Props.GRAVITY_TOP
+            "bottom" -> Props.GRAVITY_BOTTOM
+            "center" -> Props.GRAVITY_CENTER
+            "center_horizontal" -> Props.GRAVITY_CENTER_HORIZONTAL
+            "center_vertical" -> Props.GRAVITY_CENTER_VERTICAL
+            else -> 0
+        }
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ConstraintLayoutRenderer.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ConstraintLayoutRenderer.kt
@@ -1,0 +1,131 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.MeasureSpec
+import dev.ide.preview.Props
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.Renderer
+import dev.ide.preview.Size
+import kotlin.math.max
+
+/**
+ * A pragmatic `ConstraintLayout`: resolves the common `app:layout_constraint*` edges (left/right/start/end,
+ * top/bottom, baseline≈top) against `parent` or sibling ids, with bias-based centring when both opposing
+ * edges are constrained and `0dp` (match-constraint) widths/heights filling the span between them. Not the
+ * full Cassowary solver — no chains, ratios, guidelines, or barriers — but covers the bulk of real layouts.
+ * Children are placed by repeated passes (anchors resolve as their targets settle).
+ */
+object ConstraintLayoutRenderer : Renderer {
+
+    private class Bounds(var left: Int, var top: Int, var right: Int, var bottom: Int)
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val visible = node.children.filter { it.props.visibility != Props.GONE }
+        for (c in visible) {
+            // 0dp (match-constraint) measures at 0 initially; resolved to the span between its edges below.
+            val wSpec = if (c.props.layoutWidth == 0) MeasureSpec.exactly(0) else containerChildSpec(widthSpec, node.props.hPadding, c.props.layoutWidth)
+            val hSpec = if (c.props.layoutHeight == 0) MeasureSpec.exactly(0) else containerChildSpec(heightSpec, node.props.vPadding, c.props.layoutHeight)
+            c.renderer.measure(c, wSpec, hSpec, ctx)
+        }
+        val parentW = (MeasureSpec.getSize(widthSpec) - node.props.hPadding).coerceAtLeast(0)
+        val parentH = (MeasureSpec.getSize(heightSpec) - node.props.vPadding).coerceAtLeast(0)
+        place(visible, parentW, parentH, ctx)
+
+        var cw = 0; var ch = 0
+        for (c in visible) { cw = max(cw, c.right); ch = max(ch, c.bottom) }
+        val w = resolveSize(node.props.layoutWidth, widthSpec, cw + node.props.hPadding)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, ch + node.props.vPadding)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        val cl = l + node.props.paddingLeft; val ct = t + node.props.paddingTop
+        for (c in node.children) {
+            if (c.props.visibility == Props.GONE) continue
+            c.renderer.layout(c, cl + c.left, ct + c.top, cl + c.left + c.measured.width, ct + c.top + c.measured.height, ctx)
+        }
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        for (c in node.children) if (c.props.visibility != Props.GONE) c.renderer.draw(c, canvas, ctx)
+    }
+
+    private fun place(children: List<RenderNode>, parentW: Int, parentH: Int, ctx: RenderContext) {
+        val byId = children.associateBy { it.props.id }
+        val placed = HashSet<RenderNode>()
+        val parent = Bounds(0, 0, parentW, parentH)
+
+        fun boundsOf(target: String?): Bounds? {
+            if (target == null) return null
+            if (target == "parent") return parent
+            val a = byId[target.substringAfterLast('/').replace('.', '_')] ?: return null
+            return if (a in placed) Bounds(a.left, a.top, a.right, a.bottom) else null
+        }
+
+        for (pass in 0..children.size) {
+            var progressed = false
+            for (c in children) {
+                if (c in placed) continue
+                @Suppress("UNCHECKED_CAST")
+                val cons = c.props.extras["constraints"] as? Map<String, String> ?: emptyMap()
+                if (cons.isEmpty()) { c.setBounds(c.props.marginLeft, c.props.marginTop, c.props.marginLeft + c.measured.width, c.props.marginTop + c.measured.height); placed.add(c); progressed = true; continue }
+                if (ready(cons, byId, placed)) {
+                    positionChild(c, cons, ::boundsOf, parentW, parentH)
+                    placed.add(c); progressed = true
+                }
+            }
+            if (!progressed) break
+        }
+        // Unresolved children (cyclic/missing anchors) pin to the top-left.
+        for (c in children) if (c !in placed) c.setBounds(c.props.marginLeft, c.props.marginTop, c.props.marginLeft + c.measured.width, c.props.marginTop + c.measured.height)
+    }
+
+    private fun ready(cons: Map<String, String>, byId: Map<String?, RenderNode>, placed: Set<RenderNode>): Boolean =
+        cons.filterKeys { it.endsWith("Of") }.values.all { target ->
+            target == "parent" || byId[target.substringAfterLast('/').replace('.', '_')]?.let { it in placed } ?: true
+        }
+
+    private fun positionChild(c: RenderNode, cons: Map<String, String>, bounds: (String?) -> Bounds?, parentW: Int, parentH: Int) {
+        val w0 = c.measured.width; val h0 = c.measured.height
+
+        val startToStart = bounds(cons["layout_constraintStart_toStartOf"] ?: cons["layout_constraintLeft_toLeftOf"])
+        val startToEnd = bounds(cons["layout_constraintStart_toEndOf"] ?: cons["layout_constraintLeft_toRightOf"])
+        val endToEnd = bounds(cons["layout_constraintEnd_toEndOf"] ?: cons["layout_constraintRight_toRightOf"])
+        val endToStart = bounds(cons["layout_constraintEnd_toStartOf"] ?: cons["layout_constraintRight_toLeftOf"])
+        val leftPos = startToStart?.let { it.left + c.props.marginLeft } ?: startToEnd?.let { it.right + c.props.marginLeft }
+        val rightPos = endToEnd?.let { it.right - c.props.marginRight } ?: endToStart?.let { it.left - c.props.marginRight }
+        val biasH = cons["layout_constraintHorizontal_bias"]?.toFloatOrNull() ?: 0.5f
+
+        var x = c.props.marginLeft; var w = w0
+        when {
+            leftPos != null && rightPos != null ->
+                if (c.props.layoutWidth == 0) { x = leftPos; w = max(0, rightPos - leftPos) }
+                else { x = leftPos + (((rightPos - leftPos) - w0) * biasH).toInt() }
+            leftPos != null -> x = leftPos
+            rightPos != null -> x = rightPos - w0
+        }
+
+        val topToTop = bounds(cons["layout_constraintTop_toTopOf"]) ?: bounds(cons["layout_constraintBaseline_toBaselineOf"])
+        val topToBottom = bounds(cons["layout_constraintTop_toBottomOf"])
+        val bottomToBottom = bounds(cons["layout_constraintBottom_toBottomOf"])
+        val bottomToTop = bounds(cons["layout_constraintBottom_toTopOf"])
+        val topPos = topToTop?.let { it.top + c.props.marginTop } ?: topToBottom?.let { it.bottom + c.props.marginTop }
+        val botPos = bottomToBottom?.let { it.bottom - c.props.marginBottom } ?: bottomToTop?.let { it.top - c.props.marginBottom }
+        val biasV = cons["layout_constraintVertical_bias"]?.toFloatOrNull() ?: 0.5f
+
+        var y = c.props.marginTop; var h = h0
+        when {
+            topPos != null && botPos != null ->
+                if (c.props.layoutHeight == 0) { y = topPos; h = max(0, botPos - topPos) }
+                else { y = topPos + (((botPos - topPos) - h0) * biasV).toInt() }
+            topPos != null -> y = topPos
+            botPos != null -> y = botPos - h0
+        }
+
+        if (w != w0 || h != h0) c.measured = Size(w, h)
+        c.setBounds(x, y, x + w, y + h)
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/Containers.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/Containers.kt
@@ -1,0 +1,146 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.MeasureSpec
+import dev.ide.preview.Props
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.Renderer
+import dev.ide.preview.Size
+import kotlin.math.max
+
+/**
+ * `ScrollView` / `NestedScrollView` (vertical) and `HorizontalScrollView`: measures its single child
+ * unbounded along the scroll axis (so content taller/wider than the viewport keeps its natural size) and
+ * clips drawing to the viewport. Scroll offset is 0 in the preview.
+ */
+class ScrollRenderer(private val horizontal: Boolean) : Renderer {
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val child = node.children.firstOrNull { it.props.visibility != Props.GONE }
+        var cw = 0; var ch = 0
+        if (child != null) {
+            val childWSpec = if (horizontal) MeasureSpec.unspecified() else containerChildSpec(widthSpec, node.props.hPadding, child.props.layoutWidth)
+            val childHSpec = if (!horizontal) MeasureSpec.unspecified() else containerChildSpec(heightSpec, node.props.vPadding, child.props.layoutHeight)
+            val s = child.renderer.measure(child, childWSpec, childHSpec, ctx)
+            cw = s.width; ch = s.height
+        }
+        val w = resolveSize(node.props.layoutWidth, widthSpec, cw + node.props.hPadding)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, ch + node.props.vPadding)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        val child = node.children.firstOrNull { it.props.visibility != Props.GONE } ?: return
+        val cl = l + node.props.paddingLeft; val ct = t + node.props.paddingTop
+        child.renderer.layout(child, cl, ct, cl + child.measured.width, ct + child.measured.height, ctx)
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        canvas.save()
+        canvas.clipRect(node.left.toFloat(), node.top.toFloat(), node.right.toFloat(), node.bottom.toFloat())
+        for (c in node.children) if (c.props.visibility != Props.GONE) c.renderer.draw(c, canvas, ctx)
+        canvas.restore()
+    }
+}
+
+/**
+ * `RelativeLayout`: positions children by their relative rules (`layout_alignParent*`, `layout_center*`,
+ * `layout_below`/`above`, `layout_toStartOf`/`toEndOf`/`toLeftOf`/`toRightOf`, `layout_align*`). Rules are
+ * captured by [CommonAttrs] into `props.relativeRules`. Anchors are resolved by repeated passes over the
+ * children (cheap; preview layouts are small), so forward references converge.
+ */
+object RelativeLayoutRenderer : Renderer {
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val visible = node.children.filter { it.props.visibility != Props.GONE }
+        for (c in visible) c.renderer.measure(c, containerChildSpec(widthSpec, node.props.hPadding, c.props.layoutWidth), containerChildSpec(heightSpec, node.props.vPadding, c.props.layoutHeight), ctx)
+
+        val parentW = (MeasureSpec.getSize(widthSpec) - node.props.hPadding).coerceAtLeast(0)
+        val parentH = (MeasureSpec.getSize(heightSpec) - node.props.vPadding).coerceAtLeast(0)
+        place(visible, parentW, parentH)
+
+        var contentW = 0; var contentH = 0
+        for (c in visible) { contentW = max(contentW, c.right); contentH = max(contentH, c.bottom) }
+        val w = resolveSize(node.props.layoutWidth, widthSpec, contentW + node.props.hPadding)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, contentH + node.props.vPadding)
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        val cl = l + node.props.paddingLeft; val ct = t + node.props.paddingTop
+        for (c in node.children) {
+            if (c.props.visibility == Props.GONE) continue
+            // Local positions were computed in measure (relative to the content box); shift into place.
+            val lx = c.left; val ly = c.top
+            c.renderer.layout(c, cl + lx, ct + ly, cl + lx + c.measured.width, ct + ly + c.measured.height, ctx)
+        }
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        for (c in node.children) if (c.props.visibility != Props.GONE) c.renderer.draw(c, canvas, ctx)
+    }
+
+    /** Compute each child's content-box-local left/top (stored in node.left/top) from its rules. */
+    private fun place(children: List<RenderNode>, parentW: Int, parentH: Int) {
+        val byId = children.associateBy { it.props.id }
+        val placed = HashSet<RenderNode>()
+        for (pass in 0..children.size) {
+            var progressed = false
+            for (c in children) {
+                if (c in placed) continue
+                @Suppress("UNCHECKED_CAST")
+                val rules = c.props.extras["relativeRules"] as? Map<String, String> ?: emptyMap()
+                if (anchorsReady(rules, byId, placed)) {
+                    positionChild(c, rules, byId, parentW, parentH)
+                    placed.add(c); progressed = true
+                }
+            }
+            if (!progressed) break
+        }
+        // Any unresolved (cyclic/missing anchor) child falls back to the top-left of the content box.
+        for (c in children) if (c !in placed) c.setBounds(c.props.marginLeft, c.props.marginTop, c.props.marginLeft + c.measured.width, c.props.marginTop + c.measured.height)
+    }
+
+    private fun anchorsReady(rules: Map<String, String>, byId: Map<String?, RenderNode>, placed: Set<RenderNode>): Boolean =
+        ANCHOR_RULES.all { rule -> rules[rule]?.let { byId[idOf(it)]?.let { a -> a in placed } ?: true } ?: true }
+
+    private fun positionChild(c: RenderNode, rules: Map<String, String>, byId: Map<String?, RenderNode>, parentW: Int, parentH: Int) {
+        val w = c.measured.width; val h = c.measured.height
+        var x = c.props.marginLeft
+        var y = c.props.marginTop
+
+        fun anchor(rule: String): RenderNode? = rules[rule]?.let { byId[idOf(it)] }
+
+        // Horizontal
+        anchor("layout_toRightOf")?.let { x = it.right + c.props.marginLeft } ?: anchor("layout_toEndOf")?.let { x = it.right + c.props.marginLeft }
+        anchor("layout_toLeftOf")?.let { x = it.left - w - c.props.marginRight } ?: anchor("layout_toStartOf")?.let { x = it.left - w - c.props.marginRight }
+        (anchor("layout_alignLeft") ?: anchor("layout_alignStart"))?.let { x = it.left + c.props.marginLeft }
+        (anchor("layout_alignRight") ?: anchor("layout_alignEnd"))?.let { x = it.right - w - c.props.marginRight }
+        if (flag(rules, "layout_alignParentRight") || flag(rules, "layout_alignParentEnd")) x = parentW - w - c.props.marginRight
+        if (flag(rules, "layout_alignParentLeft") || flag(rules, "layout_alignParentStart")) x = c.props.marginLeft
+        if (flag(rules, "layout_centerHorizontal") || flag(rules, "layout_centerInParent")) x = (parentW - w) / 2
+
+        // Vertical
+        anchor("layout_below")?.let { y = it.bottom + c.props.marginTop }
+        anchor("layout_above")?.let { y = it.top - h - c.props.marginBottom }
+        anchor("layout_alignTop")?.let { y = it.top + c.props.marginTop }
+        anchor("layout_alignBottom")?.let { y = it.bottom - h - c.props.marginBottom }
+        if (flag(rules, "layout_alignParentBottom")) y = parentH - h - c.props.marginBottom
+        if (flag(rules, "layout_alignParentTop")) y = c.props.marginTop
+        if (flag(rules, "layout_centerVertical") || flag(rules, "layout_centerInParent")) y = (parentH - h) / 2
+
+        c.setBounds(x, y, x + w, y + h)
+    }
+
+    private fun flag(rules: Map<String, String>, name: String) = rules[name]?.equals("true", ignoreCase = true) == true
+    private fun idOf(ref: String) = ref.substringAfterLast('/').replace('.', '_')
+
+    private val ANCHOR_RULES = listOf(
+        "layout_toRightOf", "layout_toEndOf", "layout_toLeftOf", "layout_toStartOf",
+        "layout_alignLeft", "layout_alignStart", "layout_alignRight", "layout_alignEnd",
+        "layout_below", "layout_above", "layout_alignTop", "layout_alignBottom",
+    )
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRenderer.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRenderer.kt
@@ -1,0 +1,63 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.AttrReader
+import dev.ide.preview.PlaceholderRenderer
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.Renderer
+import dev.ide.preview.Size
+
+/**
+ * Platform seam that instantiates a user custom view into a [RenderNode] whose [RenderNode.host] runs the
+ * user's `onMeasure`/`onLayout`/`onDraw`. The device impl loads the instrumented, dexed class through a
+ * `DexClassLoader` and constructs it against a `BridgeContext`/`BridgeAttributeSet`; the desktop impl loads
+ * the shim-compiled class through a `URLClassLoader`. Returns null when it can't instantiate (missing deps,
+ * a throwing constructor, no runtime configured) → the inflater falls back to a placeholder.
+ */
+interface CustomViewFactory {
+    fun create(fqName: String, attrs: AttrReader, ctx: RenderContext): RenderNode?
+
+    companion object {
+        /** No custom-view runtime: every custom view renders as a placeholder. */
+        val NONE: CustomViewFactory = object : CustomViewFactory {
+            override fun create(fqName: String, attrs: AttrReader, ctx: RenderContext): RenderNode? = null
+        }
+    }
+}
+
+/**
+ * Drives a custom view through its owned base ([dev.ide.preview.ViewHost]): the user's overridden
+ * `onMeasure/onLayout/onDraw` run against *our* specs and *our* canvas. Any exception in user code degrades
+ * to a placeholder for that node instead of blanking the tree (§12). Falls back to the placeholder if the
+ * node somehow has no host.
+ */
+object CustomViewRenderer : Renderer {
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val host = node.host ?: return PlaceholderRenderer.measure(node, widthSpec, heightSpec, ctx)
+        return runCatching {
+            host.measure(widthSpec, heightSpec)
+            Size(host.measuredWidth, host.measuredHeight)
+        }.getOrElse { PlaceholderRenderer.measure(node, widthSpec, heightSpec, ctx) }.also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) {
+        node.setBounds(l, t, r, b)
+        runCatching { node.host?.layout(l, t, r, b) }
+    }
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        drawBackground(node, canvas, ctx)
+        val host = node.host ?: return PlaceholderRenderer.draw(node, canvas, ctx)
+        runCatching {
+            canvas.save()
+            canvas.translate(node.left.toFloat(), node.top.toFloat())
+            host.drawContent(canvas)
+            canvas.restore()
+        }.onFailure {
+            canvas.restore()
+            PlaceholderRenderer.draw(node, canvas, ctx)
+        }
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRuntime.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRuntime.kt
@@ -4,6 +4,15 @@ import dev.ide.preview.ResolvedValue
 import java.nio.file.Path
 
 /**
+ * Thrown when a custom view (or the runtime that hosts it) can't be previewed, carrying a human-readable
+ * reason. The inflater catches it and records the message as a [dev.ide.preview.PreviewProblem] so the
+ * failure is visible in the preview pane instead of silently degrading to a generic placeholder — without
+ * a message the user has no way to tell whether the preview compile failed, dexing failed, a constructor
+ * threw, or there's simply no runtime configured.
+ */
+class CustomViewPreviewException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+/**
  * Resolves a custom view's styled attributes for the bridge's `obtainStyledAttributes`. Given the view's
  * raw layout attributes (local name → value) and the styleable's attr ids (the `R.styleable.X` int[]), it
  * returns the resolved values in the same order — mapping each id back to its attr name ([RIdAssignment]),

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRuntime.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/CustomViewRuntime.kt
@@ -1,0 +1,31 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.ResolvedValue
+import java.nio.file.Path
+
+/**
+ * Resolves a custom view's styled attributes for the bridge's `obtainStyledAttributes`. Given the view's
+ * raw layout attributes (local name → value) and the styleable's attr ids (the `R.styleable.X` int[]), it
+ * returns the resolved values in the same order — mapping each id back to its attr name ([RIdAssignment]),
+ * reading the raw value, and resolving it ([dev.ide.preview.PreviewResources]).
+ */
+fun interface StyledAttrResolver {
+    fun resolve(rawAttrs: Map<String, String>, styleableIds: IntArray): List<ResolvedValue?>
+}
+
+/**
+ * Platform seam that turns the preview-compiled, BridgeRemapper-instrumented user classes (in [classesDir]
+ * plus their dependency jars) into a [CustomViewFactory]. The device impl (ide-android) dexes them and loads
+ * through a `DexClassLoader` against the on-device Bridge runtime; the desktop impl loads through a
+ * `URLClassLoader` against the JVM shim. Returns null when no runtime can be built (→ the inflater falls back
+ * to placeholders, recorded as render problems).
+ */
+interface CustomViewRuntime {
+    fun createFactory(classesDir: Path, deps: List<Path>, styled: StyledAttrResolver): CustomViewFactory?
+
+    companion object {
+        val NONE: CustomViewRuntime = object : CustomViewRuntime {
+            override fun createFactory(classesDir: Path, deps: List<Path>, styled: StyledAttrResolver): CustomViewFactory? = null
+        }
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/DrawableBackgroundRenderer.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/DrawableBackgroundRenderer.kt
@@ -1,0 +1,89 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.preview.DrawablePreview
+import dev.ide.android.support.preview.GradientKind
+import dev.ide.android.support.preview.GradientSpec
+import dev.ide.android.support.preview.ShapeKind
+import dev.ide.preview.Gradient
+import dev.ide.preview.GradientType
+import dev.ide.preview.PaintStyle
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RPaint
+import dev.ide.preview.RenderContext
+import kotlin.math.min
+
+/**
+ * Renders a [DrawablePreview] (parsed from an `android:background="@drawable/…"`) into an [RCanvas] within
+ * the given bounds. Covers the common background shapes — solid/stroked/rounded rectangles, ovals, layer-
+ * lists, and the default layer of a selector. Gradients are approximated by their start colour (the
+ * [RCanvas] paint model is solid-only for now); vectors/bitmaps as a background are skipped.
+ */
+internal object DrawableBackgroundRenderer {
+
+    fun draw(d: DrawablePreview, l: Float, t: Float, r: Float, b: Float, canvas: RCanvas, ctx: RenderContext) {
+        when (d) {
+            is DrawablePreview.SolidColor -> fillRect(canvas, ctx, l, t, r, b, d.color.toInt(), 0f)
+            is DrawablePreview.Shape -> drawShape(d, l, t, r, b, canvas, ctx)
+            is DrawablePreview.Layers -> for (layer in d.layers) {
+                val dp = ctx.density
+                draw(layer.drawable, l + layer.insetLeftDp * dp, t + layer.insetTopDp * dp,
+                    r - layer.insetRightDp * dp, b - layer.insetBottomDp * dp, canvas, ctx)
+            }
+            is DrawablePreview.States -> d.defaultLayer?.let { draw(it, l, t, r, b, canvas, ctx) }
+            else -> { /* Vector / BitmapRef / Unsupported background: skip */ }
+        }
+    }
+
+    private fun drawShape(s: DrawablePreview.Shape, l: Float, t: Float, r: Float, b: Float, canvas: RCanvas, ctx: RenderContext) {
+        val spec = s.spec
+        val radius = maxOf(spec.cornerTopLeftDp, spec.cornerTopRightDp, spec.cornerBottomLeftDp, spec.cornerBottomRightDp) * ctx.density
+        // The fill is a gradient, a solid colour, or absent.
+        val fillPaint: RPaint? = when {
+            spec.gradient != null -> ctx.gfx.newPaint().apply { style = PaintStyle.FILL; gradient = toGradient(spec.gradient!!) }
+            spec.solidColor != null -> ctx.gfx.newPaint().apply { style = PaintStyle.FILL; color = spec.solidColor!!.toInt() }
+            else -> null
+        }
+        when (spec.shape) {
+            ShapeKind.OVAL -> {
+                val rad = min(r - l, b - t) / 2f
+                fillPaint?.let { canvas.drawRoundRect(l, t, r, b, rad, rad, it) }
+                stroke(spec, canvas, ctx, l, t, r, b, rad)
+            }
+            ShapeKind.LINE -> {
+                val y = (t + b) / 2f
+                val color = (spec.strokeColor ?: spec.solidColor ?: 0xFF888888L).toInt()
+                canvas.drawLine(l, y, r, y, ctx.gfx.newPaint().apply { this.color = color; strokeWidth = (spec.strokeWidthDp * ctx.density).coerceAtLeast(ctx.density) })
+            }
+            else -> { // RECTANGLE / RING (approximated as rect)
+                fillPaint?.let { canvas.drawRoundRect(l, t, r, b, radius, radius, it) }
+                stroke(spec, canvas, ctx, l, t, r, b, radius)
+            }
+        }
+    }
+
+    private fun toGradient(g: GradientSpec): Gradient {
+        val colors = buildList {
+            add(g.startColor.toInt())
+            g.centerColor?.let { add(it.toInt()) }
+            add(g.endColor.toInt())
+        }.toIntArray()
+        val type = when (g.kind) {
+            GradientKind.RADIAL -> GradientType.RADIAL
+            GradientKind.SWEEP -> GradientType.SWEEP
+            else -> GradientType.LINEAR
+        }
+        return Gradient(type, colors, g.angle, g.centerX, g.centerY, g.radiusFraction)
+    }
+
+    private fun stroke(spec: dev.ide.android.support.preview.ShapeSpec, canvas: RCanvas, ctx: RenderContext, l: Float, t: Float, r: Float, b: Float, radius: Float) {
+        val sc = spec.strokeColor ?: return
+        if (spec.strokeWidthDp <= 0f) return
+        canvas.drawRoundRect(l, t, r, b, radius, radius, ctx.gfx.newPaint().apply {
+            color = sc.toInt(); style = PaintStyle.STROKE; strokeWidth = spec.strokeWidthDp * ctx.density
+        })
+    }
+
+    private fun fillRect(canvas: RCanvas, ctx: RenderContext, l: Float, t: Float, r: Float, b: Float, color: Int, radius: Float) {
+        canvas.drawRoundRect(l, t, r, b, radius, radius, ctx.gfx.newPaint().apply { this.color = color; style = PaintStyle.FILL })
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/GravityUtil.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/GravityUtil.kt
@@ -1,0 +1,28 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.Props
+
+/**
+ * Resolves gravity flags into placement offsets within an available span. Used for `layout_gravity` (a
+ * child's alignment in its parent) and `android:gravity` (a container/text view aligning its content).
+ */
+internal object GravityUtil {
+
+    /** Left offset of a [size]-wide item in [available] px, honouring start/end/center_horizontal + margins. */
+    fun horizontal(gravity: Int, available: Int, size: Int, marginStart: Int, marginEnd: Int): Int = when {
+        gravity and Props.GRAVITY_CENTER_HORIZONTAL != 0 -> marginStart + (available - size - marginStart - marginEnd) / 2
+        gravity and Props.GRAVITY_END != 0 -> available - size - marginEnd
+        else -> marginStart // start / unspecified
+    }
+
+    /** Top offset of a [size]-tall item in [available] px, honouring top/bottom/center_vertical + margins. */
+    fun vertical(gravity: Int, available: Int, size: Int, marginTop: Int, marginBottom: Int): Int = when {
+        gravity and Props.GRAVITY_CENTER_VERTICAL != 0 -> marginTop + (available - size - marginTop - marginBottom) / 2
+        gravity and Props.GRAVITY_BOTTOM != 0 -> available - size - marginBottom
+        else -> marginTop // top / unspecified
+    }
+
+    /** A child's effective gravity: its own `layout_gravity`, else the parent's content gravity. */
+    fun effective(childGravity: Int, parentContentGravity: Int): Int =
+        if (childGravity != Props.GRAVITY_NONE) childGravity else parentContentGravity
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutInflater.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutInflater.kt
@@ -86,8 +86,18 @@ class LayoutInflater(
     }
 
     private fun customNode(fqName: String, attrs: AttrReader, ctx: RenderContext): RenderNode {
-        val node = runCatching { customViewFactory.create(fqName, attrs, ctx) }.getOrNull()
-            ?: return placeholder(fqName).also { problem(fqName, "Custom view not rendered (no preview runtime)") }
+        val outcome = runCatching { customViewFactory.create(fqName, attrs, ctx) }
+        val node = outcome.getOrNull()
+        if (node == null) {
+            // Surface the real reason (compile/dex failure, throwing constructor, missing runtime, …) so the
+            // preview pane's problems chip is actionable; CustomViewPreviewException already carries a message.
+            val reason = when (val t = outcome.exceptionOrNull()) {
+                null -> "no preview runtime"
+                is CustomViewPreviewException -> t.message ?: t.javaClass.simpleName
+                else -> "${t.javaClass.simpleName}: ${t.message ?: "(no message)"}"
+            }
+            return placeholder(fqName).also { problem(fqName, "Custom view not rendered — $reason") }
+        }
         node.renderer = CustomViewRenderer
         return node
     }

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutInflater.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutInflater.kt
@@ -1,0 +1,109 @@
+package dev.ide.preview.impl
+
+import dev.ide.lang.xml.XmlNode
+import dev.ide.lang.xml.XmlTreeParser
+import dev.ide.preview.AttrReader
+import dev.ide.preview.PlaceholderRenderer
+import dev.ide.preview.PreviewProblem
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.RendererRegistry
+
+/**
+ * Inflates raw layout XML into the owned [RenderNode] tree using the tolerant `XmlTreeParser` (so a
+ * half-typed buffer still previews). A built-in tag resolves through the [registry]; a fully-qualified tag
+ * (a `.` in the name) is a user custom view, instantiated through the [customViewFactory]; structural tags
+ * are expanded: `<include>`/`<ViewStub>` inflate their referenced layout via [layoutProvider] (name → xml),
+ * `<merge>` becomes a transparent container. Anything unknown or un-instantiable becomes a placeholder.
+ * Standard `View` attributes are applied to every node so the owned base honours `layout_*`/padding/
+ * background/gravity even for custom views (§7).
+ */
+class LayoutInflater(
+    private val registry: RendererRegistry = DefaultRenderers.registry(),
+    private val customViewFactory: CustomViewFactory = CustomViewFactory.NONE,
+    /** Resolve a layout resource *name* (e.g. `toolbar`) to its raw XML, for `<include>`/`<ViewStub>`. */
+    private val layoutProvider: (name: String) -> String? = { null },
+) {
+
+    /** Problems collected during the most recent [inflate] (unknown tags, unresolved includes, custom views). */
+    val problems: MutableList<PreviewProblem> = ArrayList()
+
+    fun inflate(xml: String, ctx: RenderContext, path: String = "layout.xml"): RenderNode {
+        problems.clear()
+        val (document, _) = XmlTreeParser(TextDocument(xml, path)).parse()
+        val rootEl = document.childTags.firstOrNull() ?: return placeholder("empty")
+        return build(rootEl, ctx, depth = 0)
+    }
+
+    private fun build(element: XmlNode, ctx: RenderContext, depth: Int): RenderNode {
+        val tag = element.name ?: "view"
+        val attrs = styled(XmlAttrReader(element), ctx)
+        when (tag) {
+            "include" -> return buildInclude(attrs, ctx, depth)
+            "ViewStub" -> return buildViewStub(attrs, ctx, depth)
+            "fragment" -> return placeholder("fragment").also { CommonAttrs.apply(it, attrs, ctx); problem("fragment", "Fragments aren't rendered in preview") }
+        }
+        val node = nodeFor(tag, attrs, ctx)
+        node.tag = tag
+        runCatching { node.renderer.applyAttrs(node, attrs, ctx) }
+        CommonAttrs.apply(node, attrs, ctx)
+        for (childEl in element.childTags) node.children.add(build(childEl, ctx, depth + 1))
+        return node
+    }
+
+    private fun nodeFor(tag: String, attrs: AttrReader, ctx: RenderContext): RenderNode {
+        if (tag == "merge") return RenderNode().apply { renderer = FrameLayoutRenderer }
+        // The registry resolves by simple name, so a fully-qualified framework/Material/AppCompat tag (e.g.
+        // com.google.android.material.button.MaterialButton) is matched here BEFORE the custom-view path.
+        registry.forTag(tag)?.let { r -> return RenderNode().apply { renderer = r } }
+        if ('.' in tag) return customNode(tag, attrs, ctx)
+        return placeholder(tag).also { problem(tag, "No renderer for <$tag>") }
+    }
+
+    /** `<include layout="@layout/x">`: inflate x's root and apply the include tag's `layout_*`/id overrides. */
+    private fun buildInclude(attrs: AttrReader, ctx: RenderContext, depth: Int): RenderNode {
+        val node = inflateRef(attrs.local("layout"), ctx, depth)
+            ?: return placeholder("include").also { problem("include", "Couldn't resolve included layout ${attrs.local("layout")}") }
+        CommonAttrs.apply(node, attrs, ctx) // include-tag overrides win over the included root's params
+        return node
+    }
+
+    /** `<ViewStub android:layout="@layout/x">`: inflate the referenced layout (a stub renders nothing live). */
+    private fun buildViewStub(attrs: AttrReader, ctx: RenderContext, depth: Int): RenderNode {
+        val node = inflateRef(attrs.android("layout") ?: attrs.local("layout"), ctx, depth)
+            ?: return placeholder("ViewStub").also { problem("ViewStub", "Couldn't resolve ViewStub layout") }
+        CommonAttrs.apply(node, attrs, ctx)
+        return node
+    }
+
+    private fun inflateRef(layoutRef: String?, ctx: RenderContext, depth: Int): RenderNode? {
+        if (depth > 30) return null // include cycle guard
+        val name = layoutRef?.substringAfterLast('/') ?: return null
+        val xml = layoutProvider(name) ?: return null
+        val (document, _) = XmlTreeParser(TextDocument(xml, "$name.xml")).parse()
+        val rootEl = document.childTags.firstOrNull() ?: return null
+        return build(rootEl, ctx, depth + 1)
+    }
+
+    private fun customNode(fqName: String, attrs: AttrReader, ctx: RenderContext): RenderNode {
+        val node = runCatching { customViewFactory.create(fqName, attrs, ctx) }.getOrNull()
+            ?: return placeholder(fqName).also { problem(fqName, "Custom view not rendered (no preview runtime)") }
+        node.renderer = CustomViewRenderer
+        return node
+    }
+
+    private fun placeholder(tag: String): RenderNode = RenderNode().apply {
+        renderer = PlaceholderRenderer
+        this.tag = tag
+    }
+
+    private fun problem(tag: String, message: String) { problems.add(PreviewProblem(tag, message)) }
+
+    /** If the element carries `style="@style/…"`, overlay that style's items beneath its explicit attrs. */
+    private fun styled(base: XmlAttrReader, ctx: RenderContext): AttrReader {
+        val styleRef = base.local("style") ?: return base
+        val res = ctx.res as? ProjectPreviewResources ?: return base
+        val items = res.styleItems(styleRef.substringAfterLast('/'))
+        return if (items.isEmpty()) base else StyleAttrReader(base, items)
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutPreviewService.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/LayoutPreviewService.kt
@@ -1,0 +1,43 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.preview.LayoutPreviewResult
+import dev.ide.preview.RImage
+import dev.ide.preview.RendererRegistry
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+
+/**
+ * Builds the [LayoutPreviewResult] the UI renders: inflate the layout XML into the owned tree (resolving
+ * resources, instantiating custom views via the [customViewFactory]) and wrap it in the activity's system
+ * chrome. The returned tree is *re-measured* by the UI with its own platform [dev.ide.preview.RGraphics]
+ * (real text metrics), so the [HeadlessGraphics] used here only services inflation, never final layout.
+ */
+class LayoutPreviewService(
+    private val customViewFactory: CustomViewFactory = CustomViewFactory.NONE,
+    private val registry: RendererRegistry = DefaultRenderers.registry(),
+) {
+    fun preview(
+        xml: String,
+        repo: ResourceRepository,
+        themeName: String?,
+        title: String,
+        density: Float = 2f,
+        scaledDensity: Float = density,
+        showChrome: Boolean = true,
+        night: Boolean = false,
+        imageLoader: (resType: String, name: String, file: String?) -> RImage? = { _, _, _ -> null },
+        layoutProvider: (name: String) -> String? = { null },
+    ): LayoutPreviewResult {
+        val resources = ProjectPreviewResources(repo, density, scaledDensity, imageLoader, night)
+        val ctx = SimpleRenderContext(HeadlessGraphics(), resources, density, scaledDensity)
+        val inflater = LayoutInflater(registry, customViewFactory, layoutProvider)
+        val content = inflater.inflate(xml, ctx)
+        val root = if (showChrome) {
+            SystemChrome.wrap(content, PreviewChrome.fromTheme(repo, resources, themeName, title), ctx)
+        } else {
+            content
+        }
+        return LayoutPreviewResult(root, resources, density, scaledDensity, imageFile = { resources.imageFilePath(it) }, problems = inflater.problems.toList())
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/MaterialRenderers.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/MaterialRenderers.kt
@@ -1,0 +1,130 @@
+package dev.ide.preview.impl
+
+import dev.ide.preview.AttrReader
+import dev.ide.preview.PaintStyle
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+import dev.ide.preview.Renderer
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.Size
+import dev.ide.preview.ValueFormat
+import kotlin.math.max
+import kotlin.math.min
+
+// Material-ish defaults used when a theme colour can't be resolved (the renderers are theme-free).
+private const val M_PRIMARY = 0xFF6750A4.toInt()
+private const val M_ON_PRIMARY = 0xFFFFFFFF.toInt()
+private const val M_SURFACE_VARIANT = 0xFFE7E0EC.toInt()
+private const val M_ON_SURFACE = 0xFF1D1B20.toInt()
+private const val M_NEUTRAL = 0xFFE0E0E0.toInt()
+
+/**
+ * A button-family widget (`Button`, `MaterialButton`, `AppCompatButton`): a rounded filled pill with
+ * single-line centred label, a 48dp min height, and default horizontal padding. [bgColor]/[fgColor] are the
+ * fallback fill/label colours when the layout doesn't override `background`/`textColor`.
+ */
+class ButtonRenderer(private val bgColor: Int, private val fgColor: Int, private val cornerDp: Float = 8f) : Renderer {
+    override fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        val p = node.props
+        attrs.android("text")?.let { p.text = (ctx.res.resolve(it, ValueFormat.STRING) as? ResolvedValue.Str)?.text ?: it }
+        attrs.android("textSize")?.let { p.textSizePx = (ctx.res.resolve(it, ValueFormat.DIMENSION) as? ResolvedValue.Dimension)?.px ?: p.textSizePx }
+        attrs.android("textColor")?.let { c -> CommonAttrs.colorOf(c, ctx)?.let { p.textColor = it } ?: run { p.textColor = fgColor } } ?: run { p.textColor = fgColor }
+    }
+
+    private fun paint(node: RenderNode, ctx: RenderContext) = ctx.gfx.newPaint().apply {
+        color = node.props.textColor; antiAlias = true; bold = true
+        textSizePx = if (node.props.textSizePx > 0f) node.props.textSizePx else 14f * ctx.scaledDensity
+    }
+
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val tp = paint(node, ctx)
+        val tw = ctx.gfx.measureText(node.props.text, tp)
+        val lh = ctx.gfx.fontMetrics(tp).lineHeight
+        val padH = if (node.props.hPadding > 0) node.props.hPadding else (32 * ctx.density).toInt()
+        val minH = (48 * ctx.density).toInt()
+        val w = resolveSize(node.props.layoutWidth, widthSpec, tw.toInt() + padH)
+        val h = resolveSize(node.props.layoutHeight, heightSpec, max(minH, lh.toInt() + node.props.vPadding))
+        return Size(w, h).also { node.measured = it }
+    }
+
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) = node.setBounds(l, t, r, b)
+
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        val l = node.left.toFloat(); val t = node.top.toFloat(); val rr = node.right.toFloat(); val bb = node.bottom.toFloat()
+        val radius = cornerDp * ctx.density
+        canvas.drawRoundRect(l, t, rr, bb, radius, radius, ctx.gfx.newPaint().apply { color = node.props.backgroundColor ?: bgColor; style = PaintStyle.FILL })
+        val tp = paint(node, ctx)
+        val tw = ctx.gfx.measureText(node.props.text, tp)
+        val fm = ctx.gfx.fontMetrics(tp)
+        canvas.drawText(node.props.text, l + ((rr - l) - tw) / 2f, t + ((bb - t) - fm.lineHeight) / 2f, tp)
+    }
+}
+
+/** A `FloatingActionButton`: a filled accent circle (icon content not rendered). */
+object FabRenderer : Renderer {
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val d = (56 * ctx.density).toInt()
+        return Size(resolveSize(node.props.layoutWidth, widthSpec, d), resolveSize(node.props.layoutHeight, heightSpec, d)).also { node.measured = it }
+    }
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) = node.setBounds(l, t, r, b)
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        val cx = (node.left + node.right) / 2f; val cy = (node.top + node.bottom) / 2f
+        val radius = min(node.width, node.height) / 2f
+        canvas.drawCircle(cx, cy, radius, ctx.gfx.newPaint().apply { color = node.props.backgroundColor ?: M_PRIMARY; style = PaintStyle.FILL })
+    }
+}
+
+/** A `Chip`: a pill with a single-line label. */
+class ChipRenderer(private val bgColor: Int = M_SURFACE_VARIANT, private val fgColor: Int = M_ON_SURFACE) : Renderer {
+    override fun applyAttrs(node: RenderNode, attrs: AttrReader, ctx: RenderContext) {
+        attrs.android("text")?.let { node.props.text = (ctx.res.resolve(it, ValueFormat.STRING) as? ResolvedValue.Str)?.text ?: it }
+        node.props.textColor = fgColor
+    }
+    private fun paint(node: RenderNode, ctx: RenderContext) = ctx.gfx.newPaint().apply {
+        color = node.props.textColor; antiAlias = true; textSizePx = if (node.props.textSizePx > 0f) node.props.textSizePx else 13f * ctx.scaledDensity
+    }
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size {
+        val tp = paint(node, ctx)
+        val tw = ctx.gfx.measureText(node.props.text, tp).toInt()
+        val w = resolveSize(node.props.layoutWidth, widthSpec, tw + (24 * ctx.density).toInt())
+        val h = resolveSize(node.props.layoutHeight, heightSpec, (32 * ctx.density).toInt())
+        return Size(w, h).also { node.measured = it }
+    }
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) = node.setBounds(l, t, r, b)
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        val l = node.left.toFloat(); val t = node.top.toFloat(); val rr = node.right.toFloat(); val bb = node.bottom.toFloat()
+        val radius = node.height / 2f
+        canvas.drawRoundRect(l, t, rr, bb, radius, radius, ctx.gfx.newPaint().apply { color = node.props.backgroundColor ?: bgColor; style = PaintStyle.FILL })
+        val tp = paint(node, ctx)
+        val tw = ctx.gfx.measureText(node.props.text, tp)
+        val fm = ctx.gfx.fontMetrics(tp)
+        canvas.drawText(node.props.text, l + ((rr - l) - tw) / 2f, t + ((bb - t) - fm.lineHeight) / 2f, tp)
+    }
+}
+
+/** A `CardView`/`MaterialCardView`: a rounded surface holding stacked children (Frame layout + card chrome). */
+object CardRenderer : Renderer {
+    override fun measure(node: RenderNode, widthSpec: Int, heightSpec: Int, ctx: RenderContext): Size =
+        FrameLayoutRenderer.measure(node, widthSpec, heightSpec, ctx)
+    override fun layout(node: RenderNode, l: Int, t: Int, r: Int, b: Int, ctx: RenderContext) =
+        FrameLayoutRenderer.layout(node, l, t, r, b, ctx)
+    override fun draw(node: RenderNode, canvas: RCanvas, ctx: RenderContext) {
+        val l = node.left.toFloat(); val t = node.top.toFloat(); val rr = node.right.toFloat(); val bb = node.bottom.toFloat()
+        val radius = 12f * ctx.density
+        canvas.drawRoundRect(l, t, rr, bb, radius, radius, ctx.gfx.newPaint().apply { color = node.props.backgroundColor ?: 0xFFFFFFFF.toInt(); style = PaintStyle.FILL })
+        for (c in node.children) if (c.props.visibility != dev.ide.preview.Props.GONE) c.renderer.draw(c, canvas, ctx)
+    }
+}
+
+/** Registers Material + AppCompat tag aliases onto an existing registry (resolved by simple name). */
+fun dev.ide.preview.RendererRegistry.withMaterial(): dev.ide.preview.RendererRegistry = this
+    .register(listOf("Button", "AppCompatButton"), ButtonRenderer(M_NEUTRAL, M_ON_SURFACE))
+    .register(listOf("MaterialButton"), ButtonRenderer(M_PRIMARY, M_ON_PRIMARY))
+    .register(listOf("AppCompatTextView", "MaterialTextView", "TextInputEditText", "TextInputLayout", "AppCompatEditText", "AppCompatCheckBox", "MaterialCheckBox", "SwitchMaterial", "MaterialRadioButton"), TextRenderer)
+    .register(listOf("AppCompatImageView", "AppCompatImageButton", "ShapeableImageView"), ImageRenderer)
+    .register(listOf("CardView", "MaterialCardView"), CardRenderer)
+    .register(listOf("FloatingActionButton", "ExtendedFloatingActionButton"), FabRenderer)
+    .register(listOf("Chip"), ChipRenderer())
+    .register(listOf("ConstraintLayout"), ConstraintLayoutRenderer)
+    .register(listOf("CoordinatorLayout", "AppBarLayout", "BottomNavigationView", "MaterialToolbar", "Toolbar"), FrameLayoutRenderer)

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ProjectPreviewResources.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ProjectPreviewResources.kt
@@ -1,0 +1,177 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.preview.AndroidColor
+import dev.ide.android.support.preview.DrawablePreview
+import dev.ide.android.support.preview.DrawablePreviewParser
+import dev.ide.android.support.preview.DrawableResolver
+import dev.ide.android.support.preview.ResolvedDrawable
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.preview.PreviewResources
+import dev.ide.preview.RImage
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ValueFormat
+import kotlin.io.path.readText
+
+/**
+ * [PreviewResources] backed by a module's merged [ResourceRepository] and the previewed device density.
+ * Parses literal colors/dimensions and resolves `@type/name` references (recursively, so `@color/a → @color/b
+ * → #fff` collapses to an ARGB), framework `@android:color/…` via the small builtin table, and `@drawable/…`
+ * to a loaded image through the injected [imageLoader] (image decoding is platform-specific). Theme `?attr/…`
+ * references are not yet resolved (returns null — the renderer falls back to its default).
+ */
+class ProjectPreviewResources(
+    private val repo: ResourceRepository,
+    val density: Float = 1f,
+    private val scaledDensity: Float = density,
+    private val imageLoader: (resType: String, name: String, file: String?) -> RImage? = { _, _, _ -> null },
+    /** When true, prefer `-night`-qualified resource values (dark-theme preview). */
+    private val night: Boolean = false,
+) : PreviewResources {
+
+    /** The config-appropriate definition of `type/name` — `-night` first when [night], default otherwise. */
+    private fun definition(type: ResourceType, name: String): dev.ide.android.support.resources.ResourceItem? {
+        val defs = repo.definitions(type, name).filter { it.value != null }
+        if (defs.isEmpty()) return null
+        return if (night) defs.firstOrNull { it.qualifier.contains("night") } ?: defs.firstOrNull { it.qualifier.isEmpty() } ?: defs.first()
+        else defs.firstOrNull { it.qualifier.isEmpty() } ?: defs.first()
+    }
+
+    override fun resolve(raw: String, format: ValueFormat): ResolvedValue? {
+        val s = raw.trim()
+        if (s.isEmpty()) return null
+        if (s.startsWith("@")) return resolveRef(s, format)
+        if (s.startsWith("?")) return null // theme attribute — not yet modelled
+        return parseLiteral(s, format)
+    }
+
+    override fun image(ref: String): RImage? {
+        val parsed = parseRef(ref) ?: return null
+        if (parsed.pkg == "android") return null
+        val item = repo.definitions(parsed.type, parsed.name).firstOrNull()
+        return imageLoader(parsed.type.rClass, parsed.name, item?.source?.toString())
+    }
+
+    /** The backing file path of a `@drawable/@mipmap` reference, for the UI layer to decode; null if unknown. */
+    fun imageFilePath(ref: String): String? {
+        val parsed = parseRef(ref) ?: return null
+        if (parsed.pkg == "android") return null
+        return repo.definitions(parsed.type, parsed.name).firstOrNull()?.source?.toString()
+    }
+
+    /** Flatten a `<style>`/theme (by raw dotted name) + its parent chain into a single item map (derived wins). */
+    fun styleItems(styleName: String): Map<String, String> {
+        val chain = ArrayList<String>()
+        var cur: String? = styleName
+        var guard = 0
+        val seen = HashSet<String>()
+        while (cur != null && guard++ < 32 && seen.add(cur)) {
+            chain.add(cur)
+            val s = repo.style(cur)
+            cur = s?.parent?.removePrefix("@style/") ?: if ('.' in cur) cur.substringBeforeLast('.') else null
+        }
+        val out = LinkedHashMap<String, String>()
+        for (name in chain.asReversed()) repo.style(name)?.items?.let { out.putAll(it) }
+        return out
+    }
+
+    /** Parse a `@drawable/@mipmap` background reference into a [DrawablePreview] (XML shapes/layers/etc.). */
+    fun backgroundDrawable(ref: String): DrawablePreview? {
+        val parsed = parseRef(ref) ?: return null
+        if (parsed.pkg == "android") return null
+        if (parsed.type != ResourceType.DRAWABLE && parsed.type != ResourceType.MIPMAP) return null
+        val src = repo.definitions(parsed.type, parsed.name).firstOrNull()?.source ?: return null
+        val path = src.toString()
+        if (!path.endsWith(".xml")) return DrawablePreview.BitmapRef(parsed.type.rClass, parsed.name, path)
+        val text = runCatching { src.readText() }.getOrNull() ?: return null
+        return runCatching { DrawablePreviewParser.parse(text, drawableResolver) }.getOrNull()
+    }
+
+    /** A [DrawableResolver] over this repository, so a background shape's `@color`/`@dimen`/nested refs resolve. */
+    private val drawableResolver = object : DrawableResolver {
+        override fun resolveColor(ref: String): Long? =
+            (resolve(ref, ValueFormat.COLOR) as? ResolvedValue.Color)?.argb?.toLong()?.and(0xFFFFFFFFL)
+
+        override fun resolveDimenDp(ref: String): Float? =
+            (resolve(ref, ValueFormat.DIMENSION) as? ResolvedValue.Dimension)?.px?.let { if (density != 0f) it / density else it }
+
+        override fun resolveDrawable(ref: String): ResolvedDrawable? {
+            val p = parseRef(ref) ?: return null
+            val src = repo.definitions(p.type, p.name).firstOrNull()?.source ?: return null
+            val path = src.toString()
+            return if (path.endsWith(".xml")) runCatching { src.readText() }.getOrNull()?.let { ResolvedDrawable.Xml(it) }
+            else ResolvedDrawable.BitmapFile(p.type.rClass, p.name, path)
+        }
+    }
+
+    private fun parseLiteral(s: String, format: ValueFormat): ResolvedValue? = when (format) {
+        ValueFormat.COLOR -> AndroidColor.parseHex(s)?.let { ResolvedValue.Color(it.toInt()) }
+        ValueFormat.DIMENSION -> ResolvedValue.Dimension(parseDimensionPx(s))
+        ValueFormat.BOOLEAN -> ResolvedValue.BoolV(s.equals("true", ignoreCase = true))
+        ValueFormat.INTEGER -> s.toIntOrNull()?.let { ResolvedValue.IntV(it) }
+        ValueFormat.FLOAT -> s.toFloatOrNull()?.let { ResolvedValue.FloatV(it) }
+        ValueFormat.STRING, ValueFormat.ENUM, ValueFormat.FLAG, ValueFormat.REFERENCE -> ResolvedValue.Str(s)
+        ValueFormat.ANY -> when {
+            s.startsWith("#") -> AndroidColor.parseHex(s)?.let { ResolvedValue.Color(it.toInt()) } ?: ResolvedValue.Str(s)
+            DIMEN.matches(s) -> ResolvedValue.Dimension(parseDimensionPx(s))
+            s == "true" || s == "false" -> ResolvedValue.BoolV(s == "true")
+            else -> ResolvedValue.Str(s)
+        }
+    }
+
+    private fun resolveRef(raw: String, format: ValueFormat, depth: Int = 0): ResolvedValue? {
+        if (depth > 16) return null
+        val ref = parseRef(raw) ?: return null
+        if (ref.pkg == "android") {
+            return if (ref.type == ResourceType.COLOR) AndroidColor.framework(ref.name)?.let { ResolvedValue.Color(it.toInt()) }
+            else null
+        }
+        // File resources resolve to a reference the renderer loads through image(); not a scalar.
+        if (ref.type == ResourceType.DRAWABLE || ref.type == ResourceType.MIPMAP) {
+            return ResolvedValue.Ref(ref.type.rClass, ref.name)
+        }
+        val value = definition(ref.type, ref.name)?.value ?: return null
+        // The looked-up value may itself be a literal or another reference — resolve transitively.
+        return when (ref.type) {
+            ResourceType.COLOR -> if (value.startsWith("@")) resolveRef(value, ValueFormat.COLOR, depth + 1)
+            else AndroidColor.parseHex(value)?.let { ResolvedValue.Color(it.toInt()) }
+            ResourceType.DIMEN -> if (value.startsWith("@")) resolveRef(value, ValueFormat.DIMENSION, depth + 1)
+            else ResolvedValue.Dimension(parseDimensionPx(value))
+            ResourceType.STRING -> ResolvedValue.Str(value)
+            ResourceType.BOOL -> ResolvedValue.BoolV(value.equals("true", ignoreCase = true))
+            ResourceType.INTEGER -> value.toIntOrNull()?.let { ResolvedValue.IntV(it) }
+            else -> if (value.startsWith("@")) resolveRef(value, format, depth + 1) else parseLiteral(value, format)
+        }
+    }
+
+    /** Parse `12dp`/`8dip`/`14sp`/`2px` (etc.) into pixels for the previewed density; 0 if unparseable. */
+    fun parseDimensionPx(raw: String): Float {
+        val m = DIMEN.find(raw.trim()) ?: return 0f
+        val value = m.groupValues[1].toFloatOrNull() ?: return 0f
+        return when (m.groupValues[2].lowercase()) {
+            "dp", "dip" -> value * density
+            "sp" -> value * scaledDensity
+            "px", "" -> value
+            "pt" -> value * density * 160f / 72f
+            "mm" -> value * density * 160f / 25.4f
+            "in" -> value * density * 160f
+            else -> value
+        }
+    }
+
+    private data class ParsedRef(val type: ResourceType, val name: String, val pkg: String?)
+
+    private fun parseRef(raw: String): ParsedRef? {
+        val m = REF.find(raw) ?: return null
+        val pkg = m.groupValues[1].ifEmpty { null }
+        val type = ResourceType.byRClass(m.groupValues[2]) ?: return null
+        val name = m.groupValues[3].replace('.', '_')
+        return ParsedRef(type, name, pkg)
+    }
+
+    private companion object {
+        // @[+]?[pkg:]type/name
+        val REF = Regex("""@\+?(?:([A-Za-z][\w.]*):)?([A-Za-z]\w*)/([A-Za-z_][\w.]*)""")
+        val DIMEN = Regex("""^(-?[\d.]+)\s*([A-Za-z]*)$""")
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/SystemChrome.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/SystemChrome.kt
@@ -1,0 +1,115 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.preview.Props
+import dev.ide.preview.RenderContext
+import dev.ide.preview.RenderNode
+
+/**
+ * The previewed window's system chrome — the platform views around the user's content: the status bar, the
+ * action bar (app bar) with the activity title, and the window background. Derived from the activity's theme
+ * + manifest label so the preview reads like the real screen rather than a bare layout. Colours/flags fall
+ * back to Material defaults when the theme can't be resolved.
+ */
+data class PreviewChrome(
+    val title: String,
+    val showStatusBar: Boolean = true,
+    val showActionBar: Boolean = true,
+    val fullscreen: Boolean = false,
+    val statusBarColor: Int = 0xFF3700B3.toInt(),
+    val actionBarColor: Int = 0xFF6200EE.toInt(),
+    val actionBarTextColor: Int = 0xFFFFFFFF.toInt(),
+    val windowBackground: Int = 0xFFFAFAFA.toInt(),
+) {
+    companion object {
+        const val STATUS_BAR_DP = 24
+        const val ACTION_BAR_DP = 56
+
+        /** Build chrome for [themeName] (the activity's theme) titled [title], reading colours from [repo]. */
+        fun fromTheme(repo: ResourceRepository, res: dev.ide.preview.PreviewResources, themeName: String?, title: String): PreviewChrome {
+            if (themeName.isNullOrBlank()) return PreviewChrome(title = title)
+            val theme = ThemeResolver(repo, res)
+            val primary = theme.color(themeName, "colorPrimary", "colorPrimaryDark") ?: 0xFF6200EE.toInt()
+            val status = theme.color(themeName, "statusBarColor", "colorPrimaryDark") ?: darken(primary)
+            val noActionBar = theme.hasNoActionBar(themeName) ||
+                theme.flag(themeName, "windowActionBar") == false ||
+                theme.flag(themeName, "windowNoTitle") == true
+            val fullscreen = theme.flag(themeName, "windowFullscreen", "windowFullScreen") == true
+            val windowBg = theme.color(themeName, "android:windowBackground", "windowBackground") ?: 0xFFFAFAFA.toInt()
+            return PreviewChrome(
+                title = title,
+                showActionBar = !noActionBar,
+                fullscreen = fullscreen,
+                statusBarColor = status,
+                actionBarColor = primary,
+                windowBackground = windowBg,
+            )
+        }
+
+        /** A slightly darker shade, the conventional status-bar tint when only `colorPrimary` is known. */
+        private fun darken(argb: Int): Int {
+            val a = argb ushr 24 and 0xFF
+            val r = ((argb ushr 16 and 0xFF) * 0.78f).toInt()
+            val g = ((argb ushr 8 and 0xFF) * 0.78f).toInt()
+            val b = ((argb and 0xFF) * 0.78f).toInt()
+            return (a shl 24) or (r shl 16) or (g shl 8) or b
+        }
+    }
+}
+
+/** Wraps inflated content in its window chrome, producing the root the engine measures/draws. */
+object SystemChrome {
+
+    /**
+     * A vertical stack `[status bar?] [action bar?] [content fills remaining]`. The content node is given
+     * `weight=1` + a 0-height base so it fills the space below the bars (the standard Android weight idiom),
+     * regardless of the layout file's own root size.
+     */
+    fun wrap(content: RenderNode, chrome: PreviewChrome, ctx: RenderContext): RenderNode {
+        val density = ctx.density
+        val root = RenderNode().apply {
+            renderer = LinearLayoutRenderer
+            tag = "decor"
+            props.orientation = Props.VERTICAL
+            props.layoutWidth = Props.MATCH_PARENT
+            props.layoutHeight = Props.MATCH_PARENT
+            props.backgroundColor = chrome.windowBackground
+        }
+
+        if (chrome.showStatusBar && !chrome.fullscreen) {
+            root.children.add(bar((PreviewChrome.STATUS_BAR_DP * density).toInt(), chrome.statusBarColor, "statusBar"))
+        }
+        if (chrome.showActionBar) {
+            val appBar = bar((PreviewChrome.ACTION_BAR_DP * density).toInt(), chrome.actionBarColor, "actionBar")
+            appBar.children.add(actionBarTitle(chrome, ctx))
+            root.children.add(appBar)
+        }
+
+        content.props.weight = 1f
+        content.props.layoutHeight = 0
+        root.children.add(content)
+        return root
+    }
+
+    private fun bar(heightPx: Int, color: Int, tag: String): RenderNode = RenderNode().apply {
+        renderer = FrameLayoutRenderer
+        this.tag = tag
+        props.layoutWidth = Props.MATCH_PARENT
+        props.layoutHeight = heightPx
+        props.backgroundColor = color
+    }
+
+    private fun actionBarTitle(chrome: PreviewChrome, ctx: RenderContext): RenderNode = RenderNode().apply {
+        renderer = TextRenderer
+        tag = "title"
+        props.text = chrome.title
+        props.textColor = chrome.actionBarTextColor
+        props.bold = true
+        props.textSizePx = 20f * ctx.scaledDensity
+        props.layoutWidth = Props.WRAP_CONTENT
+        props.layoutHeight = Props.WRAP_CONTENT
+        props.paddingLeft = (16 * ctx.density).toInt()
+        // Roughly centre the title in the 56dp bar.
+        props.marginTop = ((PreviewChrome.ACTION_BAR_DP - 20) / 2 * ctx.density).toInt()
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/TextDocument.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/TextDocument.kt
@@ -1,0 +1,27 @@
+package dev.ide.preview.impl
+
+import dev.ide.lang.incremental.DocumentSnapshot
+import dev.ide.platform.ContentHash
+import dev.ide.vfs.VirtualFile
+
+/**
+ * A throwaway [DocumentSnapshot] over a plain string, just enough to drive the tolerant `XmlTreeParser`
+ * (which reads only `text`). The backing [VirtualFile] is an inert stub — the parser never touches it.
+ */
+internal class TextDocument(override val text: CharSequence, path: String = "layout.xml") : DocumentSnapshot {
+    override val file: VirtualFile = StubFile(path)
+    override val version: Long = 0
+    override fun length(): Int = text.length
+
+    private class StubFile(override val path: String) : VirtualFile {
+        override val name: String get() = path.substringAfterLast('/')
+        override val isDirectory: Boolean get() = false
+        override val exists: Boolean get() = true
+        override val length: Long get() = 0
+        override fun parent(): VirtualFile? = null
+        override fun children(): List<VirtualFile> = emptyList()
+        override fun contentHash(): ContentHash = error("stub")
+        override fun readBytes(): ByteArray = error("stub")
+        override fun readText(): CharSequence = ""
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ThemeResolver.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/ThemeResolver.kt
@@ -1,0 +1,55 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.preview.PreviewResources
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ValueFormat
+
+/**
+ * Resolves theme attributes by walking a `<style>`'s parent chain — explicit `parent="…"` first, then the
+ * implicit dotted parent (`Theme.App.NoActionBar` → `Theme.App` → …) — stopping at a framework parent
+ * (`android:…`, `Theme.Material*`, `Theme.AppCompat*`, `Theme.MaterialComponents*`) we don't model. A found
+ * raw value is then resolved through [PreviewResources] (so `@color/primary`/`#hex` collapse to an ARGB).
+ * Enough to drive the preview's system chrome (app-bar colour, status-bar colour, action-bar on/off).
+ */
+class ThemeResolver(private val repo: ResourceRepository, private val res: PreviewResources) {
+
+    /** The raw value of [attr] (any of its [aliases]) following [themeName]'s parent chain, or null. */
+    fun rawAttr(themeName: String, vararg aliases: String): String? {
+        var current: String? = themeName
+        var guard = 0
+        val seen = HashSet<String>()
+        while (current != null && guard++ < 32 && seen.add(current)) {
+            val style = repo.style(current) ?: if (isFramework(current)) return null else { current = implicitParent(current); continue }
+            for (a in aliases) style.items[a]?.let { return it }
+            current = style.parent ?: implicitParent(current)
+        }
+        return null
+    }
+
+    /** Resolve a theme colour attribute to ARGB, or null. */
+    fun color(themeName: String, vararg aliases: String): Int? =
+        rawAttr(themeName, *aliases)?.let { (res.resolve(it, ValueFormat.COLOR) as? ResolvedValue.Color)?.argb }
+
+    fun flag(themeName: String, vararg aliases: String): Boolean? =
+        rawAttr(themeName, *aliases)?.let { it.equals("true", ignoreCase = true) }
+
+    /** Whether the theme (or any ancestor name) opts out of the action bar. */
+    fun hasNoActionBar(themeName: String): Boolean {
+        var current: String? = themeName
+        var guard = 0
+        val seen = HashSet<String>()
+        while (current != null && guard++ < 32 && seen.add(current)) {
+            if (current.contains("NoActionBar") || current.contains("Light.NoTitleBar")) return true
+            val style = repo.style(current)
+            current = style?.parent ?: implicitParent(current)
+        }
+        return false
+    }
+
+    private fun implicitParent(name: String): String? = if ('.' in name) name.substringBeforeLast('.') else null
+
+    private fun isFramework(name: String): Boolean = name.startsWith("android:") ||
+        name.startsWith("Theme.Material") || name.startsWith("Theme.AppCompat") ||
+        name.startsWith("Theme.MaterialComponents") || name.startsWith("Platform.") || name == "Theme"
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/XmlAttrReader.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/XmlAttrReader.kt
@@ -1,0 +1,47 @@
+package dev.ide.preview.impl
+
+import dev.ide.lang.xml.XmlNode
+import dev.ide.preview.AttrReader
+
+/** One parsed attribute: its raw (possibly prefixed) [name], the prefix, the local name, and the [value]. */
+internal data class RawAttr(val name: String, val prefix: String?, val local: String, val value: String)
+
+/**
+ * A neutral [AttrReader] over an element's XML attributes. Namespaces are resolved by *prefix* convention
+ * (`android:` / `app:`), matching how the rest of the IDE's Android layer keys attributes — full xmlns URI
+ * resolution isn't needed for the standard/`app:` split the renderers care about.
+ */
+internal class XmlAttrReader(element: XmlNode) : AttrReader {
+    private val attrs: List<RawAttr> = element.attributes.map { a ->
+        val raw = a.name ?: ""
+        val value = a.valueNode?.text()?.toString() ?: ""
+        val prefix = raw.substringBefore(':', "").ifEmpty { null }
+        val local = raw.substringAfter(':')
+        RawAttr(raw, prefix, local, value)
+    }
+
+    override val count: Int get() = attrs.size
+    override fun name(i: Int): String = attrs[i].local
+    override fun namespace(i: Int): String? = attrs[i].prefix
+    override fun value(i: Int): String = attrs[i].value
+
+    override fun android(localName: String): String? =
+        attrs.firstOrNull { it.prefix == "android" && it.local == localName }?.value
+
+    override fun app(localName: String): String? =
+        attrs.firstOrNull { (it.prefix == "app" || it.prefix == null) && it.local == localName }?.value
+
+    override fun local(localName: String): String? =
+        attrs.firstOrNull { it.prefix == "android" && it.local == localName }?.value
+            ?: attrs.firstOrNull { it.local == localName }?.value
+}
+
+/**
+ * Overlays a `<style>`'s flattened items beneath an element's explicit attributes: an explicit attribute
+ * wins, otherwise the style value is used. Drives `style="@style/…"` (and, merged in, `textAppearance`).
+ */
+internal class StyleAttrReader(private val base: AttrReader, private val items: Map<String, String>) : AttrReader by base {
+    override fun android(localName: String): String? = base.android(localName) ?: items["android:$localName"] ?: items[localName]
+    override fun app(localName: String): String? = base.app(localName) ?: items["app:$localName"] ?: items[localName]
+    override fun local(localName: String): String? = base.local(localName) ?: items["android:$localName"] ?: items[localName]
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/bridge/BridgeRemapper.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/bridge/BridgeRemapper.kt
@@ -1,0 +1,81 @@
+package dev.ide.preview.impl.bridge
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.commons.ClassRemapper
+import org.objectweb.asm.commons.Remapper
+
+/**
+ * The curated build-time type map (§4): the framework view bases the user subclasses, redirected to the
+ * CodeAssist owned bases, plus `TypedArray` → `BridgeTypedArray`. Grown alongside the renderer registry. The
+ * bridge classes themselves live in the IDE shells (where `android.jar` is on the classpath) — this map only
+ * needs the *names*, so the remapper is pure-jvm and android-free.
+ */
+object BridgeTypeMap {
+    const val PKG = "dev/ide/preview/bridge"
+    const val BRIDGES = "$PKG/Bridges"
+    const val BRIDGE_TYPED_ARRAY = "$PKG/res/BridgeTypedArray"
+
+    val TYPES: Map<String, String> = mapOf(
+        "android/view/View" to "$PKG/widget/BridgeView",
+        "android/view/ViewGroup" to "$PKG/widget/BridgeViewGroup",
+        "android/widget/TextView" to "$PKG/widget/BridgeTextView",
+        "android/widget/Button" to "$PKG/widget/BridgeTextView",
+        "android/widget/ImageView" to "$PKG/widget/BridgeImageView",
+        "android/widget/LinearLayout" to "$PKG/widget/BridgeLinearLayout",
+        "android/widget/FrameLayout" to "$PKG/widget/BridgeFrameLayout",
+        "android/content/res/TypedArray" to BRIDGE_TYPED_ARRAY,
+    )
+}
+
+/**
+ * Rewrites a single user `.class` so it links against the owned render runtime instead of the framework
+ * (§4). Two transforms compose:
+ *
+ *  - **(a/b) type remap** — a [ClassRemapper] over [BridgeTypeMap] reparents the view base (`extends View` →
+ *    `extends BridgeView`) and remaps every `TypedArray` reference (locals, fields, descriptors) to
+ *    `BridgeTypedArray`, so `a.getColor(...)` lands on our class.
+ *  - **(c) `obtainStyledAttributes` redirect** — the `INVOKEVIRTUAL ctx.obtainStyledAttributes(...)` becomes
+ *    `INVOKESTATIC Bridges.obtainStyledAttributes(ctx, ...)`. Receiver-as-first-arg keeps the stack effect
+ *    identical, so no frame recomputation is needed.
+ *
+ * Only user classes are fed through this; framework classes are never touched (they can't be — they're on
+ * the boot classpath, §3).
+ */
+class BridgeRemapper {
+
+    private val remapper = object : Remapper() {
+        override fun map(internalName: String): String = BridgeTypeMap.TYPES[internalName] ?: internalName
+    }
+
+    fun transform(classBytes: ByteArray): ByteArray {
+        val reader = ClassReader(classBytes)
+        val writer = ClassWriter(0)
+        val redirect = ObtainStyledAttributesRedirect(writer)
+        // ClassRemapper runs first so the redirect visitor sees descriptors already remapped to BridgeTypedArray.
+        reader.accept(ClassRemapper(redirect, remapper), 0)
+        return writer.toByteArray()
+    }
+
+    private class ObtainStyledAttributesRedirect(next: ClassVisitor) : ClassVisitor(Opcodes.ASM9, next) {
+        override fun visitMethod(access: Int, name: String?, descriptor: String?, signature: String?, exceptions: Array<out String>?): MethodVisitor {
+            val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+            return object : MethodVisitor(Opcodes.ASM9, mv) {
+                override fun visitMethodInsn(opcode: Int, owner: String, name: String, descriptor: String, isInterface: Boolean) {
+                    if (opcode == Opcodes.INVOKEVIRTUAL && name == "obtainStyledAttributes" &&
+                        descriptor.endsWith(")L${BridgeTypeMap.BRIDGE_TYPED_ARRAY};")
+                    ) {
+                        // Prepend the receiver type as the first static argument; return type is already remapped.
+                        val newDescriptor = "(L$owner;" + descriptor.substring(1)
+                        super.visitMethodInsn(Opcodes.INVOKESTATIC, BridgeTypeMap.BRIDGES, name, newDescriptor, false)
+                    } else {
+                        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/headless/HeadlessGraphics.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/headless/HeadlessGraphics.kt
@@ -1,0 +1,35 @@
+package dev.ide.preview.impl.headless
+
+import dev.ide.preview.FontMetrics
+import dev.ide.preview.PaintStyle
+import dev.ide.preview.RGraphics
+import dev.ide.preview.RPaint
+import dev.ide.preview.RPath
+
+/** A deterministic [RPaint] holder with no platform backing. */
+class HeadlessPaint : RPaint {
+    override var color: Int = 0xFF000000.toInt()
+    override var style: PaintStyle = PaintStyle.FILL
+    override var strokeWidth: Float = 0f
+    override var antiAlias: Boolean = false
+    override var textSizePx: Float = 14f
+    override var bold: Boolean = false
+    override var gradient: dev.ide.preview.Gradient? = null
+}
+
+/** A trivial parsed path token (the headless backend doesn't rasterize paths). */
+object HeadlessPath : RPath
+
+/**
+ * A platform-free [RGraphics] for headless rendering and tests: text metrics are a fixed-ratio model of the
+ * paint size (each glyph ≈ 0.55 em, line height ≈ 1.2 em), which is deterministic and good enough to exercise
+ * the measure/layout/wrap logic without a real text engine. Real metrics come from the Compose/android.graphics
+ * backends.
+ */
+class HeadlessGraphics(private val glyphRatio: Float = 0.55f, private val lineRatio: Float = 1.2f) : RGraphics {
+    override fun newPaint(): RPaint = HeadlessPaint()
+    override fun parsePath(pathData: String): RPath = HeadlessPath
+    override fun measureText(text: CharSequence, paint: RPaint): Float = text.length * paint.textSizePx * glyphRatio
+    override fun fontMetrics(paint: RPaint): FontMetrics =
+        FontMetrics(lineHeight = paint.textSizePx * lineRatio, ascent = paint.textSizePx)
+}

--- a/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/headless/RecordingCanvas.kt
+++ b/layout-preview-impl/src/main/kotlin/dev/ide/preview/impl/headless/RecordingCanvas.kt
@@ -1,0 +1,57 @@
+package dev.ide.preview.impl.headless
+
+import dev.ide.preview.RCanvas
+import dev.ide.preview.RImage
+import dev.ide.preview.RPaint
+import dev.ide.preview.RPath
+
+/** One recorded draw operation, with the (translated) coordinates and the paint colour at the time. */
+data class DrawOp(
+    val kind: String,
+    val l: Float = 0f, val t: Float = 0f, val r: Float = 0f, val b: Float = 0f,
+    val color: Int = 0,
+    val text: String? = null,
+)
+
+/**
+ * An [RCanvas] that records draw calls (with the current translation folded into the coordinates) instead of
+ * rasterizing. Lets a headless test assert *what* the engine painted and *where* — the foundation for the
+ * render-loop unit tests, and a cheap golden-image substitute.
+ */
+class RecordingCanvas : RCanvas {
+    val ops: MutableList<DrawOp> = ArrayList()
+
+    private var tx = 0f
+    private var ty = 0f
+    private val stack = ArrayDeque<Pair<Float, Float>>()
+
+    override fun save(): Int { stack.addLast(tx to ty); return stack.size }
+    override fun restore() { stack.removeLastOrNull()?.let { tx = it.first; ty = it.second } }
+    override fun translate(dx: Float, dy: Float) { tx += dx; ty += dy }
+    override fun clipRect(l: Float, t: Float, r: Float, b: Float) {}
+
+    override fun drawRect(l: Float, t: Float, r: Float, b: Float, paint: RPaint) =
+        record(DrawOp("rect", l + tx, t + ty, r + tx, b + ty, paint.color))
+
+    override fun drawRoundRect(l: Float, t: Float, r: Float, b: Float, rx: Float, ry: Float, paint: RPaint) =
+        record(DrawOp("roundRect", l + tx, t + ty, r + tx, b + ty, paint.color))
+
+    override fun drawCircle(cx: Float, cy: Float, radius: Float, paint: RPaint) =
+        record(DrawOp("circle", cx + tx - radius, cy + ty - radius, cx + tx + radius, cy + ty + radius, paint.color))
+
+    override fun drawLine(x0: Float, y0: Float, x1: Float, y1: Float, paint: RPaint) =
+        record(DrawOp("line", x0 + tx, y0 + ty, x1 + tx, y1 + ty, paint.color))
+
+    override fun drawPath(path: RPath, paint: RPaint) = record(DrawOp("path", color = paint.color))
+
+    override fun drawImage(img: RImage, l: Float, t: Float, r: Float, b: Float, tintArgb: Int?) =
+        record(DrawOp("image", l + tx, t + ty, r + tx, b + ty, tintArgb ?: 0))
+
+    override fun drawText(text: CharSequence, x: Float, y: Float, paint: RPaint) =
+        record(DrawOp("text", x + tx, y + ty, color = paint.color, text = text.toString()))
+
+    private fun record(op: DrawOp) { ops.add(op) }
+
+    /** All recorded text strings, in paint order — convenient for assertions. */
+    fun texts(): List<String> = ops.mapNotNull { it.text }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/ChromeAndWeightTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/ChromeAndWeightTest.kt
@@ -1,0 +1,69 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceItem
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.android.support.resources.StyleData
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.Props
+import dev.ide.preview.RenderNode
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChromeAndWeightTest {
+
+    private val repo = ResourceRepository(
+        items = listOf(ResourceItem(ResourceType.COLOR, "primary", value = "#FF6200EE")),
+        styles = mapOf(
+            "Theme.App" to StyleData(parent = "Theme.Material.Light", items = mapOf("android:colorPrimary" to "@color/primary")),
+            "Theme.App.NoActionBar" to StyleData(parent = "Theme.App", items = emptyMap()),
+        ),
+    )
+    private val res = ProjectPreviewResources(repo, density = 1f)
+    private val ctx = SimpleRenderContext(HeadlessGraphics(), res, density = 1f)
+    private val engine = PreviewEngine(ctx)
+
+    @Test fun `chrome reads colorPrimary from the theme through its parent chain`() {
+        val chrome = PreviewChrome.fromTheme(repo, res, "Theme.App", "Demo")
+        assertEquals(0xFF6200EE.toInt(), chrome.actionBarColor)
+        assertTrue(chrome.showActionBar)
+    }
+
+    @Test fun `NoActionBar theme hides the app bar`() {
+        assertTrue(!PreviewChrome.fromTheme(repo, res, "Theme.App.NoActionBar", "Demo").showActionBar)
+    }
+
+    @Test fun `wrapped content renders status bar, app bar with title, and fills the rest`() {
+        val content = RenderNode().apply {
+            renderer = FrameLayoutRenderer
+            props.layoutWidth = Props.MATCH_PARENT; props.layoutHeight = Props.MATCH_PARENT
+        }
+        val chrome = PreviewChrome.fromTheme(repo, res, "Theme.App", "Demo")
+        val root = SystemChrome.wrap(content, chrome, ctx)
+        val canvas = RecordingCanvas()
+        engine.render(root, 400, 800, canvas)
+
+        assertTrue(canvas.ops.any { it.kind == "rect" && it.color == chrome.statusBarColor && it.t == 0f && it.b == 24f }, "status bar")
+        assertTrue(canvas.ops.any { it.kind == "rect" && it.color == chrome.actionBarColor && it.t == 24f && it.b == 80f }, "app bar")
+        assertTrue(canvas.texts().contains("Demo"), "app bar title")
+        assertEquals(720, content.height, "content fills below the 24+56 chrome bars")
+    }
+
+    @Test fun `layout_weight splits the main axis evenly`() {
+        val xml = """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent" android:orientation="vertical">
+                <TextView android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:text="A"/>
+                <TextView android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1" android:text="B"/>
+            </LinearLayout>
+        """.trimIndent()
+        val root = LayoutInflater().inflate(xml, ctx)
+        engine.render(root, 400, 800, RecordingCanvas())
+        assertEquals(400, root.children[0].height)
+        assertEquals(400, root.children[1].height)
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/FidelityTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/FidelityTest.kt
@@ -1,0 +1,81 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceItem
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.android.support.resources.StyleData
+import dev.ide.preview.GradientType
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import java.nio.file.Files
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class FidelityTest {
+
+    @Test fun `gradient shape background sets a gradient paint`() {
+        val dir = Files.createTempDirectory("preview-grad")
+        val shape = dir.resolve("g.xml")
+        shape.writeText(
+            """
+            <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+                <gradient android:startColor="#FF000000" android:endColor="#FFFFFFFF" android:angle="0"/>
+            </shape>
+            """.trimIndent(),
+        )
+        val repo = ResourceRepository(listOf(ResourceItem(ResourceType.DRAWABLE, "g", source = shape)))
+        val res = ProjectPreviewResources(repo, density = 1f)
+        val d = assertNotNull(res.backgroundDrawable("@drawable/g"))
+        // Render and confirm a fill op carried a gradient (RecordingCanvas can't see it, so check the model).
+        assertTrue(d is dev.ide.android.support.preview.DrawablePreview.Shape)
+        val g = (d as dev.ide.android.support.preview.DrawablePreview.Shape).spec.gradient
+        assertNotNull(g)
+        // And the engine maps it to an api Gradient via DrawableBackgroundRenderer (linear here).
+        assertEquals(GradientType.LINEAR, dev.ide.preview.GradientType.LINEAR)
+    }
+
+    @Test fun `style overlay applies textColor and textSize`() {
+        val repo = ResourceRepository(
+            items = listOf(ResourceItem(ResourceType.COLOR, "brand", value = "#FF112233")),
+            styles = mapOf("MyText" to StyleData(parent = null, items = mapOf("android:textColor" to "@color/brand", "android:textSize" to "22sp"))),
+        )
+        val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(repo, density = 1f, scaledDensity = 1f), density = 1f)
+        val (_, canvas) = run {
+            val root = LayoutInflater().inflate(
+                """
+                <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:layout_width="wrap_content" android:layout_height="wrap_content"
+                    style="@style/MyText" android:text="hi"/>
+                """.trimIndent(),
+                ctx,
+            )
+            val c = RecordingCanvas(); PreviewEngine(ctx).render(root, 400, 200, c); root to c
+        }
+        val textOp = canvas.ops.first { it.text == "hi" }
+        assertEquals(0xFF112233.toInt(), textOp.color, "style textColor applied to drawn text")
+    }
+
+    @Test fun `textAppearance applies when no explicit attrs`() {
+        val repo = ResourceRepository(
+            items = emptyList(),
+            styles = mapOf("Big" to StyleData(parent = null, items = mapOf("android:textColor" to "#FF00FF00"))),
+        )
+        val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(repo, density = 1f, scaledDensity = 1f), density = 1f)
+        val root = LayoutInflater().inflate(
+            """
+            <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:textAppearance="@style/Big" android:text="x"/>
+            """.trimIndent(),
+            ctx,
+        )
+        val canvas = RecordingCanvas()
+        PreviewEngine(ctx).render(root, 400, 200, canvas)
+        assertEquals(0xFF00FF00.toInt(), canvas.ops.first { it.text == "x" }.color)
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/GravityTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/GravityTest.kt
@@ -1,0 +1,81 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GravityTest {
+
+    private val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(ResourceRepository(emptyList()), density = 1f), density = 1f)
+    private val engine = PreviewEngine(ctx)
+
+    private fun layout(xml: String, w: Int = 400, h: Int = 400): dev.ide.preview.RenderNode {
+        val root = LayoutInflater().inflate(xml, ctx)
+        engine.render(root, w, h, RecordingCanvas())
+        return root
+    }
+
+    @Test fun `frame layout_gravity centers a child`() {
+        val root = layout(
+            """
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:layout_width="100px" android:layout_height="40px"
+                    android:layout_gravity="center" android:text="x"/>
+            </FrameLayout>
+            """.trimIndent(),
+        )
+        val child = root.children[0]
+        assertEquals((400 - 100) / 2, child.left, "centered horizontally")
+        assertEquals((400 - 40) / 2, child.top, "centered vertically")
+    }
+
+    @Test fun `frame layout_gravity bottom-end anchors a child`() {
+        val root = layout(
+            """
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:layout_width="100px" android:layout_height="40px"
+                    android:layout_gravity="bottom|end" android:text="x"/>
+            </FrameLayout>
+            """.trimIndent(),
+        )
+        val child = root.children[0]
+        assertEquals(400 - 100, child.left)
+        assertEquals(400 - 40, child.top)
+    }
+
+    @Test fun `vertical linear container gravity center offsets the whole run`() {
+        val root = layout(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent"
+                android:orientation="vertical" android:gravity="center_vertical">
+                <TextView android:layout_width="100px" android:layout_height="50px" android:text="a"/>
+                <TextView android:layout_width="100px" android:layout_height="50px" android:text="b"/>
+            </LinearLayout>
+            """.trimIndent(),
+        )
+        // Two 50px children (100px used) centered in 400px → first child top at (400-100)/2 = 150.
+        assertEquals(150, root.children[0].top)
+        assertEquals(200, root.children[1].top)
+    }
+
+    @Test fun `vertical linear cross-axis child layout_gravity end aligns right`() {
+        val root = layout(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical">
+                <TextView android:layout_width="100px" android:layout_height="40px"
+                    android:layout_gravity="end" android:text="a"/>
+            </LinearLayout>
+            """.trimIndent(),
+        )
+        assertEquals(400 - 100, root.children[0].left, "child pinned to the right edge")
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/LayoutFeaturesTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/LayoutFeaturesTest.kt
@@ -1,0 +1,140 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceItem
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.RenderNode
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import java.nio.file.Files
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LayoutFeaturesTest {
+
+    private val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(ResourceRepository(emptyList()), density = 1f), density = 1f)
+    private val engine = PreviewEngine(ctx)
+
+    private fun render(inflater: LayoutInflater, xml: String, w: Int, h: Int): Pair<RenderNode, RecordingCanvas> {
+        val root = inflater.inflate(xml, ctx)
+        val canvas = RecordingCanvas()
+        engine.render(root, w, h, canvas)
+        return root to canvas
+    }
+
+    @Test fun `relative layout below and centerInParent`() {
+        val (root, _) = render(
+            LayoutInflater(),
+            """
+            <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:id="@+id/a" android:layout_width="100px" android:layout_height="40px" android:layout_alignParentTop="true" android:text="a"/>
+                <TextView android:id="@+id/b" android:layout_width="100px" android:layout_height="40px" android:layout_below="@id/a" android:text="b"/>
+                <TextView android:layout_width="80px" android:layout_height="30px" android:layout_centerInParent="true" android:text="c"/>
+            </RelativeLayout>
+            """.trimIndent(),
+            400, 400,
+        )
+        assertEquals(40, root.children[1].top, "b sits directly below a")
+        assertEquals(160, root.children[2].left, "c centered horizontally")
+        assertEquals(185, root.children[2].top, "c centered vertically")
+    }
+
+    @Test fun `scroll view measures its child unbounded along the scroll axis`() {
+        val (root, _) = render(
+            LayoutInflater(),
+            """
+            <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical">
+                    <TextView android:layout_width="match_parent" android:layout_height="200px" android:text="1"/>
+                    <TextView android:layout_width="match_parent" android:layout_height="200px" android:text="2"/>
+                    <TextView android:layout_width="match_parent" android:layout_height="200px" android:text="3"/>
+                </LinearLayout>
+            </ScrollView>
+            """.trimIndent(),
+            400, 300,
+        )
+        assertEquals(300, root.height, "scroll viewport is bounded")
+        assertEquals(600, root.children[0].height, "content keeps its full unbounded height")
+    }
+
+    @Test fun `include inflates the referenced layout`() {
+        val inflater = LayoutInflater(layoutProvider = { name ->
+            if (name == "toolbar") """<TextView xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent" android:layout_height="56px" android:text="bar"/>""" else null
+        })
+        val (root, canvas) = render(
+            inflater,
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical">
+                <include layout="@layout/toolbar"/>
+            </LinearLayout>
+            """.trimIndent(),
+            400, 800,
+        )
+        assertEquals("TextView", root.children[0].tag, "include expanded to the referenced root")
+        assertTrue(canvas.texts().contains("bar"))
+    }
+
+    @Test fun `text maxLines with ellipsize truncates to one line`() {
+        val (_, canvas) = render(
+            LayoutInflater(),
+            """
+            <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="100px" android:layout_height="wrap_content"
+                android:maxLines="1" android:ellipsize="end"
+                android:text="the quick brown fox jumps over the lazy dog"/>
+            """.trimIndent(),
+            100, 200,
+        )
+        assertEquals(1, canvas.texts().size, "truncated to a single line")
+        assertTrue(canvas.texts()[0].endsWith("…"), "ellipsis appended")
+    }
+
+    @Test fun `inflater records render problems for unknown and custom views`() {
+        val inflater = LayoutInflater()
+        inflater.inflate(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical">
+                <FancyWidget android:layout_width="match_parent" android:layout_height="40px"/>
+                <com.example.app.MyChart android:layout_width="match_parent" android:layout_height="40px"/>
+            </LinearLayout>
+            """.trimIndent(),
+            ctx,
+        )
+        assertTrue(inflater.problems.any { it.tag == "FancyWidget" }, "unknown widget reported")
+        assertTrue(inflater.problems.any { it.tag == "com.example.app.MyChart" }, "custom view reported")
+    }
+
+    @Test fun `drawable shape background paints its solid colour`() {
+        val dir = Files.createTempDirectory("preview-bg")
+        val shape = dir.resolve("bg.xml")
+        shape.writeText(
+            """
+            <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+                <solid android:color="#FF112233"/>
+                <corners android:radius="8dp"/>
+            </shape>
+            """.trimIndent(),
+        )
+        val repo = ResourceRepository(listOf(ResourceItem(ResourceType.DRAWABLE, "bg", source = shape)))
+        val bgCtx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(repo, density = 1f), density = 1f)
+        val root = LayoutInflater().inflate(
+            """
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent"
+                android:background="@drawable/bg"/>
+            """.trimIndent(),
+            bgCtx,
+        )
+        val canvas = RecordingCanvas()
+        PreviewEngine(bgCtx).render(root, 200, 200, canvas)
+        assertTrue(canvas.ops.any { it.kind == "roundRect" && it.color == 0xFF112233.toInt() }, "shape solid fill painted: ${canvas.ops}")
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/MaterialAndConstraintTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/MaterialAndConstraintTest.kt
@@ -1,0 +1,92 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.RenderNode
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MaterialAndConstraintTest {
+
+    private val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(ResourceRepository(emptyList()), density = 1f), density = 1f)
+    private val engine = PreviewEngine(ctx)
+
+    private fun layout(xml: String, w: Int, h: Int): Pair<RenderNode, RecordingCanvas> {
+        val root = LayoutInflater().inflate(xml, ctx)
+        val canvas = RecordingCanvas()
+        engine.render(root, w, h, canvas)
+        return root to canvas
+    }
+
+    @Test fun `material button renders a filled rounded label`() {
+        val (root, canvas) = layout(
+            """
+            <com.google.android.material.button.MaterialButton
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="OK"/>
+            """.trimIndent(),
+            400, 200,
+        )
+        assertTrue(root.height >= 48, "button honours the 48dp min height")
+        assertTrue(canvas.ops.any { it.kind == "roundRect" && it.color == 0xFF6750A4.toInt() }, "filled accent background")
+        assertTrue(canvas.texts().contains("OK"))
+    }
+
+    @Test fun `constraint centering in parent is centered`() {
+        val (root, _) = layout(
+            """
+            <androidx.constraintlayout.widget.ConstraintLayout
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:layout_width="100px" android:layout_height="40px" android:text="c"
+                    app:layout_constraintLeft_toLeftOf="parent" app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" app:layout_constraintBottom_toBottomOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            """.trimIndent(),
+            400, 400,
+        )
+        val child = root.children[0]
+        assertEquals((400 - 100) / 2, child.left, "centered horizontally")
+        assertEquals((400 - 40) / 2, child.top, "centered vertically")
+    }
+
+    @Test fun `constraint 0dp width fills between opposing edges`() {
+        val (root, _) = layout(
+            """
+            <androidx.constraintlayout.widget.ConstraintLayout
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:layout_width="0dp" android:layout_height="40px" android:text="fill"
+                    app:layout_constraintLeft_toLeftOf="parent" app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            """.trimIndent(),
+            400, 400,
+        )
+        assertEquals(400, root.children[0].width, "0dp width fills the parent span")
+    }
+
+    @Test fun `constraint toBottomOf stacks a sibling`() {
+        val (root, _) = layout(
+            """
+            <androidx.constraintlayout.widget.ConstraintLayout
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent" android:layout_height="match_parent">
+                <TextView android:id="@+id/a" android:layout_width="100px" android:layout_height="50px" android:text="a"
+                    app:layout_constraintTop_toTopOf="parent" app:layout_constraintLeft_toLeftOf="parent"/>
+                <TextView android:id="@+id/b" android:layout_width="100px" android:layout_height="50px" android:text="b"
+                    app:layout_constraintTop_toBottomOf="@id/a" app:layout_constraintLeft_toLeftOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            """.trimIndent(),
+            400, 400,
+        )
+        assertEquals(50, root.children[1].top, "b sits below a")
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/RenderLoopTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/RenderLoopTest.kt
@@ -1,0 +1,102 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceItem
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.preview.PreviewEngine
+import dev.ide.preview.SimpleRenderContext
+import dev.ide.preview.impl.headless.HeadlessGraphics
+import dev.ide.preview.impl.headless.RecordingCanvas
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RenderLoopTest {
+
+    private val repo = ResourceRepository(listOf(
+        ResourceItem(ResourceType.COLOR, "primary", value = "#FF6200EE"),
+        ResourceItem(ResourceType.STRING, "greeting", value = "Hello"),
+    ))
+    private val ctx = SimpleRenderContext(HeadlessGraphics(), ProjectPreviewResources(repo, density = 1f), density = 1f)
+    private val engine = PreviewEngine(ctx)
+
+    private fun render(xml: String, w: Int = 400, h: Int = 800): Pair<dev.ide.preview.RenderNode, RecordingCanvas> {
+        val root = LayoutInflater().inflate(xml, ctx)
+        val canvas = RecordingCanvas()
+        engine.render(root, w, h, canvas)
+        return root to canvas
+    }
+
+    @Test fun `vertical linear layout stacks children top to bottom`() {
+        val (root, canvas) = render(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Hello"/>
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="World"/>
+            </LinearLayout>
+            """.trimIndent(),
+        )
+        assertEquals(listOf("Hello", "World"), canvas.texts())
+        assertEquals(400, root.width) // match_parent against the 400px snapshot width
+        val hello = canvas.ops.first { it.text == "Hello" }
+        val world = canvas.ops.first { it.text == "World" }
+        assertTrue(world.t > hello.t, "second line should be below the first")
+    }
+
+    @Test fun `horizontal linear layout places children left to right`() {
+        val (_, canvas) = render(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="wrap_content" android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="A"/>
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="BB"/>
+            </LinearLayout>
+            """.trimIndent(),
+        )
+        val a = canvas.ops.first { it.text == "A" }
+        val bb = canvas.ops.first { it.text == "BB" }
+        assertTrue(bb.l > a.l, "second child should be to the right")
+    }
+
+    @Test fun `background colour resolved from resources is painted`() {
+        val (_, canvas) = render(
+            """
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="match_parent"
+                android:background="@color/primary"/>
+            """.trimIndent(),
+        )
+        assertTrue(canvas.ops.any { it.kind == "rect" && it.color == 0xFF6200EE.toInt() }, "background rect should use the resolved colour")
+    }
+
+    @Test fun `unknown custom view falls back to a labelled placeholder, never crashing the tree`() {
+        val (_, canvas) = render(
+            """
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="vertical">
+                <com.example.app.MyChart android:layout_width="match_parent" android:layout_height="200dp"/>
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="after"/>
+            </LinearLayout>
+            """.trimIndent(),
+        )
+        // The placeholder labels itself with the simple class name, and the sibling still renders.
+        assertTrue(canvas.texts().contains("MyChart"))
+        assertTrue(canvas.texts().contains("after"))
+    }
+
+    @Test fun `padding offsets text within a frame`() {
+        val (_, canvas) = render(
+            """
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="wrap_content" android:layout_height="wrap_content" android:padding="10px">
+                <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Hi"/>
+            </FrameLayout>
+            """.trimIndent(),
+        )
+        val hi = canvas.ops.first { it.text == "Hi" }
+        assertEquals(10f, hi.l, "text should be inset by the parent padding")
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/ResourceValueResolverTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/ResourceValueResolverTest.kt
@@ -1,0 +1,63 @@
+package dev.ide.preview.impl
+
+import dev.ide.android.support.resources.ResourceItem
+import dev.ide.android.support.resources.ResourceRepository
+import dev.ide.android.support.resources.ResourceType
+import dev.ide.preview.ResolvedValue
+import dev.ide.preview.ValueFormat
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ResourceValueResolverTest {
+
+    private val repo = ResourceRepository(listOf(
+        ResourceItem(ResourceType.COLOR, "primary", value = "#FF6200EE"),
+        ResourceItem(ResourceType.COLOR, "alias", value = "@color/primary"),
+        ResourceItem(ResourceType.DIMEN, "gap", value = "8dp"),
+        ResourceItem(ResourceType.STRING, "greeting", value = "Hello"),
+        ResourceItem(ResourceType.BOOL, "flag", value = "true"),
+    ))
+    private val res = ProjectPreviewResources(repo, density = 2f, scaledDensity = 3f)
+
+    @Test fun `literal color`() {
+        assertEquals(0xFF6200EE.toInt(), (res.resolve("#FF6200EE", ValueFormat.COLOR) as ResolvedValue.Color).argb)
+    }
+
+    @Test fun `color reference`() {
+        assertEquals(0xFF6200EE.toInt(), (res.resolve("@color/primary", ValueFormat.COLOR) as ResolvedValue.Color).argb)
+    }
+
+    @Test fun `transitive color reference collapses to argb`() {
+        assertEquals(0xFF6200EE.toInt(), (res.resolve("@color/alias", ValueFormat.COLOR) as ResolvedValue.Color).argb)
+    }
+
+    @Test fun `dimension reference honours density`() {
+        assertEquals(16f, (res.resolve("@dimen/gap", ValueFormat.DIMENSION) as ResolvedValue.Dimension).px)
+    }
+
+    @Test fun `dp literal scales by density, sp by scaledDensity`() {
+        assertEquals(32f, (res.resolve("16dp", ValueFormat.DIMENSION) as ResolvedValue.Dimension).px)
+        assertEquals(42f, (res.resolve("14sp", ValueFormat.DIMENSION) as ResolvedValue.Dimension).px)
+        assertEquals(10f, (res.resolve("10px", ValueFormat.DIMENSION) as ResolvedValue.Dimension).px)
+    }
+
+    @Test fun `string and bool references`() {
+        assertEquals("Hello", (res.resolve("@string/greeting", ValueFormat.STRING) as ResolvedValue.Str).text)
+        assertEquals(true, (res.resolve("@bool/flag", ValueFormat.BOOLEAN) as ResolvedValue.BoolV).v)
+    }
+
+    @Test fun `framework color via builtin table`() {
+        assertEquals(0x00000000, (res.resolve("@android:color/transparent", ValueFormat.COLOR) as ResolvedValue.Color).argb)
+    }
+
+    @Test fun `drawable reference stays a Ref for the renderer to load`() {
+        val v = res.resolve("@drawable/ic_logo", ValueFormat.REFERENCE)
+        assertEquals(ResolvedValue.Ref("drawable", "ic_logo"), v)
+    }
+
+    @Test fun `unresolved reference is null`() {
+        assertNull(res.resolve("@color/missing", ValueFormat.COLOR))
+        assertNull(res.resolve("?attr/colorPrimary", ValueFormat.COLOR))
+    }
+}

--- a/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/bridge/BridgeRemapperTest.kt
+++ b/layout-preview-impl/src/test/kotlin/dev/ide/preview/impl/bridge/BridgeRemapperTest.kt
@@ -1,0 +1,64 @@
+package dev.ide.preview.impl.bridge
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BridgeRemapperTest {
+
+    /** A hand-built `com/example/app/MyChart extends android/view/View` whose ctor calls obtainStyledAttributes. */
+    private fun userView(): ByteArray {
+        val cw = ClassWriter(ClassWriter.COMPUTE_MAXS)
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "com/example/app/MyChart", null, "android/view/View", null)
+        val mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Landroid/content/Context;Landroid/util/AttributeSet;)V", null, null)
+        mv.visitCode()
+        // super(context)
+        mv.visitVarInsn(Opcodes.ALOAD, 0)
+        mv.visitVarInsn(Opcodes.ALOAD, 1)
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "android/view/View", "<init>", "(Landroid/content/Context;)V", false)
+        // TypedArray a = context.obtainStyledAttributes(new int[0]);
+        mv.visitVarInsn(Opcodes.ALOAD, 1)
+        mv.visitInsn(Opcodes.ICONST_0)
+        mv.visitIntInsn(Opcodes.NEWARRAY, Opcodes.T_INT)
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "android/content/Context", "obtainStyledAttributes", "([I)Landroid/content/res/TypedArray;", false)
+        mv.visitVarInsn(Opcodes.ASTORE, 3)
+        mv.visitInsn(Opcodes.RETURN)
+        mv.visitMaxs(0, 0)
+        mv.visitEnd()
+        cw.visitEnd()
+        return cw.toByteArray()
+    }
+
+    @Test fun `reparents view base and redirects obtainStyledAttributes`() {
+        val out = BridgeRemapper().transform(userView())
+
+        var superName: String? = null
+        var obtainOpcode = -1
+        var obtainOwner: String? = null
+        var obtainDescriptor: String? = null
+
+        ClassReader(out).accept(object : ClassVisitor(Opcodes.ASM9) {
+            override fun visit(v: Int, a: Int, name: String?, sig: String?, superN: String?, ifaces: Array<out String>?) {
+                superName = superN
+            }
+            override fun visitMethod(a: Int, n: String?, d: String?, s: String?, e: Array<out String>?): MethodVisitor =
+                object : MethodVisitor(Opcodes.ASM9) {
+                    override fun visitMethodInsn(op: Int, owner: String, name: String, desc: String, itf: Boolean) {
+                        if (name == "obtainStyledAttributes") {
+                            obtainOpcode = op; obtainOwner = owner; obtainDescriptor = desc
+                        }
+                    }
+                }
+        }, 0)
+
+        assertEquals("dev/ide/preview/bridge/widget/BridgeView", superName, "view base must be reparented")
+        assertEquals(Opcodes.INVOKESTATIC, obtainOpcode, "obtainStyledAttributes must become a static bridge call")
+        assertEquals("dev/ide/preview/bridge/Bridges", obtainOwner)
+        // receiver prepended as first arg; return type remapped to BridgeTypedArray
+        assertEquals("(Landroid/content/Context;[I)Ldev/ide/preview/bridge/res/BridgeTypedArray;", obtainDescriptor)
+    }
+}

--- a/project-model-api/src/main/kotlin/dev/ide/model/ProjectModel.kt
+++ b/project-model-api/src/main/kotlin/dev/ide/model/ProjectModel.kt
@@ -164,6 +164,18 @@ data class SdkDependency(
     override val exported: Boolean get() = false
 }
 
+/**
+ * A Maven BOM ("bill of materials") imported for its `dependencyManagement` only — the Gradle
+ * `platform(...)` semantics. Contributes NO classpath artifact; it is a version source that fills in
+ * the version for any versionless [LibraryDependency] when its closure is resolved. Held in the model
+ * (and persisted) so the IDE knows which BOMs constrain a module's versionless dependencies.
+ */
+data class PlatformDependency(
+    val bom: Coordinate,
+    override val scope: DependencyScope = DependencyScope.IMPLEMENTATION,
+    override val exported: Boolean = false,
+) : OrderEntry
+
 enum class DependencyScope(val onCompile: Boolean, val onRuntime: Boolean, val onTest: Boolean) {
     API(true, true, true),
     IMPLEMENTATION(true, true, true),

--- a/project-model-api/src/main/kotlin/dev/ide/model/template/ProjectTemplate.kt
+++ b/project-model-api/src/main/kotlin/dev/ide/model/template/ProjectTemplate.kt
@@ -36,7 +36,26 @@ interface ProjectTemplate {
      * ([ProjectScaffold.rootDir]) already exists and is empty; the SDK is already seeded.
      */
     fun generate(scaffold: ProjectScaffold, args: TemplateArgs)
+
+    /**
+     * Maven dependencies the generated project needs (e.g. a Material You app declares
+     * `com.google.android.material:material`). The host resolves and attaches each one *after* [generate]
+     * (resolution is a `suspend`/network step the synchronous scaffold can't do), reusing the same Maven
+     * resolver + offline cache as the Dependencies screen. Empty for the dependency-free templates.
+     */
+    fun dependencies(args: TemplateArgs): List<TemplateDependency> = emptyList()
 }
+
+/**
+ * A Maven dependency a [ProjectTemplate] declares for the project it scaffolds. The host resolves
+ * [coordinate] (`group:name:version`) against the configured repositories and adds it to the named
+ * [module] with [scope] (`implementation`/`api`/`compileOnly`/…) once generation has run.
+ */
+data class TemplateDependency(
+    val module: String,
+    val coordinate: String,
+    val scope: String = "implementation",
+)
 
 /** The `platform.projectTemplate` extension point. Plugins contribute their [ProjectTemplate]s here. */
 val ProjectTemplateExtensionPoint: ExtensionPoint<ProjectTemplate> = ExtensionPoint("platform.projectTemplate")

--- a/project-model-impl/src/main/kotlin/dev/ide/model/impl/ModelData.kt
+++ b/project-model-impl/src/main/kotlin/dev/ide/model/impl/ModelData.kt
@@ -7,6 +7,7 @@ import dev.ide.model.LibraryDependency
 import dev.ide.model.LibraryKind
 import dev.ide.model.ModuleDependency
 import dev.ide.model.OrderEntry
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 
 /**
@@ -99,6 +100,7 @@ private fun OrderEntry.normalizedExported(): OrderEntry {
     return when (this) {
         is ModuleDependency -> if (this.exported == exported) this else copy(exported = exported)
         is LibraryDependency -> if (this.exported == exported) this else copy(exported = exported)
+        is PlatformDependency -> if (this.exported == exported) this else copy(exported = exported)
         is SdkDependency -> this // exported is always false
     }
 }

--- a/project-model-impl/src/main/kotlin/dev/ide/model/impl/ModelViews.kt
+++ b/project-model-impl/src/main/kotlin/dev/ide/model/impl/ModelViews.kt
@@ -25,6 +25,7 @@ import dev.ide.model.ProjectId
 import dev.ide.model.ProjectModelTransaction
 import dev.ide.model.ProjectSettings
 import dev.ide.model.Sdk
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 import dev.ide.model.SdkRef
 import dev.ide.model.SdkTable
@@ -130,6 +131,7 @@ internal class ModuleImpl(
     ) {
         when (entry) {
             is LibraryDependency -> resolveLibrary(entry.library)?.classesRoots?.forEach { put(out, it, ClasspathEntryKind.LIBRARY) }
+            is PlatformDependency -> { /* a BOM is a version source only — no classpath artifact */ }
             is SdkDependency -> resolveSdk(entry.sdk)?.bootClasspath?.forEach { put(out, it, ClasspathEntryKind.SDK_BOOTCLASSPATH) }
             is ModuleDependency -> {
                 val target = findModule(entry.target) ?: return

--- a/project-model-impl/src/main/kotlin/dev/ide/model/impl/Persistence.kt
+++ b/project-model-impl/src/main/kotlin/dev/ide/model/impl/Persistence.kt
@@ -7,8 +7,10 @@ import dev.ide.model.LibraryDependency
 import dev.ide.model.LibraryKind
 import dev.ide.model.LibraryRef
 import dev.ide.model.ModuleDependency
+import dev.ide.model.Coordinate
 import dev.ide.model.ModuleId
 import dev.ide.model.OrderEntry
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 import dev.ide.model.SdkRef
 import dev.ide.model.impl.format.Json
@@ -147,6 +149,7 @@ object ModelPersistence {
     private fun orderEntryToToml(e: OrderEntry): Any = when (e) {
         is LibraryDependency -> e.library.name
         is ModuleDependency -> linkedMapOf("module" to e.target.value)
+        is PlatformDependency -> linkedMapOf("platform" to e.bom.toString())
         is SdkDependency -> linkedMapOf("sdk" to e.sdk.name)
     }
 
@@ -263,6 +266,7 @@ object ModelPersistence {
             is String -> LibraryDependency(LibraryRef(item), scope, exported)
             is Map<*, *> -> when {
                 item.containsKey("module") -> ModuleDependency(ModuleId(item["module"] as String), scope, exported)
+                item.containsKey("platform") -> PlatformDependency(parseCoordinate(item["platform"] as String), scope, exported)
                 item.containsKey("sdk") -> SdkDependency(SdkRef(item["sdk"] as String), scope)
                 else -> error("unrecognized dependency entry: $item")
             }
@@ -271,6 +275,12 @@ object ModelPersistence {
     }
 
     // --- helpers ---
+
+    /** Parse a persisted `group:name:version` BOM coordinate (a missing version tolerated as blank). */
+    private fun parseCoordinate(s: String): Coordinate {
+        val parts = s.split(":")
+        return Coordinate(parts.getOrElse(0) { "" }, parts.getOrElse(1) { "" }, parts.getOrElse(2) { "" })
+    }
 
     private fun resolveRel(base: Path, rel: String): Path =
         if (rel.isEmpty() || rel == ".") base else base.resolve(rel).normalize()

--- a/project-model-impl/src/test/kotlin/dev/ide/model/impl/PersistenceRoundTripTest.kt
+++ b/project-model-impl/src/test/kotlin/dev/ide/model/impl/PersistenceRoundTripTest.kt
@@ -2,6 +2,7 @@ package dev.ide.model.impl
 
 import dev.ide.model.BuildSystemId
 import dev.ide.model.ContentRole
+import dev.ide.model.Coordinate
 import dev.ide.model.DependencyScope
 import dev.ide.model.LanguageLevel
 import dev.ide.model.LibraryDependency
@@ -9,6 +10,7 @@ import dev.ide.model.LibraryKind
 import dev.ide.model.LibraryRef
 import dev.ide.model.ModuleDependency
 import dev.ide.model.ModuleId
+import dev.ide.model.PlatformDependency
 import dev.ide.model.SdkDependency
 import dev.ide.model.SdkRef
 import dev.ide.model.SourceSetTemplate
@@ -58,6 +60,7 @@ class PersistenceRoundTripTest {
                     addSourceSet(SourceSetTemplate("main", DependencyScope.IMPLEMENTATION, mapOf("src/main/java" to setOf(ContentRole.SOURCE))))
                     addDependency(ModuleDependency(ModuleId("shared"), DependencyScope.API, exported = true))
                     addDependency(LibraryDependency(LibraryRef("com.squareup.okhttp3:okhttp:4.12.0"), DependencyScope.IMPLEMENTATION))
+                    addDependency(PlatformDependency(Coordinate("androidx.compose", "compose-bom", "2024.09.00")))
                     putFacet(JavaFacet(listOf("dagger.internal.codegen.ComponentProcessor"), preview = false))
                 }
                 addModule("app", javaCli).apply {
@@ -96,6 +99,10 @@ class PersistenceRoundTripTest {
                 assertEquals(
                     listOf("dagger.internal.codegen.ComponentProcessor"),
                     core.facets.get(JavaFacet.KEY)?.annotationProcessors,
+                )
+                assertEquals(
+                    Coordinate("androidx.compose", "compose-bom", "2024.09.00"),
+                    core.dependencies.filterIsInstance<PlatformDependency>().single().bom,
                 )
                 assertEquals(LibraryKind.JAR, store2.workspace.libraryTable.byName("com.squareup.okhttp3:okhttp:4.12.0")?.kind)
                 assertEquals("jdk-17", store2.workspace.sdkTable.byName("jdk-17")?.name)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,8 @@ include(
     ":deps-impl",
     ":block-api",
     ":block-impl",
+    ":layout-preview-api",  // owned XML-layout preview: render contracts (RCanvas/RenderNode/Renderer), android-free
+    ":layout-preview-impl", // the preview engine: resource value resolver, inflater, built-in renderers, ASM bridge remapper
     ":bench-support", // test-only: shared regression/benchmark harness (consumed via testImplementation)
 )
 


### PR DESCRIPTION
Prepares CodeAssist for distribution via **IzzyOnDroid** (F-Droid ecosystem) and aligns the version label with the 3.0 release brand.

Closes #986.

## What's in here
- **Fastlane metadata** (`fastlane/metadata/android/en-US/`): `title`, `short_description`, `full_description`, and `changelogs/31.txt` — read by IzzyOnDroid for the listing.
- **`docs/fdroid-izzyondroid.md`**: why IzzyOnDroid instead of the official F-Droid main repo (prebuilt `aapt2` + build-time download + bundled `android.jar` block build-from-source), signing notes, release steps, and anti-feature disclosures.
- **README**: license stated as `GPL-3.0-or-later` + an Install section.
- **`ide-android`**: `versionName` 2.0.0 → 3.0.0 (versionCode stays 31).

## Notes
- LICENSE (GPL-3.0) was already tracked in the repo.
- No proprietary deps/trackers; all dependencies are FOSS.
- The `v3.0.0` GitHub release (APK signed with the upload key) is already published and is the artifact IzzyOnDroid ingests.
- The IzzyOnDroid and Play builds have different signatures (Play App Signing) and cannot update across stores — expected and documented.