### PR TITLE
[Feat] Use shizuku for quick apk installation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ compose = "1.11.1"
 agp = "9.2.1"
 activityCompose = "1.13.0"
 androidxCore = "1.13.1"   # androidx.core — provides FileProvider for sharing app-private files
+api = "13.1.5"            # Shizuku API/provider — privileged APK installation when its service is available
 androidxTestRunner = "1.6.2"      # androidx.test:runner — AndroidJUnitRunner for connectedAndroidTest
 androidxTestExtJunit = "1.2.1"    # androidx.test.ext:junit — JUnit4 + AndroidJUnit4 on device
 # Pure-Java Android build tools, invoked IN-PROCESS (no `java -jar`) so they run on ART when statically
@@ -106,6 +107,8 @@ trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version.ref = "trove
 compose-runtime-desktop = { module = "org.jetbrains.compose.runtime:runtime-desktop", version.ref = "compose" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-core = { module = "androidx.core:core", version.ref = "androidxCore" }
+api = { module = "dev.rikka.shizuku:api", version.ref = "api" }
+provider = { module = "dev.rikka.shizuku:provider", version.ref = "api" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }

--- a/ide-android/build.gradle.kts
+++ b/ide-android/build.gradle.kts
@@ -954,6 +954,8 @@ dependencies {
     // app-private project files for Share / "Open with", and grants read access on inbound intents.
     implementation(libs.androidx.core)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.api)
+    implementation(libs.provider)
 
     // The on-device Kotlin interpreter (:interp-core) + its Compose bridge/render surface (:interp-compose,
     // dev.ide.interp.compose — KMP, re-exporting :interp-core): drives a ResolvedTree against the real

--- a/ide-android/src/main/AndroidManifest.xml
+++ b/ide-android/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
          biggest lever against OOM during on-device builds; the dexer also bounds its parallelism to the heap
          (see DexConcurrency). -->
     <application
+            android:name=".CodeAssistApplication"
             android:allowBackup="true"
             android:largeHeap="true"
             android:icon="@mipmap/ic_launcher"
@@ -161,6 +162,16 @@
                     android:name="android.support.FILE_PROVIDER_PATHS"
                     android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Shizuku supplies an adb/root-privileged binder. APK installation prefers it when the service is
+             running and the user has granted CodeAssist access, then falls back to PackageInstaller. -->
+        <provider
+                android:name="rikka.shizuku.ShizukuProvider"
+                android:authorities="${applicationId}.shizuku"
+                android:enabled="true"
+                android:exported="true"
+                android:multiprocess="false"
+                android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
 
         <!-- Surfaces the whole app directory as a browsable, read/write root in the system Files app and
              any SAF file manager — so users can drop in icons/layouts/assets and edit project files from a

--- a/ide-android/src/main/kotlin/dev/ide/android/AndroidFileOps.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/AndroidFileOps.kt
@@ -7,8 +7,12 @@ import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.core.content.FileProvider
+import androidx.lifecycle.lifecycleScope
 import dev.ide.core.CaprojFormat
 import dev.ide.ui.backend.IdeBackend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -19,8 +23,21 @@ import java.io.File
  */
 internal class AndroidFileOps(private val activity: ComponentActivity) {
 
-    /** Hand the APK at [path] to the system package installer (the OS install-confirmation UI). */
-    fun promptInstall(path: String) = runCatching {
+    /** Prefer Shizuku for a built APK, falling back to the OS install-confirmation UI. */
+    fun promptInstall(path: String) {
+        activity.lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                ShizukuApkInstaller.install(activity, File(path).toPath()) { }
+            }
+            if (result == ShizukuApkInstaller.Result.SUCCESS) {
+                Toast.makeText(activity, "Installed ${File(path).name} with Shizuku", Toast.LENGTH_SHORT).show()
+            } else {
+                promptSystemInstall(path)
+            }
+        }
+    }
+
+    private fun promptSystemInstall(path: String) = runCatching {
         val uri = FileProvider.getUriForFile(activity, "${activity.packageName}.fileprovider", File(path))
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, "application/vnd.android.package-archive")

--- a/ide-android/src/main/kotlin/dev/ide/android/AndroidIde.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/AndroidIde.kt
@@ -153,7 +153,7 @@ object AndroidIde {
         // loading of the user's/libraries' code. The peer factory dexes the small generated peer classes the
         // VM needs when an interpreted object is handed to real platform code (a Comparator, a Runnable).
         val programInterpreter = VmProgramInterpreter(peerFactory = DexPeerFactory())
-        // Installs + launches a built APK (the android Run) via the system package installer.
+        // Installs + launches a built APK (the android Run), preferring Shizuku with a system-installer fallback.
         val apkInstaller = ApkInstallerImpl(context)
         // The debug-only in-app log bridge: extract the bundled runtime jar (woven into debug builds); the
         // bridge inside the built app binds the IDE's exported AppLogSinkService over Binder and pushes its

--- a/ide-android/src/main/kotlin/dev/ide/android/ApkInstallerImpl.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/ApkInstallerImpl.kt
@@ -18,11 +18,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 /**
- * On-device [ApkInstaller]: installs a built APK via Android's [PackageInstaller] and launches it on
- * success, the device "Run" for an android-app. The OS shows its own install-confirmation (this app holds
- * `REQUEST_INSTALL_PACKAGES`); if the app isn't yet allowed to install unknown apps, it opens the relevant
- * Settings screen. A per-session receiver handles the pending-user-action prompt, then launches the
- * installed package. Streams progress to the build console via [installAndLaunch]'s `log`.
+ * On-device [ApkInstaller]: prefers Shizuku for a built APK, falls back to Android's [PackageInstaller],
+ * and launches it on success. The fallback shows the OS confirmation (this app holds
+ * `REQUEST_INSTALL_PACKAGES`) and opens the relevant Settings screen when unknown-app installs aren't yet
+ * allowed. A per-session receiver handles the fallback's pending-user-action prompt. Progress from either
+ * path is streamed to the build console via [installAndLaunch]'s `log`.
  *
  * Under build-process isolation this runs in the `:build` process (no foreground activity), so the launch is
  * handed to the UI process via [PackageLaunchBridge] — firing the activity from `:build` would trip Android's
@@ -33,6 +33,17 @@ class ApkInstallerImpl(context: Context) : ApkInstaller {
 
     override suspend fun installAndLaunch(apk: Path, packageName: String, log: (String) -> Unit): Boolean = withContext(Dispatchers.IO) {
         if (!Files.exists(apk)) { log("APK not found: $apk"); return@withContext false }
+
+        when (ShizukuApkInstaller.install(context, apk, log)) {
+            ShizukuApkInstaller.Result.SUCCESS -> {
+                log("Installed $packageName with Shizuku.")
+                if (!PackageLaunchBridge.forwardLaunch(packageName)) ApkLauncher.launch(context, packageName, log)
+                return@withContext true
+            }
+            ShizukuApkInstaller.Result.FAILED -> log("Falling back to the system package installer…")
+            ShizukuApkInstaller.Result.UNAVAILABLE -> Unit
+        }
+
         val pm = context.packageManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !pm.canRequestPackageInstalls()) {
             log("Allow CodeAssist to install apps (Settings → Install unknown apps), then Run again.")

--- a/ide-android/src/main/kotlin/dev/ide/android/CodeAssistApplication.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/CodeAssistApplication.kt
@@ -1,0 +1,21 @@
+package dev.ide.android
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import rikka.shizuku.ShizukuProvider
+import java.io.File
+
+class CodeAssistApplication : Application() {
+    override fun attachBaseContext(base: Context) {
+        // ActivityThread installs providers after Application.attachBaseContext but before onCreate.
+        ShizukuProvider.enableMultiProcessSupport(processName(base.packageName) == base.packageName)
+        super.attachBaseContext(base)
+    }
+
+    private fun processName(fallback: String): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        getProcessName()
+    } else {
+        runCatching { File("/proc/self/cmdline").readText().trimEnd('\u0000') }.getOrDefault(fallback)
+    }
+}

--- a/ide-android/src/main/kotlin/dev/ide/android/ShizukuApkInstaller.kt
+++ b/ide-android/src/main/kotlin/dev/ide/android/ShizukuApkInstaller.kt
@@ -1,0 +1,109 @@
+package dev.ide.android
+
+import android.content.Context
+import android.content.pm.PackageManager
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import moe.shizuku.server.IShizukuService
+import rikka.shizuku.Shizuku
+import rikka.shizuku.ShizukuProvider
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.coroutines.resume
+
+/** Installs an APK through Shizuku's privileged shell, if Shizuku is running and permission is granted. */
+internal object ShizukuApkInstaller {
+    enum class Result { SUCCESS, UNAVAILABLE, FAILED }
+
+    private const val PERMISSION_REQUEST = 0xCA71
+    private val installMutex = Mutex()
+
+    /**
+     * Streams the APK to `pm install` over stdin, so the Shizuku shell never needs filesystem access to the
+     * app's private project directory. [Result.UNAVAILABLE] and [Result.FAILED] are intentionally distinct for
+     * logging, but both tell the caller to continue with Android's regular PackageInstaller.
+     */
+    suspend fun install(context: Context, apk: Path, log: (String) -> Unit): Result = installMutex.withLock {
+        if (!Files.isRegularFile(apk)) return@withLock Result.FAILED
+        if (!awaitBinder(context) || runCatching { Shizuku.isPreV11() }.getOrDefault(true)) {
+            return@withLock Result.UNAVAILABLE
+        }
+        if (!awaitPermission()) return@withLock Result.UNAVAILABLE
+
+        log("Installing ${apk.fileName} with Shizuku…")
+        runCatching {
+            val size = Files.size(apk)
+            val service = IShizukuService.Stub.asInterface(Shizuku.getBinder())
+            val process = service.newProcess(
+                arrayOf("/system/bin/pm", "install", "-r", "-S", size.toString()),
+                null,
+                null,
+            )
+
+            Files.newInputStream(apk).use { input ->
+                FileOutputStream(process.outputStream.fileDescriptor).use { output -> input.copyTo(output) }
+            }
+            val stdout = FileInputStream(process.inputStream.fileDescriptor).bufferedReader().use { it.readText() }.trim()
+            val stderr = FileInputStream(process.errorStream.fileDescriptor).bufferedReader().use { it.readText() }.trim()
+            val exitCode = process.waitFor()
+            val message = listOf(stdout, stderr).filter { it.isNotBlank() }.joinToString("\n")
+
+            if (exitCode == 0 && stdout.lineSequence().any { it.trim() == "Success" }) {
+                Result.SUCCESS
+            } else {
+                log("Shizuku install failed${message.takeIf { it.isNotBlank() }?.let { ": $it" } ?: "."}")
+                Result.FAILED
+            }
+        }.getOrElse {
+            log("Shizuku install failed: ${it.message ?: it.javaClass.simpleName}")
+            Result.FAILED
+        }
+    }
+
+    /** The provider lives in the UI process; this requests its binder when called from the :build process. */
+    private suspend fun awaitBinder(context: Context): Boolean {
+        if (runCatching { Shizuku.pingBinder() }.getOrDefault(false)) return true
+        runCatching { ShizukuProvider.requestBinderForNonProviderProcess(context.applicationContext) }
+        return withTimeoutOrNull(1_500) {
+            suspendCancellableCoroutine { continuation ->
+                lateinit var listener: Shizuku.OnBinderReceivedListener
+                listener = Shizuku.OnBinderReceivedListener {
+                    Shizuku.removeBinderReceivedListener(listener)
+                    if (continuation.isActive) continuation.resume(true)
+                }
+                Shizuku.addBinderReceivedListenerSticky(listener)
+                continuation.invokeOnCancellation { Shizuku.removeBinderReceivedListener(listener) }
+            }
+        } ?: false
+    }
+
+    private suspend fun awaitPermission(): Boolean {
+        if (runCatching { Shizuku.checkSelfPermission() }.getOrDefault(PackageManager.PERMISSION_DENIED) ==
+            PackageManager.PERMISSION_GRANTED
+        ) return true
+        if (runCatching { Shizuku.shouldShowRequestPermissionRationale() }.getOrDefault(true)) return false
+
+        return withTimeoutOrNull(30_000) {
+            suspendCancellableCoroutine { continuation ->
+                lateinit var listener: Shizuku.OnRequestPermissionResultListener
+                listener = Shizuku.OnRequestPermissionResultListener { requestCode, grantResult ->
+                    if (requestCode == PERMISSION_REQUEST && continuation.isActive) {
+                        Shizuku.removeRequestPermissionResultListener(listener)
+                        continuation.resume(grantResult == PackageManager.PERMISSION_GRANTED)
+                    }
+                }
+                Shizuku.addRequestPermissionResultListener(listener)
+                continuation.invokeOnCancellation { Shizuku.removeRequestPermissionResultListener(listener) }
+                runCatching { Shizuku.requestPermission(PERMISSION_REQUEST) }
+                    .onFailure {
+                        Shizuku.removeRequestPermissionResultListener(listener)
+                        if (continuation.isActive) continuation.resume(false)
+                    }
+            }
+        } ?: false
+    }
+}

--- a/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/IdeServices.kt
@@ -295,7 +295,7 @@ class AndroidDeviceTools(
 
 /**
  * Installs (and then launches) a freshly built APK: the on-device "Run" for an android-app. Supplied by
- * :ide-android (it needs Android's `PackageInstaller` + the OS install-confirmation UI); null on the
+ * :ide-android (it prefers Shizuku when available and otherwise uses Android's `PackageInstaller`); null on the
  * desktop, where the android task stops at producing the signed artifact. [installAndLaunch] returns once
  * the installation is initiated and streams progress + the eventual launch to [log].
  */


### PR DESCRIPTION
pressing on install button each time is annoying.
If the user has shizuku installed and turned on, the app now uses it to install the compiled app over package manager.