### PR TITLE
feat(agent-mcp): Model Context Protocol server over stdio

### DIFF
--- a/.github/workflows/apk.yml
+++ b/.github/workflows/apk.yml
@@ -1,0 +1,58 @@
+name: APK
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+  workflow_dispatch:
+
+# Build the installable Android APK (:ide-android). Unlike the framework jobs, this needs the full
+# module set (CI_CORE_ONLY must stay unset) and the Android SDK; the runner's stock SDK plus the exact
+# platform AGP wants (android-36.1 for compileSdk=36 + compileSdkMinor=1) are provisioned with
+# setup-android. The `debug` variant is signed with the debug key so the artifact installs directly.
+env:
+  JAVA_VERSION: "25"
+
+concurrency:
+  group: apk-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: assembleDebug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Provision the Android SDK the module needs (licenses accepted by setup-android). sdkmanager is a
+      # no-op for components the runner already ships.
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: "platform-tools platforms;android-36 platforms;android-36.1 build-tools;36.0.0"
+
+      # Same as the framework jobs: one-shot CI builds gain nothing from incremental compilation.
+      - name: Disable Kotlin incremental compilation (CI)
+        run: |
+          mkdir -p ~/.gradle
+          echo "kotlin.incremental=false" >> ~/.gradle/gradle.properties
+
+      - name: Build debug APK
+        run: ./gradlew :ide-android:assembleDebug --console=plain --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeassist-debug-apk
+          path: ide-android/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -1,0 +1,59 @@
+name: MCP server
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+  workflow_dispatch:
+
+# Build + test the standalone MCP server (:agent-mcp). Pure Kotlin/JVM like the rest of the framework, so
+# CI_CORE_ONLY drops the IDE shells (which need the Android SDK) and CI needs no SDK provisioning. The
+# server's stdio wire path is covered by in-process pipe-stream tests, and `installDist` proves the module
+# produces a runnable launcher clients can spawn.
+env:
+  CI_CORE_ONLY: "true"
+  JAVA_VERSION: "25"
+
+concurrency:
+  group: mcp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: agent-mcp tests + distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Same as ci.yml: one-shot CI builds gain nothing from incremental compilation, and a restored
+      # incremental cache can produce phantom "unresolved reference" errors after the classpath changes.
+      - name: Disable Kotlin incremental compilation (CI)
+        run: |
+          mkdir -p ~/.gradle
+          echo "kotlin.incremental=false" >> ~/.gradle/gradle.properties
+
+      - name: Unit tests
+        run: ./gradlew :agent-mcp:test --console=plain --stacktrace
+
+      - name: Build runnable distribution
+        run: ./gradlew :agent-mcp:installDist --console=plain --stacktrace
+
+      - name: Upload test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-test-reports
+          path: |
+            agent-mcp/build/reports/tests/**
+            agent-mcp/build/test-results/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/agent-mcp/build.gradle.kts
+++ b/agent-mcp/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("jvm")
+    application
+}
+
+// agent-mcp — a Model Context Protocol server that exposes the agent's tools (builtinTools over an
+// AgentWorkspace) to any MCP client over stdio JSON-RPC. Pure Kotlin/JVM, so it compiles and tests under
+// CI_CORE_ONLY. The `application` plugin gives the module a standalone launcher (`./gradlew
+// :agent-mcp:installDist` / `:agent-mcp:run`) that a client like Claude Desktop can spawn with a
+// `--project <dir>` argument; hosts embedding the server (e.g. ide-core) call the builder directly with
+// their engine-backed AgentWorkspace instead.
+dependencies {
+    api(project(":agent-api"))
+    implementation(project(":agent-impl"))
+    implementation(libs.mcp)
+    implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+
+application {
+    mainClass.set("dev.ide.agent.mcp.MainKt")
+    applicationDefaultJvmArgs = listOf("-Dfile.encoding=UTF-8")
+}

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
@@ -1,0 +1,191 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.AgentPermissionGate
+import dev.ide.agent.AgentTool
+import dev.ide.agent.AgentToolRegistry
+import dev.ide.agent.AgentWorkspace
+import dev.ide.agent.AllowAllGate
+import dev.ide.agent.PermissionMode
+import dev.ide.agent.ProjectOverview
+import dev.ide.agent.SimpleToolRegistry
+import dev.ide.agent.ToolExecutionResult
+import dev.ide.agent.WriteRequest
+import dev.ide.agent.impl.SystemPrompt
+import dev.ide.agent.impl.builtinTools
+import io.modelcontextprotocol.json.McpJsonDefaults
+import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.server.McpServer
+import io.modelcontextprotocol.server.McpServerFeatures
+import io.modelcontextprotocol.server.McpSyncServer
+import io.modelcontextprotocol.spec.McpSchema
+import io.modelcontextprotocol.spec.McpServerTransportProvider
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Turns CodeAssist's agent tool layer into an MCP server. Every tool in the registry is advertised over the
+ * wire (its JSON schema carried verbatim) and routed through the same [AgentPermissionGate] the in-IDE
+ * agent uses, so mutating tools are authorized before they run and read tools never prompt. Two read-only
+ * resources expose the project's live overview and agent memory, and a prompt returns the CodeAssist agent
+ * grounding for a client that wants it.
+ *
+ * The [McpServerTransportProvider] is injected so a host can serve over stdio (the [runStdioServer]
+ * entry point), an embedded socket, or any other transport without changing the tool wiring.
+ */
+object CodeAssistMcpServer {
+
+    const val DEFAULT_SERVER_NAME = "codeassist"
+    const val DEFAULT_SERVER_VERSION = "1.0.0"
+
+    const val PROJECT_OVERVIEW_URI = "codeassist://project/overview"
+    const val PROJECT_MEMORY_URI = "codeassist://project/memory"
+    const val AGENT_PROMPT = "codeassist_agent"
+
+    /**
+     * Builds a configured [McpServer.McpSyncServer] that serves [tools] over [transportProvider].
+     * Defaults the tool registry to the built-in tool set bound to [workspace] (the engine-backed port
+     * implemented by the host), so a call needs nothing but the workspace when the built-ins suffice.
+     */
+    fun build(
+        transportProvider: McpServerTransportProvider,
+        workspace: AgentWorkspace,
+        tools: AgentToolRegistry = SimpleToolRegistry(builtinTools(workspace)),
+        gate: AgentPermissionGate = AllowAllGate,
+        serverName: String = DEFAULT_SERVER_NAME,
+        serverVersion: String = DEFAULT_SERVER_VERSION,
+        mapper: McpJsonMapper = McpJsonDefaults.getMapper(),
+    ): McpSyncServer {
+        val toolSpecs = tools.tools.map { tool -> toolSpec(tool, workspace, gate, mapper) }
+        return McpServer.sync(transportProvider)
+            .serverInfo(serverName, serverVersion)
+            .capabilities(
+                McpSchema.ServerCapabilities.builder()
+                    .tools(true)
+                    .resources(true, false)
+                    .prompts(true)
+                    .build(),
+            )
+            .tools(toolSpecs)
+            .resources(projectOverviewResource(workspace, mapper), projectMemoryResource(workspace, mapper))
+            .prompts(agentPrompt(workspace, tools))
+            .build()
+    }
+
+    /**
+     * Advertises a single [AgentTool] as an MCP tool. The call handler bridges MCP's blocking
+     * [McpSchema.CallToolRequest] handler onto the agent's suspend world with [runBlocking]; a stdio
+     * server processes one session at a time, so the bridge cannot interleave. Mutating tools are
+     * authorized through [gate] first and refused (as an MCP tool-level error the client's model can act
+     * on) when denied.
+     */
+    private fun toolSpec(
+        tool: AgentTool,
+        workspace: AgentWorkspace,
+        gate: AgentPermissionGate,
+        mapper: McpJsonMapper,
+    ): McpServerFeatures.SyncToolSpecification = McpServerFeatures.SyncToolSpecification.builder()
+        .tool(tool.spec.toMcpTool(mapper))
+        .callHandler { _, request ->
+            val args = MapToolArgs(request.arguments() ?: emptyMap(), mapper)
+            if (tool.mutating) {
+                val granted = runBlocking {
+                    gate.authorize(WriteRequest(tool.spec.name, tool.summarize(args), pathArg(args)))
+                }
+                if (!granted) {
+                    return@callHandler ToolExecutionResult.error(
+                        "Permission denied (${describeMode(gate)}): ${tool.summarize(args)} was not authorized.",
+                    ).toCallToolResult()
+                }
+            }
+            val result = try {
+                runBlocking { tool.execute(args) }
+            } catch (t: Throwable) {
+                ToolExecutionResult.error("Tool '${tool.spec.name}' failed: ${t.message ?: t::class.simpleName}")
+            }
+            result.toCallToolResult()
+        }
+        .build()
+
+    private fun pathArg(args: MapToolArgs): String? = args.optString("path")
+
+    private fun describeMode(gate: AgentPermissionGate): String = when (gate.mode) {
+        PermissionMode.ASK_EACH -> "the user did not approve it"
+        PermissionMode.AUTO_ACCEPT -> "it was rejected by the permission policy"
+        PermissionMode.PLAN_ONLY -> "file changes are disabled in PLAN_ONLY mode"
+    }
+
+    // --- Resources (read-only, never permission-gated) ---
+
+    private fun projectOverviewResource(
+        workspace: AgentWorkspace,
+        mapper: McpJsonMapper,
+    ): McpServerFeatures.SyncResourceSpecification {
+        val resource = McpSchema.Resource.builder(PROJECT_OVERVIEW_URI, "Project overview")
+            .description("The open project's modules, source roots, and dependencies.")
+            .mimeType("text/plain")
+            .build()
+        return McpServerFeatures.SyncResourceSpecification(resource) { _, _ ->
+            val text = runBlocking { formatOverview(workspace.projectOverview()) }
+            McpSchema.ReadResourceResult.builder(listOf(textResource(PROJECT_OVERVIEW_URI, text))).build()
+        }
+    }
+
+    private fun projectMemoryResource(
+        workspace: AgentWorkspace,
+        mapper: McpJsonMapper,
+    ): McpServerFeatures.SyncResourceSpecification {
+        val resource = McpSchema.Resource.builder(PROJECT_MEMORY_URI, "Project memory")
+            .description("The agent's persisted notes and the project's own instruction files.")
+            .mimeType("text/markdown")
+            .build()
+        return McpServerFeatures.SyncResourceSpecification(resource) { _, _ ->
+            val text = runBlocking { workspace.readMemory() }
+            McpSchema.ReadResourceResult.builder(listOf(textResource(PROJECT_MEMORY_URI, text))).build()
+        }
+    }
+
+    private fun textResource(uri: String, text: String): McpSchema.TextResourceContents =
+        McpSchema.TextResourceContents.builder(uri, text).build()
+
+    private fun formatOverview(overview: ProjectOverview): String {
+        val sb = StringBuilder("Project: ${overview.name}")
+        overview.modules.forEach { m ->
+            sb.append("\n\nModule ${m.name} (${m.type})")
+            m.languageLevel?.let { sb.append(", language level ").append(it) }
+            sb.append("\n  source roots: ").append(m.sourceRoots.joinToString(", ").ifEmpty { "(none)" })
+            sb.append("\n  dependencies: ").append(m.dependencies.joinToString(", ").ifEmpty { "(none)" })
+        }
+        return sb.toString()
+    }
+
+    // --- Prompt ---
+
+    /**
+     * A `codeassist_agent` prompt that returns the same grounding the in-IDE agent is given, so a client
+     * can adopt the platform's real shape (on-device, interpreter-based runs, no hosted Gradle) instead of
+     * guessing at a desktop toolchain.
+     */
+    private fun agentPrompt(
+        workspace: AgentWorkspace,
+        tools: AgentToolRegistry,
+    ): McpServerFeatures.SyncPromptSpecification {
+        val prompt = McpSchema.Prompt.builder(AGENT_PROMPT)
+            .description("The CodeAssist agent grounding: what this IDE is and how to work in it.")
+            .build()
+        return McpServerFeatures.SyncPromptSpecification(prompt) { _, _ ->
+            val grounding = SystemPrompt.build(
+                mode = PermissionMode.ASK_EACH,
+                toolNames = tools.specs().map { it.name },
+                projectContext = runBlocking { workspace.projectRoot()?.let { "Project root: $it" } },
+            )
+            val messages = listOf(
+                McpSchema.PromptMessage.builder(
+                    McpSchema.Role.USER,
+                    McpSchema.TextContent.builder(grounding).build(),
+                ).build(),
+            )
+            McpSchema.GetPromptResult.builder(messages)
+                .description("CodeAssist agent grounding and working rules.")
+                .build()
+        }
+    }
+}

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FileSystemAgentWorkspace.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FileSystemAgentWorkspace.kt
@@ -1,0 +1,271 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.AgentWorkspace
+import dev.ide.agent.DiagnosticInfo
+import dev.ide.agent.ModuleInfo
+import dev.ide.agent.ProjectOverview
+import dev.ide.agent.QuickFixInfo
+import dev.ide.agent.RenameResult
+import dev.ide.agent.SymbolHit
+import dev.ide.agent.TextEdit
+import dev.ide.agent.TextMatch
+import dev.ide.agent.WorkspaceEntry
+import java.net.HttpURLConnection
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitOption
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.BasicFileAttributes
+
+/**
+ * A disk-backed [AgentWorkspace] for the standalone stdio server ([Main]), used when no engine is
+ * available. File, search, and web operations run directly against the project directory; code
+ * intelligence and build/run operations need the engine-backed workspace that ide-core provides, so they
+ * report "not supported" (via the [AgentWorkspace] defaults) instead of pretending to work.
+ *
+ * Paths are resolved relative to the project root unless they are absolute. The project is modelled as a
+ * single `app` module whose source roots are the directories that actually exist under the root
+ * (`src`, `src/main/java`, `src/main/kotlin`, `src/main/res`, `app/src/main/java`, …).
+ */
+class FileSystemAgentWorkspace(
+    private val root: Path,
+    private val maxFileBytes: Long = 4L * 1024 * 1024,
+) : AgentWorkspace {
+
+    init {
+        require(Files.isDirectory(root)) { "Project root is not a directory: $root" }
+    }
+
+    override fun projectRoot(): String = root.toString()
+
+    override suspend fun readFile(path: String, startLine: Int?, endLine: Int?): String {
+        val text = Files.readString(resolve(path), StandardCharsets.UTF_8)
+        if (startLine == null) return text
+        return sliceLines(text, startLine, endLine ?: Int.MAX_VALUE)
+    }
+
+    override suspend fun listDir(path: String): List<WorkspaceEntry> {
+        val dir = resolve(path)
+        if (!Files.isDirectory(dir)) return emptyList()
+        return Files.list(dir).use { stream ->
+            stream.sorted().map { entry ->
+                val name = entry.fileName.toString()
+                WorkspaceEntry(name, root.relativize(entry).toString(), Files.isDirectory(entry))
+            }.toList()
+        }
+    }
+
+    override suspend fun searchText(query: String, regex: Boolean, caseSensitive: Boolean, limit: Int): List<TextMatch> {
+        val pattern = if (regex) Regex(query, if (caseSensitive) setOf() else setOf(RegexOption.IGNORE_CASE))
+        else Regex(Regex.escape(query), if (caseSensitive) setOf() else setOf(RegexOption.IGNORE_CASE))
+        val matches = ArrayList<TextMatch>()
+        Files.walk(root, FileVisitOption.FOLLOW_LINKS).use { stream ->
+            stream.filter { file ->
+                Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS) &&
+                    TEXT_EXTENSIONS.any { file.fileName.toString().endsWith(it) }
+            }.forEach { file ->
+                if (matches.size >= limit) return@forEach
+                if (Files.size(file) > maxFileBytes) return@forEach
+                val relative = root.relativize(file).toString()
+                Files.readAllLines(file, StandardCharsets.UTF_8).forEachIndexed { index, line ->
+                    if (matches.size >= limit) return@forEachIndexed
+                    if (pattern.containsMatchIn(line)) {
+                        val column = pattern.find(line)?.range?.first?.plus(1) ?: 1
+                        matches += TextMatch(relative, index + 1, column, line.trim())
+                    }
+                }
+            }
+        }
+        return matches
+    }
+
+    override suspend fun findSymbol(query: String, limit: Int): List<SymbolHit> = emptyList()
+
+    override suspend fun diagnostics(path: String): List<DiagnosticInfo> = emptyList()
+
+    override suspend fun projectOverview(): ProjectOverview {
+        val sourceRoots = SOURCE_ROOTS.filter { Files.isDirectory(root.resolve(it)) }
+        return ProjectOverview(
+            name = root.fileName?.toString() ?: "project",
+            modules = listOf(
+                ModuleInfo(
+                    name = "app",
+                    type = "java",
+                    languageLevel = null,
+                    sourceRoots = sourceRoots,
+                    dependencies = emptyList(),
+                ),
+            ),
+        )
+    }
+
+    // --- Writes ---
+
+    override suspend fun createFile(path: String, content: String): String {
+        val file = resolve(path)
+        require(!Files.exists(file)) { "File already exists: $path" }
+        Files.createDirectories(file.parent)
+        Files.writeString(file, content, StandardCharsets.UTF_8)
+        return path
+    }
+
+    override suspend fun writeFile(path: String, content: String) {
+        val file = resolve(path)
+        Files.createDirectories(file.parent)
+        Files.writeString(file, content, StandardCharsets.UTF_8)
+    }
+
+    override suspend fun applyEdits(path: String, edits: List<TextEdit>) {
+        val file = resolve(path)
+        var text = if (Files.exists(file)) Files.readString(file, StandardCharsets.UTF_8) else ""
+        edits.sortedByDescending { it.offset }.forEach { e ->
+            require(e.offset in 0..text.length) { "Edit offset ${e.offset} out of range for $path (length ${text.length})" }
+            require(e.offset + e.oldLength <= text.length) { "Edit range out of bounds for $path" }
+            text = text.substring(0, e.offset) + e.newText + text.substring(e.offset + e.oldLength)
+        }
+        Files.writeString(file, text, StandardCharsets.UTF_8)
+    }
+
+    override suspend fun createDir(path: String): String {
+        Files.createDirectories(resolve(path))
+        return path
+    }
+
+    override suspend fun renamePath(path: String, newName: String): String {
+        val source = resolve(path)
+        require(Files.exists(source)) { "Path not found: $path" }
+        val target = source.resolveSibling(newName)
+        require(!Files.exists(target)) { "Target already exists: $target" }
+        Files.move(source, target, StandardCopyOption.ATOMIC_MOVE)
+        return root.relativize(target).toString()
+    }
+
+    override suspend fun movePath(path: String, destDir: String): String {
+        val source = resolve(path)
+        require(Files.exists(source)) { "Path not found: $path" }
+        val destination = resolve(destDir).resolve(source.fileName)
+        Files.createDirectories(destination.parent)
+        Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE)
+        return root.relativize(destination).toString()
+    }
+
+    override suspend fun deletePath(path: String): Boolean {
+        val target = resolve(path)
+        if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) return false
+        Files.walk(target).use { stream -> stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) } }
+        return true
+    }
+
+    override suspend fun addDependency(module: String, coordinate: String): String =
+        "Adding dependencies requires the engine-backed workspace (the in-IDE agent)."
+
+    // --- Code intelligence: not available without the engine ---
+
+    override suspend fun quickFixes(path: String, line: Int): List<QuickFixInfo> = emptyList()
+
+    override suspend fun applyQuickFix(path: String, line: Int, index: Int): String =
+        "Quick fixes require the engine-backed workspace."
+
+    override suspend fun formatFile(path: String): String = "Formatting requires the engine-backed workspace."
+
+    override suspend fun organizeImports(path: String): String =
+        "Organizing imports requires the engine-backed workspace."
+
+    override suspend fun renameSymbol(path: String, offset: Int, newName: String): RenameResult =
+        RenameResult(success = false, message = "Semantic rename requires the engine-backed workspace.")
+
+    // --- Memory ---
+
+    override suspend fun readMemory(): String {
+        val notes = memoryFile()
+        val instruction = instructionFile()
+        val parts = mutableListOf<String>()
+        instruction?.let {
+            if (Files.isRegularFile(it)) parts += "## Instruction file (${root.relativize(it)})\n\n${Files.readString(it, StandardCharsets.UTF_8)}"
+        }
+        if (Files.isRegularFile(notes)) parts += "## Agent notes\n\n${Files.readString(notes, StandardCharsets.UTF_8)}"
+        return parts.joinToString("\n\n")
+    }
+
+    override suspend fun writeMemory(content: String): String {
+        Files.writeString(memoryFile(), content, StandardCharsets.UTF_8)
+        return "Saved agent notes (${memoryFile().fileName})."
+    }
+
+    // --- Web ---
+
+    override suspend fun fetchUrl(url: String, maxChars: Int): String = http("GET", url, emptyList(), null, maxChars)
+
+    override suspend fun httpRequest(method: String, url: String, headers: List<String>, body: String?, maxChars: Int): String =
+        http(method, url, headers, body, maxChars)
+
+    private fun http(method: String, url: String, headers: List<String>, body: String?, maxChars: Int): String {
+        val connection = URI(url).toURL().openConnection() as HttpURLConnection
+        try {
+            connection.requestMethod = method
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 30_000
+            headers.forEach { header ->
+                val colon = header.indexOf(':')
+                if (colon > 0) connection.setRequestProperty(header.substring(0, colon).trim(), header.substring(colon + 1).trim())
+            }
+            if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { it.write(body.toByteArray(StandardCharsets.UTF_8)) }
+            }
+            val status = connection.responseCode
+            val input = if (status in 200..299) connection.inputStream else connection.errorStream
+            val response = if (input == null) "" else input.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }
+            val truncated = response.take(maxChars) + if (response.length > maxChars) "\n…(truncated)" else ""
+            return "HTTP $status ${connection.responseMessage}\n\n$truncated"
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    // --- Helpers ---
+
+    private fun resolve(path: String): Path {
+        val p = Paths.get(path)
+        return if (p.isAbsolute) p.normalize() else root.resolve(p).normalize()
+    }
+
+    private fun memoryFile(): Path = root.resolve(".codeassist-memory.md")
+
+    private fun instructionFile(): Path {
+        val candidate = root.resolve("AGENTS.md")
+        return candidate.takeIf { Files.isRegularFile(candidate) }
+            ?: root.resolve(".agent").resolve("AGENTS.md").takeIf { Files.isRegularFile(it) }
+            ?: root.resolve(".codeassist").resolve("AGENTS.md")
+    }
+
+    private fun sliceLines(text: String, startLine: Int, endLine: Int): String {
+        if (startLine < 1) return text
+        val lines = text.lines()
+        val first = (startLine - 1).coerceIn(0, lines.size)
+        val last = if (endLine == Int.MAX_VALUE) lines.size else endLine.coerceIn(first, lines.size)
+        return lines.subList(first, last).joinToString("\n")
+    }
+
+    private companion object {
+        val SOURCE_ROOTS = listOf(
+            "src",
+            "src/main/java",
+            "src/main/kotlin",
+            "src/main/res",
+            "src/test/java",
+            "app/src/main/java",
+            "app/src/main/kotlin",
+            "app/src/main/res",
+        )
+
+        val TEXT_EXTENSIONS = listOf(
+            ".txt", ".kt", ".java", ".xml", ".gradle", ".kts", ".md", ".properties", ".json", ".yml", ".yaml", ".toml",
+        )
+    }
+}

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
@@ -1,0 +1,89 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.AgentPermissionGate
+import dev.ide.agent.AllowAllGate
+import dev.ide.agent.PermissionMode
+import dev.ide.agent.WriteRequest
+import io.modelcontextprotocol.json.McpJsonDefaults
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+
+/**
+ * The standalone stdio entry point for the CodeAssist MCP server.
+ *
+ * Usage:
+ * ```
+ * ./gradlew :agent-mcp:installDist
+ * build/install/agent-mcp/bin/agent-mcp --project /path/to/project [--auto-accept]
+ * ```
+ *
+ * A client (Claude Desktop, opencode, Cursor, ...) spawns this process and speaks newline-delimited
+ * JSON-RPC over stdin/stdout. It serves the built-in agent tools over a [FileSystemAgentWorkspace]
+ * rooted at `--project` (defaulting to the current directory or `$CODEASSIST_MCP_PROJECT`), so a client
+ * can read, search, edit, and reorganize a real project without the IDE. The engine-backed capabilities
+ * (diagnostics, completion, semantic rename, builds/runs) report "not supported" here — host the server
+ * in the IDE to get those.
+ *
+ * Mutating tools (writes, deletes, renames, HTTP requests) are denied by default, matching the agent's
+ * conservative posture; pass `--auto-accept` to authorize them, or embed the server and supply your own
+ * [AgentPermissionGate] for interactive approval.
+ */
+fun main(args: Array<String>) {
+    var project = System.getenv("CODEASSIST_MCP_PROJECT")
+    var autoAccept = false
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "--project" -> project = args.getOrNull(++i) ?: error("--project requires a directory argument")
+            "--auto-accept" -> autoAccept = true
+            "--help", "-h" -> {
+                println(
+                    """
+                    |Usage: agent-mcp [--project <dir>] [--auto-accept]
+                    |
+                    |  --project <dir>  Project root to serve (default: current directory, or
+                    |                   ${'$'}CODEASSIST_MCP_PROJECT).
+                    |  --auto-accept    Authorize mutating tools (writes, deletes, HTTP requests) without
+                    |                   prompting. Off by default: they are refused.
+                    |
+                    |Serves the Model Context Protocol over stdin/stdout (stdio transport).
+                    """.trimMargin(),
+                )
+                return
+            }
+            else -> error("Unknown argument: ${args[i]} (see --help)")
+        }
+        i++
+    }
+
+    val root = Paths.get(project ?: ".").toAbsolutePath().normalize()
+    require(Files.isDirectory(root)) { "Project root is not a directory: $root" }
+
+    val workspace = FileSystemAgentWorkspace(root)
+    val gate = if (autoAccept) AllowAllGate else ReadOnlyGate
+
+    // MCP output MUST be the only thing on stdout; anything else a client parses as a protocol message.
+    System.err.println("CodeAssist MCP server ready (project: $root)")
+    System.err.println("Mutating tools: ${if (autoAccept) "auto-accepted" else "denied"}. Waiting for protocol messages on stdin.")
+
+    val mapper = McpJsonDefaults.getMapper()
+    val transport = StdioServerTransportProvider(mapper, System.`in`, System.out)
+    val server = CodeAssistMcpServer.build(transport, workspace, gate = gate, mapper = mapper)
+
+    Runtime.getRuntime().addShutdownHook(Thread { server.close() })
+    // The stdio transport owns an inbound thread; this latch just keeps main alive until the process ends.
+    SHUTDOWN_LATCH.await()
+}
+
+/**
+ * A permission gate that refuses every mutating tool, so a stdio client started without `--auto-accept`
+ * can read and search but cannot change the project.
+ */
+private object ReadOnlyGate : AgentPermissionGate {
+    override val mode: PermissionMode get() = PermissionMode.PLAN_ONLY
+    override suspend fun authorize(request: WriteRequest): Boolean = false
+}
+
+private val SHUTDOWN_LATCH = CountDownLatch(1)

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/McpToolMapping.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/McpToolMapping.kt
@@ -1,0 +1,97 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.ToolArgs
+import dev.ide.agent.ToolExecutionResult
+import dev.ide.agent.ToolSpec
+import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.json.TypeRef
+import io.modelcontextprotocol.spec.McpSchema
+import java.io.IOException
+
+/**
+ * The wire mapping between the agent tool model (agent-api, JSON-schema strings, dependency-free) and the
+ * MCP model (io.modelcontextprotocol, Jackson-backed). The agent's tool specs are already JSON Schema, so
+ * they map 1:1 into MCP [McpSchema.Tool] declarations; arguments arrive from MCP as a `Map` and are read
+ * back through the same [ToolArgs] accessor the in-IDE agent uses, so a tool implementation never needs to
+ * know which side it is running on.
+ */
+
+private val MAP_TYPE_REF: TypeRef<Map<String, Any>> = object : TypeRef<Map<String, Any>>() {}
+
+/** Converts an agent [ToolSpec] into an MCP tool declaration, preserving name, description, and schema. */
+fun ToolSpec.toMcpTool(mapper: McpJsonMapper): McpSchema.Tool = McpSchema.Tool.builder(name, parseParameters(mapper, this))
+    .description(description)
+    .build()
+
+private fun parseParameters(mapper: McpJsonMapper, spec: ToolSpec): Map<String, Any> {
+    if (spec.parameters.isBlank()) return emptyMap()
+    return try {
+        mapper.readValue(spec.parameters, MAP_TYPE_REF)
+    } catch (e: IOException) {
+        throw IllegalArgumentException(
+            "Tool '${spec.name}' advertises an invalid JSON-schema parameters string: ${spec.parameters}",
+            e,
+        )
+    }
+}
+
+/**
+ * A [ToolArgs] view over MCP's argument map. MCP decodes JSON arguments with Jackson, so numbers arrive as
+ * [Number] and lists as `List<*>`; the accessors coerce instead of casting so a tool's `int`/`string`
+ * reads work regardless of the exact decoded shape.
+ */
+class MapToolArgs(
+    private val args: Map<String, Any?> = emptyMap(),
+    private val mapper: McpJsonMapper? = null,
+) : ToolArgs {
+
+    override fun string(key: String): String =
+        requireNotNull(optString(key)) { "Missing required argument '$key'." }
+
+    override fun optString(key: String): String? = when (val v = args[key]) {
+        null -> null
+        is String -> v
+        else -> v.toString()
+    }
+
+    override fun int(key: String): Int = requireNotNull(optInt(key)) { "Missing required argument '$key'." }
+
+    override fun optInt(key: String): Int? = when (val v = args[key]) {
+        null -> null
+        is Number -> v.toInt()
+        is String -> v.toIntOrNull()
+        else -> null
+    }
+
+    override fun boolean(key: String): Boolean =
+        requireNotNull(optBoolean(key)) { "Missing required argument '$key'." }
+
+    override fun optBoolean(key: String): Boolean? = when (val v = args[key]) {
+        null -> null
+        is Boolean -> v
+        is String -> v.toBooleanStrictOrNull()
+        else -> null
+    }
+
+    override fun stringList(key: String): List<String> = when (val v = args[key]) {
+        null -> emptyList()
+        is List<*> -> v.mapNotNull { it?.toString() }
+        else -> listOf(v.toString())
+    }
+
+    /** The raw argument object, re-serialized to its JSON form when a mapper is available. */
+    override fun raw(): String {
+        val mapper = mapper ?: return args.toString()
+        return try {
+            mapper.writeValueAsString(args)
+        } catch (e: IOException) {
+            args.toString()
+        }
+    }
+}
+
+/** Converts an agent [ToolExecutionResult] into an MCP [McpSchema.CallToolResult]. */
+fun ToolExecutionResult.toCallToolResult(): McpSchema.CallToolResult = McpSchema.CallToolResult.builder()
+    .content(listOf(McpSchema.TextContent.builder(content).build()))
+    .isError(isError)
+    .build()

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/CodeAssistMcpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/CodeAssistMcpServerTest.kt
@@ -1,0 +1,335 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.AgentPermissionGate
+import dev.ide.agent.AgentWorkspace
+import dev.ide.agent.AllowAllGate
+import dev.ide.agent.DiagnosticInfo
+import dev.ide.agent.ModuleInfo
+import dev.ide.agent.PermissionMode
+import dev.ide.agent.ProjectOverview
+import dev.ide.agent.SimpleToolRegistry
+import dev.ide.agent.SymbolHit
+import dev.ide.agent.TextEdit
+import dev.ide.agent.TextMatch
+import dev.ide.agent.WorkspaceEntry
+import dev.ide.agent.WriteRequest
+import dev.ide.agent.impl.builtinTools
+import io.modelcontextprotocol.client.McpClient
+import io.modelcontextprotocol.json.McpJsonDefaults
+import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.json.TypeRef
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
+import io.modelcontextprotocol.spec.McpClientTransport
+import io.modelcontextprotocol.spec.McpSchema
+import io.modelcontextprotocol.spec.ProtocolVersions
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.charset.StandardCharsets
+import java.util.function.Function
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end stdio protocol tests: a real MCP client talks newline-delimited JSON-RPC to the server over
+ * in-process pipe streams, so the full wire path (initialize handshake, tools/list, tools/call, resources,
+ * prompts) is exercised offline with no subprocess.
+ */
+class CodeAssistMcpServerTest {
+
+    @Test
+    fun `initialize and tools list expose the agent tool set`() {
+        val fake = FakeWorkspace("Main.kt" to "fun main() {}")
+        val (server, client) = connect(fake, AllowAllGate)
+
+        try {
+            val init = client.initialize()
+            assertEquals(CodeAssistMcpServer.DEFAULT_SERVER_NAME, init.serverInfo().name())
+
+            val toolNames = client.listTools().tools().map { it.name() }.toSet()
+            assertTrue("read_file" in toolNames)
+            assertTrue("edit_file" in toolNames)
+            assertTrue("create_file" in toolNames)
+            assertTrue("search_text" in toolNames)
+            assertTrue("project_overview" in toolNames)
+            assertTrue("run_program" in toolNames)
+            assertTrue("run_task" in toolNames)
+            assertTrue("read_memory" in toolNames)
+            assertTrue("web_fetch" in toolNames)
+            assertTrue("http_request" in toolNames)
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `read_file tool returns the workspace file content`() {
+        val fake = FakeWorkspace("src/Main.kt" to "fun main() { println(\"hi\") }")
+        val (server, client) = connect(fake, AllowAllGate)
+
+        try {
+            client.initialize()
+            val result = client.callTool(
+                McpSchema.CallToolRequest.builder("read_file")
+                    .arguments(mapOf("path" to "src/Main.kt"))
+                    .build(),
+            )
+            assertFalse(result.isError())
+            val text = textOf(result)
+            assertTrue("fun main()" in text)
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `mutating tool applies edits when the gate allows`() {
+        val fake = FakeWorkspace("src/Main.kt" to "fun main() { println(\"old\") }")
+        val (server, client) = connect(fake, AllowAllGate)
+
+        try {
+            client.initialize()
+            val result = client.callTool(
+                McpSchema.CallToolRequest.builder("edit_file")
+                    .arguments(
+                        mapOf(
+                            "path" to "src/Main.kt",
+                            "old_string" to "old",
+                            "new_string" to "new",
+                        ),
+                    )
+                    .build(),
+            )
+            assertFalse(result.isError())
+            assertEquals("fun main() { println(\"new\") }", fake.readNow("src/Main.kt"))
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `mutating tool is refused when the gate denies`() {
+        val fake = FakeWorkspace("src/Main.kt" to "fun main() {}")
+        val (server, client) = connect(fake, DenyGate)
+
+        try {
+            client.initialize()
+            val result = client.callTool(
+                McpSchema.CallToolRequest.builder("write_file")
+                    .arguments(mapOf("path" to "src/Other.kt", "content" to "fun other() {}"))
+                    .build(),
+            )
+            assertTrue(result.isError())
+            assertTrue(textOf(result).contains("Permission denied"))
+            assertTrue("Other.kt" !in fake.files.keys)
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `resources and prompt are advertised`() {
+        val fake = FakeWorkspace(memory = "Convention: use spaces.")
+        val (server, client) = connect(fake, AllowAllGate)
+
+        try {
+            client.initialize()
+            val resourceUris = client.listResources().resources().map { it.uri() }
+            assertTrue(CodeAssistMcpServer.PROJECT_OVERVIEW_URI in resourceUris)
+            assertTrue(CodeAssistMcpServer.PROJECT_MEMORY_URI in resourceUris)
+
+            val memory = client.readResource(
+                McpSchema.ReadResourceRequest.builder(CodeAssistMcpServer.PROJECT_MEMORY_URI).build(),
+            )
+            val memoryText = (memory.contents().single() as McpSchema.TextResourceContents).text()
+            assertTrue("Convention: use spaces." in memoryText)
+
+            val prompt = client.getPrompt(
+                McpSchema.GetPromptRequest.builder(CodeAssistMcpServer.AGENT_PROMPT).build(),
+            )
+            val systemMessage = prompt.messages().first()
+            assertEquals(McpSchema.Role.USER, systemMessage.role())
+            val body = (systemMessage.content() as McpSchema.TextContent).text()
+            assertTrue("CodeAssist" in body)
+            assertTrue("read_file" in body)
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `create and delete round-trip through the filesystem workspace`() {
+        val root = java.nio.file.Files.createTempDirectory("ca-mcp")
+        val workspace = FileSystemAgentWorkspace(root)
+        val (server, client) = connect(workspace, AllowAllGate)
+
+        try {
+            client.initialize()
+            val created = client.callTool(
+                McpSchema.CallToolRequest.builder("create_file")
+                    .arguments(mapOf("path" to "notes.md", "content" to "# Hi"))
+                    .build(),
+            )
+            assertFalse(created.isError())
+            assertEquals("# Hi", java.nio.file.Files.readString(root.resolve("notes.md")))
+
+            val deleted = client.callTool(
+                McpSchema.CallToolRequest.builder("delete_path")
+                    .arguments(mapOf("path" to "notes.md"))
+                    .build(),
+            )
+            assertFalse(deleted.isError())
+            assertTrue(!java.nio.file.Files.exists(root.resolve("notes.md")))
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    // --- Plumbing ---
+
+    private fun connect(workspace: AgentWorkspace, gate: AgentPermissionGate): Pair<Server, Client> {
+        val mapper = McpJsonDefaults.getMapper()
+
+        // client writes requests -> server reads; server writes responses -> client reads
+        val clientToServer = PipedOutputStream()
+        val serverInput = PipedInputStream(clientToServer)
+        val serverToClient = PipedOutputStream()
+        val clientInput = PipedInputStream(serverToClient)
+
+        val server = CodeAssistMcpServer.build(
+            transportProvider = StdioServerTransportProvider(mapper, serverInput, serverToClient),
+            workspace = workspace,
+            tools = SimpleToolRegistry(builtinTools(workspace)),
+            gate = gate,
+            mapper = mapper,
+        )
+        val client = McpClient.sync(PipeMcpClientTransport(clientInput, clientToServer, mapper)).build()
+        return Pair(server, client)
+    }
+
+    private fun textOf(result: McpSchema.CallToolResult): String =
+        result.content().joinToString("\n") { (it as McpSchema.TextContent).text() }
+
+    /** An in-memory [AgentWorkspace] for the wire-level tests. */
+    private class FakeWorkspace(
+        val files: MutableMap<String, String> = mutableMapOf(),
+        private val memory: String = "",
+    ) : AgentWorkspace {
+        constructor(vararg entries: Pair<String, String>) : this(entries.toMap().toMutableMap())
+
+        fun readNow(path: String): String = files.getValue(path)
+
+        override fun projectRoot(): String = "/project"
+        override suspend fun readFile(path: String, startLine: Int?, endLine: Int?): String =
+            files[path] ?: throw IllegalArgumentException("no such file: $path")
+        override suspend fun listDir(path: String): List<WorkspaceEntry> = emptyList()
+        override suspend fun searchText(query: String, regex: Boolean, caseSensitive: Boolean, limit: Int): List<TextMatch> = emptyList()
+        override suspend fun findSymbol(query: String, limit: Int): List<SymbolHit> = emptyList()
+        override suspend fun diagnostics(path: String): List<DiagnosticInfo> = emptyList()
+        override suspend fun projectOverview(): ProjectOverview =
+            ProjectOverview("test", listOf(ModuleInfo("app", "java", "17", listOf("src"), emptyList())))
+        override suspend fun createFile(path: String, content: String): String {
+            require(path !in files) { "already exists: $path" }
+            files[path] = content
+            return path
+        }
+        override suspend fun writeFile(path: String, content: String) { files[path] = content }
+        override suspend fun applyEdits(path: String, edits: List<TextEdit>) {
+            var text = files[path] ?: ""
+            edits.sortedByDescending { it.offset }.forEach { e ->
+                text = text.substring(0, e.offset) + e.newText + text.substring(e.offset + e.oldLength)
+            }
+            files[path] = text
+        }
+        override suspend fun createDir(path: String): String = path
+        override suspend fun renamePath(path: String, newName: String): String = newName
+        override suspend fun movePath(path: String, destDir: String): String = path
+        override suspend fun deletePath(path: String): Boolean = files.remove(path) != null
+        override suspend fun addDependency(module: String, coordinate: String): String = "added"
+        override suspend fun readMemory(): String = memory
+        override suspend fun writeMemory(content: String): String = "saved"
+        override suspend fun fetchUrl(url: String, maxChars: Int): String = "page"
+        override suspend fun httpRequest(method: String, url: String, headers: List<String>, body: String?, maxChars: Int): String =
+            "HTTP 200 OK"
+    }
+
+    /** Refuses every mutating tool. */
+    private object DenyGate : AgentPermissionGate {
+        override val mode: PermissionMode get() = PermissionMode.PLAN_ONLY
+        override suspend fun authorize(request: WriteRequest): Boolean = false
+    }
+
+    /**
+     * A minimal in-process [McpClientTransport] speaking newline-delimited JSON-RPC over the given
+     * streams — the client half of the wire the stdio server speaks, without spawning a subprocess. It
+     * mirrors [io.modelcontextprotocol.client.transport.StdioClientTransport]'s shape (a reader thread
+     * feeding a sink, writes serialized with the mapper).
+     */
+    private class PipeMcpClientTransport(
+        private val input: InputStream,
+        private val output: OutputStream,
+        private val mapper: McpJsonMapper,
+    ) : McpClientTransport {
+
+        private val inbound = Sinks.many().unicast().onBackpressureBuffer<McpSchema.JSONRPCMessage>()
+
+        override fun protocolVersions(): List<String> = listOf(ProtocolVersions.MCP_2025_11_25)
+
+        override fun connect(
+            handler: Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>>,
+        ): Mono<Void> {
+            Thread {
+                try {
+                    val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (line.isBlank()) continue
+                        val message = McpSchema.deserializeJsonRpcMessage(mapper, line)
+                        inbound.tryEmitNext(message)
+                    }
+                } finally {
+                    inbound.tryEmitComplete()
+                }
+            }.apply { isDaemon = true }.start()
+            return inbound.asFlux()
+                .flatMap { message -> Mono.just(message).transform(handler) }
+                .then()
+        }
+
+        override fun sendMessage(message: McpSchema.JSONRPCMessage): Mono<Void> = Mono.fromRunnable {
+            val json = mapper.writeValueAsString(message).replace("\n", "\\n")
+            synchronized(output) {
+                output.write(json.toByteArray(StandardCharsets.UTF_8))
+                output.write('\n'.code)
+                output.flush()
+            }
+        }
+
+        override fun closeGracefully(): Mono<Void> = Mono.fromRunnable {
+            inbound.tryEmitComplete()
+            try {
+                input.close()
+            } catch (_: Exception) {
+            }
+        }
+
+        override fun <T> unmarshalFrom(data: Any, typeRef: TypeRef<T>): T = mapper.convertValue(data, typeRef)
+    }
+
+    private typealias Server = io.modelcontextprotocol.server.McpSyncServer
+    private typealias Client = io.modelcontextprotocol.client.McpSyncClient
+}

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/McpToolMappingTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/McpToolMappingTest.kt
@@ -1,0 +1,82 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.ToolExecutionResult
+import dev.ide.agent.ToolSpec
+import dev.ide.agent.toolSchema
+import io.modelcontextprotocol.json.McpJsonDefaults
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class McpToolMappingTest {
+
+    private val mapper = McpJsonDefaults.getMapper()
+
+    @Test
+    fun `tool spec maps to an mcp tool preserving name description and schema`() {
+        val spec = ToolSpec(
+            "read_file",
+            "Read a file's current text.",
+            toolSchema {
+                string("path", "File path.")
+                integer("start_line", "First line (1-based).", required = false)
+            },
+        )
+
+        val tool = spec.toMcpTool(mapper)
+
+        assertEquals("read_file", tool.name())
+        assertEquals("Read a file's current text.", tool.description())
+        val schema = tool.inputSchema()
+        assertEquals("object", schema["type"])
+        assertTrue((schema["properties"] as Map<*, *>).containsKey("path"))
+        assertEquals(listOf("path"), schema["required"])
+    }
+
+    @Test
+    fun `blank parameters map to an empty input schema`() {
+        val tool = ToolSpec("ping", "Pings.", "").toMcpTool(mapper)
+        assertEquals(emptyMap<String, Any>(), tool.inputSchema())
+    }
+
+    @Test
+    fun `mcp args are read through the tool args accessors with coercion`() {
+        val args = MapToolArgs(
+            mapOf(
+                "path" to "Main.kt",
+                "limit" to 5,
+                "verbose" to true,
+                "tags" to listOf("a", "b"),
+            ),
+        )
+
+        assertEquals("Main.kt", args.string("path"))
+        assertEquals(5, args.int("limit"))
+        assertTrue(args.boolean("verbose"))
+        assertEquals(listOf("a", "b"), args.stringList("tags"))
+        assertNull(args.optString("missing"))
+        assertEquals("5", args.optString("limit"), "numbers coerce to their string form")
+        assertEquals("Main.kt", args.optString("path"))
+    }
+
+    @Test
+    fun `missing required argument throws`() {
+        val args = MapToolArgs(emptyMap())
+        val thrown = runCatching { args.string("path") }.exceptionOrNull()
+        assertTrue(thrown is IllegalArgumentException)
+        assertEquals("Missing required argument 'path'.", thrown.message)
+    }
+
+    @Test
+    fun `tool result maps to call tool result with error flag`() {
+        val ok = ToolExecutionResult.ok("done").toCallToolResult()
+        assertFalse(ok.isError())
+        assertEquals("done", (ok.content().single() as io.modelcontextprotocol.spec.McpSchema.TextContent).text())
+
+        val err = ToolExecutionResult.error("boom").toCallToolResult()
+        assertTrue(err.isError())
+        assertEquals("boom", (err.content().single() as io.modelcontextprotocol.spec.McpSchema.TextContent).text())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,9 @@ admobMediationPangle = "8.2.0.4.0"     # com.google.ads.mediation:pangle — Pan
 admobMediationMintegral = "17.1.71.0"  # com.google.ads.mediation:mintegral — Mintegral adapter (native-capable)
 androidStub = "4.1.1.4"     # com.google.android:android — the throwaway stub android.jar (compileOnly) :applog-runtime compiles against
 okhttp = "4.12.0"           # com.squareup.okhttp3 — HTTP + SSE transport for the agent's LLM client (:agent-impl); runs on JVM and ART
+# The Model Context Protocol Java SDK (io.modelcontextprotocol.sdk:mcp) — the wire protocol for
+# :agent-mcp's stdio server. 2.0.0 tracks the 2025-11-25 spec; the `mcp` bundle pulls mcp-core + Jackson 3.
+mcp = "2.0.0"
 cfr = "0.152"               # org.benf:cfr — single-jar Java decompiler for the "navigate into library class" view (:decompiler). Chosen over Fernflower/Vineflower because those NPE on ART (their plugin loader calls Class.getProtectionDomain(), null on Android); CFR is self-contained and runs on-device.
 # KSP2 (Kotlin Symbol Processing, standalone Analysis-API runner). 2.3.10 explicitly supports Kotlin 2.4.0
 # ("Sanitize ':' in internal-name module suffix so KSP works with Kotlin 2.4.0 default module names", #2964)
@@ -149,6 +152,9 @@ android-stub = { module = "com.google.android:android", version.ref = "androidSt
 # desktop and ART (bundled into :ide-android like the other in-process tools). okhttp-sse tracks okhttp.
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp" }
+# The MCP SDK convenience bundle (mcp-core + Jackson 3): stdio server/client transports and the full
+# tools/resources/prompts JSON-RPC model for :agent-mcp.
+mcp = { module = "io.modelcontextprotocol.sdk:mcp", version.ref = "mcp" }
 # KSP2 standalone runner. `symbol-processing-api` = the processor SPI (SymbolProcessor/…Provider/KSPLogger/
 # Resolver/CodeGenerator), on the compile classpath so a bundled processor and our runner see the types.
 # `symbol-processing-common-deps` = KSPConfig/KSPJvmConfig. `symbol-processing-aa-embeddable` = the ~78 MB

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -98,6 +98,7 @@ include(
     ":plugin-impl", // ActionManager: resolves UI_ACTION_EP/ACTION_GROUP_EP into places/menus, dispatches
     ":agent-api",   // agentic-coding SPI: provider-neutral LLM client + AgentTool + AgentWorkspace engine port
     ":agent-impl",  // the agent engine: OkHttp/SSE transport, Anthropic/OpenAI/Gemini providers, loop, built-in tools
+    ":agent-mcp",   // Model Context Protocol server: exposes the agent's tools over stdio JSON-RPC to external clients
     ":layout-preview-api",  // owned XML-layout preview: render contracts (RCanvas/RenderNode/Renderer), android-free
     ":layout-preview-impl", // the preview engine: resource value resolver, inflater, built-in renderers, ASM bridge remapper
     ":bench-support", // test-only: shared regression/benchmark harness (consumed via testImplementation)


### PR DESCRIPTION
Adds the MCP server module (:agent-mcp) exposing the built-in agent tools over stdio JSON-RPC (io.modelcontextprotocol 2.0.0), plus two CI workflows: mcp.yml (module tests) and apk.yml (installable debug APK). Verified locally: 11/11 agent-mcp tests pass and the stdio binary serves initialize/tools/resources/prompts.