### PR TITLE
feat(agent-mcp): in-app Streamable HTTP MCP server + FTP asset server

### DIFF
--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
@@ -43,6 +43,9 @@ object CodeAssistMcpServer {
     /** Default port for the in-IDE MCP-over-HTTP server (`adb forward tcp:8765 tcp:8765`). */
     const val DEFAULT_HTTP_PORT = 8765
 
+    /** Default port for the local FTP asset server (`adb forward tcp:8021 tcp:8021`). */
+    const val DEFAULT_FTP_PORT = 8021
+
     /**
      * Builds a configured [McpServer.McpSyncServer] that serves [tools] over [transportProvider].
      * Defaults the tool registry to the built-in tool set bound to [workspace] (the engine-backed port
@@ -114,6 +117,14 @@ object CodeAssistMcpServer {
         provider.bind(port)
         return HttpMcpServer(provider)
     }
+
+    /**
+     * Starts the local FTP asset server rooted at [root] (callers pass their `<project>/assets` directory,
+     * created on start). Anonymous, bound to 127.0.0.1 only, so uploads land directly in [root] and nothing
+     * leaks off the device. The returned [FtpServer] is closed to stop listening.
+     */
+    fun startFtpServer(root: java.nio.file.Path, port: Int = DEFAULT_FTP_PORT): FtpServer =
+        FtpServer(root, port).start()
 
     private fun toolSpec(
         tool: AgentTool,

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
@@ -40,6 +40,9 @@ object CodeAssistMcpServer {
     const val PROJECT_MEMORY_URI = "codeassist://project/memory"
     const val AGENT_PROMPT = "codeassist_agent"
 
+    /** Default port for the in-IDE MCP-over-HTTP server (`adb forward tcp:8765 tcp:8765`). */
+    const val DEFAULT_HTTP_PORT = 8765
+
     /**
      * Builds a configured [McpServer.McpSyncServer] that serves [tools] over [transportProvider].
      * Defaults the tool registry to the built-in tool set bound to [workspace] (the engine-backed port
@@ -77,6 +80,41 @@ object CodeAssistMcpServer {
      * authorized through [gate] first and refused (as an MCP tool-level error the client's model can act
      * on) when denied.
      */
+    /**
+     * Starts an MCP-over-HTTP server (Streamable HTTP, request-response mode) exposing the same tool set
+     * as [build], bound to [port] (0 picks an ephemeral port). The returned [HttpMcpServer] is how a host
+     * (e.g. the IDE's engine) embeds the server: callers get the bound port to advertise and close it to
+     * stop listening. Any MCP Streamable HTTP client can connect, including opencode configured with a
+     * `remote` server (e.g. `http://127.0.0.1:8765/mcp` after `adb forward tcp:8765 tcp:8765`).
+     */
+    fun startHttpServer(
+        workspace: AgentWorkspace,
+        port: Int = DEFAULT_HTTP_PORT,
+        tools: AgentToolRegistry = SimpleToolRegistry(builtinTools(workspace)),
+        gate: AgentPermissionGate = AllowAllGate,
+        serverName: String = DEFAULT_SERVER_NAME,
+        serverVersion: String = DEFAULT_SERVER_VERSION,
+        mapper: McpJsonMapper = McpJsonDefaults.getMapper(),
+    ): HttpMcpServer {
+        val provider = HttpStreamableServerTransportProvider(mapper)
+        val toolSpecs = tools.tools.map { tool -> toolSpec(tool, workspace, gate, mapper) }
+        McpServer.sync(provider)
+            .serverInfo(serverName, serverVersion)
+            .capabilities(
+                McpSchema.ServerCapabilities.builder()
+                    .tools(true)
+                    .resources(true, false)
+                    .prompts(true)
+                    .build(),
+            )
+            .tools(toolSpecs)
+            .resources(projectOverviewResource(workspace, mapper), projectMemoryResource(workspace, mapper))
+            .prompts(agentPrompt(workspace, tools))
+            .build()
+        provider.bind(port)
+        return HttpMcpServer(provider)
+    }
+
     private fun toolSpec(
         tool: AgentTool,
         workspace: AgentWorkspace,

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
@@ -1,0 +1,395 @@
+package dev.ide.agent.mcp
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A minimal embedded FTP server used as the CodeAssist asset inbox: anonymous, bound to 127.0.0.1 only,
+ * rooted at [root] (typically `<project>/assets`). Files uploaded with `STOR` land directly in [root], so
+ * a client can drop screenshots, APKs, or any binary and they appear in the workspace for the agent to
+ * consume. Serves the passive-mode subset a stock client (curl, `ftplib`, the OS file manager) needs:
+ * USER/PASS (anonymous), TYPE, PASV/EPSV, STOR, RETR, LIST/NLST, CWD/PWD, MKD/RMD/DELE, SIZE, MDTM, ABOR.
+ *
+ * Follows the same zero-dependency style as [HttpStreamableServerTransportProvider]'s socket server: one
+ * daemon accept thread, one daemon thread per control connection, and a short-lived passive data socket
+ * bound to 127.0.0.1 for each transfer. `TYPE A` is accepted but transfers raw bytes like `TYPE I` (the
+ * use-case is binary assets, where ASCII line-ending rewriting would corrupt the payload).
+ */
+class FtpServer(
+    root: Path,
+    private val port: Int = CodeAssistMcpServer.DEFAULT_FTP_PORT,
+) : AutoCloseable {
+    private val root: Path = root.toAbsolutePath().normalize()
+    private val lock = Any()
+    private var serverSocket: ServerSocket? = null
+    private val running = AtomicBoolean(false)
+
+    /** The port the listener is bound to, or -1 before [start]. */
+    val boundPort: Int get() = serverSocket?.localPort ?: -1
+
+    /** Starts the control listener on 127.0.0.1:[port] (0 picks an ephemeral port) and returns `this`. */
+    fun start(): FtpServer {
+        synchronized(lock) {
+            check(serverSocket == null) { "FTP server already bound to port $boundPort" }
+            Files.createDirectories(root)
+            val server = ServerSocket()
+            server.reuseAddress = true
+            server.bind(InetSocketAddress("127.0.0.1", port))
+            serverSocket = server
+            running.set(true)
+            Thread(::acceptLoop, "ftp-accept").apply { isDaemon = true }.start()
+        }
+        return this
+    }
+
+    override fun close() {
+        synchronized(lock) {
+            running.set(false)
+            serverSocket?.close()
+            serverSocket = null
+        }
+    }
+
+    private fun acceptLoop() {
+        while (running.get()) {
+            val server = serverSocket ?: return
+            if (server.isClosed) return
+            val client = try {
+                server.accept()
+            } catch (e: IOException) {
+                return
+            }
+            Thread({ handle(client) }, "ftp-conn").apply { isDaemon = true }.start()
+        }
+    }
+
+    private fun handle(client: Socket) {
+        client.use {
+            try {
+                Session(client).run()
+            } catch (e: IOException) {
+                // client hung up; nothing to send
+            } catch (e: Exception) {
+                runCatching {
+                    client.getOutputStream().write(
+                        "500 Internal error: ${e.message}\r\n".toByteArray(StandardCharsets.US_ASCII),
+                    )
+                    client.getOutputStream().flush()
+                }
+            }
+        }
+    }
+
+    /** Per-connection control session: owns the cwd, transfer type, and the current passive data socket. */
+    private inner class Session(private val client: Socket) {
+        private val reader = BufferedReader(InputStreamReader(client.getInputStream(), StandardCharsets.US_ASCII))
+        private val writer = BufferedWriter(OutputStreamWriter(client.getOutputStream(), StandardCharsets.US_ASCII))
+
+        /** POSIX-style path relative to [root] ("" is the root). */
+        private var cwd = ""
+        private var ascii = false
+        private var passive: ServerSocket? = null
+
+        fun run() {
+            reply(220, "CodeAssist FTP asset server ready.")
+            while (true) {
+                val line = reader.readLine() ?: break
+                if (line.isBlank()) continue
+                val sp = line.indexOf(' ')
+                val verb = (if (sp > 0) line.substring(0, sp) else line).uppercase(Locale.ROOT)
+                val arg = if (sp > 0) line.substring(sp + 1).trim() else ""
+                if (!dispatch(verb, arg)) break
+            }
+        }
+
+        private fun dispatch(verb: String, arg: String): Boolean = when (verb) {
+            "USER" -> { reply(331, "User name okay, need password."); true }
+            "PASS" -> { reply(230, "Logged in."); true }
+            "QUIT" -> { reply(221, "Goodbye."); false }
+            "NOOP" -> { reply(200, "NOOP okay."); true }
+            "SYST" -> { reply(215, "UNIX Type: L8"); true }
+            "TYPE" -> {
+                ascii = arg.equals("A", ignoreCase = true)
+                when {
+                    ascii || arg.equals("I", ignoreCase = true) || arg.equals("L 8", ignoreCase = true) ->
+                        reply(200, "Type set.")
+                    else -> reply(504, "Type not supported.")
+                }
+                true
+            }
+            "STRU" -> { reply(200, "Structure okay."); true }
+            "MODE" -> { reply(200, "Mode set."); true }
+            "PORT" -> { reply(502, "PORT not supported; use PASV."); true }
+            "PASV" -> pasv()
+            "EPSV" -> epsv()
+            "CWD" -> cwd(arg)
+            "CDUP" -> cwd("..")
+            "PWD" -> { reply(257, "\"/$cwd\" is the current directory."); true }
+            "MKD" -> mkd(arg)
+            "RMD" -> rmd(arg)
+            "DELE" -> dele(arg)
+            "SIZE" -> size(arg)
+            "MDTM" -> mdtm(arg)
+            "LIST" -> list(arg, detailed = true)
+            "NLST" -> list(arg, detailed = false)
+            "RETR" -> retr(arg)
+            "STOR" -> stor(arg)
+            "ABOR" -> { passive?.close(); passive = null; reply(225, "No transfer to abort."); true }
+            "FEAT" -> { feat(); true }
+            else -> { reply(502, "Command not implemented."); true }
+        }
+
+        // --- directory navigation ---
+
+        private fun cwd(arg: String): Boolean {
+            val target = resolve(arg) ?: run { reply(550, "No such directory."); return true }
+            if (!Files.isDirectory(target)) {
+                reply(550, "Not a directory.")
+                return true
+            }
+            cwd = relativePath(target)
+            reply(250, "Directory changed.")
+            return true
+        }
+
+        private fun mkd(arg: String): Boolean {
+            val target = resolve(arg) ?: run { reply(550, "Invalid path."); return true }
+            return try {
+                Files.createDirectories(target)
+                reply(257, "\"$arg\" created.")
+                true
+            } catch (e: IOException) {
+                reply(550, "Could not create directory: ${e.message}")
+                true
+            }
+        }
+
+        private fun rmd(arg: String): Boolean {
+            val target = resolve(arg) ?: run { reply(550, "Invalid path."); return true }
+            return try {
+                Files.deleteIfExists(target)
+                reply(250, "Directory removed.")
+                true
+            } catch (e: IOException) {
+                reply(550, "Could not remove directory: ${e.message}")
+                true
+            }
+        }
+
+        private fun dele(arg: String): Boolean {
+            val target = resolve(arg) ?: run { reply(550, "Invalid path."); return true }
+            return try {
+                Files.deleteIfExists(target)
+                reply(250, "File deleted.")
+                true
+            } catch (e: IOException) {
+                reply(550, "Could not delete file: ${e.message}")
+                true
+            }
+        }
+
+        private fun size(arg: String): Boolean {
+            val target = resolve(arg)
+            if (target == null || !Files.isRegularFile(target)) {
+                reply(550, "Not a file.")
+                return true
+            }
+            reply(213, Files.size(target).toString())
+            return true
+        }
+
+        private fun mdtm(arg: String): Boolean {
+            val target = resolve(arg)
+            if (target == null || !Files.isRegularFile(target)) {
+                reply(550, "Not a file.")
+                return true
+            }
+            val stamp = Files.getLastModifiedTime(target).toInstant().atZone(ZoneOffset.UTC)
+            reply(213, stamp.format(MDTM_FORMAT))
+            return true
+        }
+
+        // --- transfers ---
+
+        private fun list(arg: String, detailed: Boolean): Boolean {
+            val items = when {
+                arg.isBlank() -> childrenOf(resolve(cwd)!!)
+                else -> {
+                    val t = resolve(arg)
+                    when {
+                        t == null -> null
+                        Files.isDirectory(t) -> childrenOf(t)
+                        Files.exists(t) -> listOf(t)
+                        else -> null
+                    }
+                }
+            } ?: run { reply(550, "No such file or directory."); return true }
+            val conn = dataConnection() ?: return true
+            reply(150, "Opening data connection.")
+            conn.use {
+                val out = it.getOutputStream()
+                for (f in items) {
+                    val line = if (detailed) entryLine(f) else f.fileName.toString()
+                    out.write(line.toByteArray(StandardCharsets.UTF_8))
+                    out.write("\r\n".toByteArray(StandardCharsets.US_ASCII))
+                }
+                out.flush()
+            }
+            closeData()
+            reply(226, "Transfer complete.")
+            return true
+        }
+
+        private fun retr(arg: String): Boolean {
+            val target = resolve(arg)
+            if (target == null || !Files.isRegularFile(target)) {
+                reply(550, "No such file.")
+                return true
+            }
+            val conn = dataConnection() ?: return true
+            reply(150, "Opening data connection.")
+            conn.use {
+                val out = it.getOutputStream()
+                Files.newInputStream(target, StandardOpenOption.READ).use { input -> input.copyTo(out) }
+                out.flush()
+            }
+            closeData()
+            reply(226, "Transfer complete.")
+            return true
+        }
+
+        private fun stor(arg: String): Boolean {
+            val target = resolve(arg) ?: run { reply(550, "Invalid path."); return true }
+            val conn = dataConnection() ?: return true
+            reply(150, "Opening data connection.")
+            return try {
+                Files.createDirectories(target.parent)
+                conn.use {
+                    Files.newOutputStream(
+                        target,
+                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE,
+                    ).use { out -> it.getInputStream().copyTo(out) }
+                }
+                closeData()
+                reply(226, "Transfer complete.")
+                true
+            } catch (e: Exception) {
+                closeData()
+                reply(451, "Requested action aborted: ${e.message}")
+                true
+            }
+        }
+
+        private fun pasv(): Boolean {
+            val s = passiveSocket()
+            passive?.close()
+            passive = s
+            val p = s.localPort
+            reply(227, "Entering Passive Mode (127,0,0,1,${p ushr 8},${p and 0xFF})")
+            return true
+        }
+
+        private fun epsv(): Boolean {
+            val s = passiveSocket()
+            passive?.close()
+            passive = s
+            reply(229, "Entering Extended Passive Mode (|||${s.localPort}|)")
+            return true
+        }
+
+        private fun passiveSocket(): ServerSocket {
+            val s = ServerSocket()
+            s.reuseAddress = true
+            s.bind(InetSocketAddress("127.0.0.1", 0))
+            return s
+        }
+
+        /** Accepts the data connection for the current passive socket (15s window), or replies 425. */
+        private fun dataConnection(): Socket? {
+            val p = passive ?: run { reply(425, "Use PASV first."); return null }
+            p.soTimeout = DATA_ACCEPT_TIMEOUT_MS
+            return try {
+                p.accept()
+            } catch (e: IOException) {
+                reply(425, "Can't open data connection.")
+                null
+            }
+        }
+
+        private fun closeData() {
+            passive?.close()
+            passive = null
+        }
+
+        // --- FEAT / helpers ---
+
+        private fun feat() {
+            writer.write("211-Features supported\r\n")
+            writer.write(" UTF8\r\n")
+            writer.write(" SIZE\r\n")
+            writer.write(" MDTM\r\n")
+            writer.write(" PASV\r\n")
+            writer.write(" EPSV\r\n")
+            writer.write("211 End\r\n")
+            writer.flush()
+        }
+
+        /** Resolves an FTP path (relative to [cwd], or from the root when it starts with "/") to a real
+         *  [Path] inside [root]; null when it would escape the root (e.g. `..`). */
+        private fun resolve(arg: String): Path? {
+            val cleaned = arg.replace('\\', '/')
+            if (cleaned.isEmpty()) return resolve(cwd)
+            val base = if (cleaned.startsWith("/")) root else root.resolve(cwd)
+            val target = base.resolve(cleaned.trimStart('/')).normalize()
+            return target.takeIf { it.startsWith(root) }
+        }
+
+        private fun relativePath(p: Path): String {
+            val rel = root.relativize(p).toString()
+            return if (rel.isEmpty()) "" else rel.replace('\\', '/')
+        }
+
+        private fun childrenOf(dir: Path): List<Path>? =
+            if (Files.isDirectory(dir)) Files.list(dir).use { stream -> stream.sorted().toList() } else null
+
+        private fun entryLine(f: Path): String {
+            val isDir = Files.isDirectory(f)
+            val size = if (isDir) 0L else runCatching { Files.size(f) }.getOrDefault(0L)
+            val mtime = runCatching { Files.getLastModifiedTime(f).toInstant().atZone(ZoneOffset.UTC) }
+                .getOrDefault(LIST_EPOCH)
+            return String.format(
+                Locale.ROOT,
+                "%s %3s %3s %10d %s %s",
+                if (isDir) "drwxr-xr-x" else "-rw-r--r--",
+                "ftp", "ftp", size, mtime.format(LIST_DATE), f.fileName.toString(),
+            )
+        }
+
+        private fun reply(code: Int, text: String) {
+            writer.write("$code $text\r\n")
+            writer.flush()
+        }
+    }
+
+    private companion object {
+        const val DATA_ACCEPT_TIMEOUT_MS = 15_000
+        val LIST_DATE = DateTimeFormatter.ofPattern("MMM dd HH:mm", Locale.ROOT)
+        val MDTM_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss", Locale.ROOT)
+        val LIST_EPOCH = ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+    }
+}

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
@@ -239,8 +239,9 @@ class FtpServer(
                     }
                 }
             } ?: run { reply(550, "No such file or directory."); return true }
-            val conn = dataConnection() ?: return true
+            // Clients open the data socket only after reading 150, so the 150 must go out before we accept.
             reply(150, "Opening data connection.")
+            val conn = dataConnection() ?: return true
             conn.use {
                 val out = it.getOutputStream()
                 for (f in items) {
@@ -261,8 +262,8 @@ class FtpServer(
                 reply(550, "No such file.")
                 return true
             }
-            val conn = dataConnection() ?: return true
             reply(150, "Opening data connection.")
+            val conn = dataConnection() ?: return true
             conn.use {
                 val out = it.getOutputStream()
                 Files.newInputStream(target, StandardOpenOption.READ).use { input -> input.copyTo(out) }
@@ -275,8 +276,8 @@ class FtpServer(
 
         private fun stor(arg: String): Boolean {
             val target = resolve(arg) ?: run { reply(550, "Invalid path."); return true }
-            val conn = dataConnection() ?: return true
             reply(150, "Opening data connection.")
+            val conn = dataConnection() ?: return true
             return try {
                 Files.createDirectories(target.parent)
                 conn.use {
@@ -353,7 +354,6 @@ class FtpServer(
          *  [Path] inside [root]; null when it would escape the root (e.g. `..`). */
         private fun resolve(arg: String): Path? {
             val cleaned = arg.replace('\\', '/')
-            if (cleaned.isEmpty()) return resolve(cwd)
             val base = if (cleaned.startsWith("/")) root else root.resolve(cwd)
             val target = base.resolve(cleaned.trimStart('/')).normalize()
             return target.takeIf { it.startsWith(root) }

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/HttpMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/HttpMcpServer.kt
@@ -1,0 +1,325 @@
+package dev.ide.agent.mcp
+
+import io.modelcontextprotocol.json.McpJsonDefaults
+import io.modelcontextprotocol.json.McpJsonMapper
+import io.modelcontextprotocol.json.TypeRef
+import io.modelcontextprotocol.spec.McpSchema
+import io.modelcontextprotocol.spec.McpStreamableServerSession
+import io.modelcontextprotocol.spec.McpStreamableServerTransport
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider
+import reactor.core.publisher.Mono
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * An [McpStreamableServerTransportProvider] that speaks MCP's Streamable HTTP transport over a plain
+ * `java.net.ServerSocket` HTTP/1.1 server — no servlet container required, so it runs in-process in the IDE
+ * (or any pure-JVM host) and is addressable from another machine, e.g. via `adb forward tcp:8765 tcp:8765`
+ * followed by an opencode `remote` MCP server pointing at `http://127.0.0.1:8765/mcp`.
+ *
+ * Sessions are created on the first `initialize` request and keyed by the `Mcp-Session-Id` the server
+ * hands out; every later request/notification/response for a session is routed by that header, mirroring
+ * the SDK's servlet provider. Responses to requests are returned as a JSON-RPC body (request-response
+ * mode); `GET` streams and `DELETE` session teardown follow the protocol (the SDK clients fall back to
+ * request-response mode on the `GET` 405). Message handling is serialized per session, so the blocking
+ * sync server never sees interleaved calls.
+ */
+class HttpStreamableServerTransportProvider(
+    private val mapper: McpJsonMapper = McpJsonDefaults.getMapper(),
+) : McpStreamableServerTransportProvider {
+
+    private val sessions = ConcurrentHashMap<String, McpStreamableServerSession>()
+    private val socketServer = HttpServerSocket(this)
+
+    @Volatile
+    private var sessionFactory: McpStreamableServerSession.Factory? = null
+
+    /** Starts the HTTP listener on [port] (0 picks an ephemeral port) and returns the bound port. */
+    fun bind(port: Int): Int = socketServer.bind(port)
+
+    /** The port the listener is bound to, or -1 before [bind]. */
+    val boundPort: Int get() = socketServer.boundPort
+
+    /** Stops the HTTP listener and releases the socket. */
+    override fun close() {
+        socketServer.close()
+        sessions.clear()
+    }
+
+    override fun setSessionFactory(sessionFactory: McpStreamableServerSession.Factory) {
+        this.sessionFactory = sessionFactory
+    }
+
+    override fun notifyClients(method: String, params: Any?): Mono<Void> =
+        sessions.values
+            .map { it.sendNotification(method, params) }
+            .fold(Mono.empty<Void>()) { acc, m -> acc.then(m) }
+
+    override fun notifyClient(sessionId: String, method: String, params: Any?): Mono<Void> {
+        val session = sessions[sessionId] ?: return Mono.empty()
+        return session.sendNotification(method, params)
+    }
+
+    override fun closeGracefully(): Mono<Void> = Mono.fromRunnable { close() }
+
+    // --- message routing (called from the socket server's per-connection threads) ---
+
+    internal fun handlePost(body: String, sessionIdHeader: String?): HttpResponse {
+        val message = try {
+            McpSchema.deserializeJsonRpcMessage(mapper, body)
+        } catch (e: Exception) {
+            return errorResponse(McpSchema.ErrorCodes.INVALID_REQUEST, "Invalid message format: ${e.message}")
+        }
+
+        if (message is McpSchema.JSONRPCRequest && message.method() == McpSchema.METHOD_INITIALIZE) {
+            return handleInitialize(message)
+        }
+
+        val sessionId = sessionIdHeader?.trim()?.takeIf { it.isNotEmpty() }
+        if (sessionId == null) {
+            return errorResponse(McpSchema.ErrorCodes.METHOD_NOT_FOUND, "Session ID required in mcp-session-id header")
+        }
+        val session = sessions[sessionId]
+            ?: return errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "Session not found: $sessionId")
+
+        return synchronized(session) {
+            when (message) {
+                is McpSchema.JSONRPCResponse -> {
+                    session.accept(message).block()
+                    HttpResponse(202)
+                }
+                is McpSchema.JSONRPCNotification -> {
+                    session.accept(message).block()
+                    HttpResponse(202)
+                }
+                is McpSchema.JSONRPCRequest -> handleRequest(session, message)
+                else -> errorResponse(McpSchema.ErrorCodes.INVALID_REQUEST, "Unknown message type")
+            }
+        }
+    }
+
+    private fun handleInitialize(request: McpSchema.JSONRPCRequest): HttpResponse {
+        val factory = sessionFactory
+            ?: return errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "Server not initialized")
+        val initRequest = try {
+            mapper.convertValue(request.params(), object : TypeRef<McpSchema.InitializeRequest>() {})
+        } catch (e: Exception) {
+            return errorResponse(McpSchema.ErrorCodes.INVALID_REQUEST, "Invalid initialize params: ${e.message}")
+        }
+        return try {
+            val init = factory.startSession(initRequest)
+            sessions[init.session().id] = init.session()
+            val initResult = init.initResult().block()
+            val body = mapper.writeValueAsString(McpSchema.JSONRPCResponse.result(request.id(), initResult))
+            HttpResponse(200, headers = mapOf("Mcp-Session-Id" to init.session().id), body = body)
+        } catch (e: Exception) {
+            errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "Failed to initialize session: ${e.message}")
+        }
+    }
+
+    private fun handleRequest(
+        session: McpStreamableServerSession,
+        request: McpSchema.JSONRPCRequest,
+    ): HttpResponse {
+        val captured = AtomicReference<McpSchema.JSONRPCMessage>()
+        val transport = CapturingMcpTransport(mapper) { captured.set(it) }
+        try {
+            session.responseStream(request, transport).block()
+        } catch (e: Exception) {
+            return errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "Error processing request: ${e.message}")
+        }
+        val response = captured.get()
+            ?: return errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "No response produced for request")
+        return HttpResponse(200, body = mapper.writeValueAsString(response))
+    }
+
+    internal fun handleDelete(sessionIdHeader: String?): HttpResponse {
+        val sessionId = sessionIdHeader?.trim()?.takeIf { it.isNotEmpty() }
+            ?: return errorResponse(McpSchema.ErrorCodes.METHOD_NOT_FOUND, "Session ID required in mcp-session-id header")
+        val session = sessions.remove(sessionId)
+            ?: return errorResponse(McpSchema.ErrorCodes.INTERNAL_ERROR, "Session not found: $sessionId")
+        runCatching { session.delete().block() }
+        return HttpResponse(200)
+    }
+
+    private fun errorResponse(code: Int, message: String): HttpResponse {
+        val status = when (code) {
+            McpSchema.ErrorCodes.INVALID_REQUEST -> 400
+            McpSchema.ErrorCodes.METHOD_NOT_FOUND -> 404
+            else -> 500
+        }
+        // Transport-level errors carry a JSON-RPC error envelope with a null id; the SDK's
+        // JSONRPCResponse factories reject null ids, so the body is written by hand.
+        val escaped = message.replace("\\", "\\\\").replace("\"", "\\\"")
+        val body = """{"jsonrpc":"2.0","id":null,"error":{"code":$code,"message":"$escaped"}}"""
+        return HttpResponse(status, body = body)
+    }
+
+    /** A per-request [McpStreamableServerTransport] that captures the response the session produces. */
+    private class CapturingMcpTransport(
+        private val mapper: McpJsonMapper,
+        private val onMessage: (McpSchema.JSONRPCMessage) -> Unit,
+    ) : McpStreamableServerTransport {
+        override fun sendMessage(message: McpSchema.JSONRPCMessage): Mono<Void> =
+            Mono.fromRunnable { onMessage(message) }
+
+        override fun sendMessage(message: McpSchema.JSONRPCMessage, messageId: String): Mono<Void> =
+            sendMessage(message)
+
+        override fun <T> unmarshalFrom(data: Any, typeRef: TypeRef<T>): T = mapper.convertValue(data, typeRef)
+
+        override fun closeGracefully(): Mono<Void> = Mono.empty()
+    }
+}
+
+/** A bound, running MCP-over-HTTP server; close it to stop listening. */
+class HttpMcpServer internal constructor(
+    private val provider: HttpStreamableServerTransportProvider,
+) : AutoCloseable {
+    /** The port the server is listening on. */
+    val port: Int get() = provider.boundPort
+
+    override fun close() {
+        provider.close()
+    }
+}
+
+internal class HttpResponse(
+    val status: Int,
+    val headers: Map<String, String> = emptyMap(),
+    val body: String = "",
+)
+
+/** Minimal HTTP/1.1 server: one thread per connection, `Connection: close`, no keep-alive. */
+private class HttpServerSocket(
+    private val provider: HttpStreamableServerTransportProvider,
+) {
+    private val lock = Any()
+    private var serverSocket: ServerSocket? = null
+    private val acceptThread = Thread(::acceptLoop, "mcp-http-accept").apply { isDaemon = true }
+
+    val boundPort: Int get() = serverSocket?.localPort ?: -1
+
+    fun bind(port: Int): Int {
+        synchronized(lock) {
+            check(serverSocket == null) { "HTTP server already bound to port $boundPort" }
+            val server = ServerSocket()
+            server.reuseAddress = true
+            server.bind(InetSocketAddress("0.0.0.0", port))
+            serverSocket = server
+            acceptThread.start()
+            return server.localPort
+        }
+    }
+
+    fun close() {
+        synchronized(lock) {
+            serverSocket?.close()
+            serverSocket = null
+        }
+    }
+
+    private fun acceptLoop() {
+        while (true) {
+            val server = serverSocket ?: return
+            if (server.isClosed) return
+            val client = try {
+                server.accept()
+            } catch (e: IOException) {
+                return
+            }
+            Thread({ handle(client) }, "mcp-http-conn").apply { isDaemon = true }.start()
+        }
+    }
+
+    private fun handle(client: Socket) {
+        client.use {
+            try {
+                val request = readRequest(it.getInputStream())
+                val response = when (request.method) {
+                    "POST" -> provider.handlePost(request.body, request.header("mcp-session-id"))
+                    "DELETE" -> provider.handleDelete(request.header("mcp-session-id"))
+                    else -> HttpResponse(405, body = "Method not allowed")
+                }
+                writeResponse(it.getOutputStream(), response)
+            } catch (e: IOException) {
+                // client hung up; nothing to send
+            } catch (e: Exception) {
+                writeResponse(it.getOutputStream(), HttpResponse(500, body = "Internal error: ${e.message}"))
+            }
+        }
+    }
+
+    private fun readRequest(input: InputStream): HttpRequest {
+        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
+        val requestLine = reader.readLine() ?: throw IOException("empty request")
+        val parts = requestLine.split(' ')
+        val method = parts.getOrNull(0) ?: ""
+        val path = parts.getOrNull(1) ?: "/"
+        val headers = LinkedHashMap<String, String>()
+        while (true) {
+            val line = reader.readLine() ?: break
+            if (line.isEmpty()) break
+            val idx = line.indexOf(':')
+            if (idx > 0) {
+                headers[line.substring(0, idx).trim().lowercase()] = line.substring(idx + 1).trim()
+            }
+        }
+        val length = headers["content-length"]?.toIntOrNull() ?: 0
+        val body = if (length > 0) {
+            val chars = CharArray(length)
+            var read = 0
+            while (read < length) {
+                val n = reader.read(chars, read, length - read)
+                if (n < 0) break
+                read += n
+            }
+            String(chars, 0, read)
+        } else {
+            ""
+        }
+        return HttpRequest(method, path, headers, body)
+    }
+
+    private fun writeResponse(output: OutputStream, response: HttpResponse) {
+        val writer = BufferedWriter(OutputStreamWriter(output, StandardCharsets.UTF_8))
+        writer.write("HTTP/1.1 ${response.status} ${reasonPhrase(response.status)}\r\n")
+        writer.write("Connection: close\r\n")
+        writer.write("Content-Type: application/json\r\n")
+        writer.write("Content-Length: ${response.body.toByteArray(StandardCharsets.UTF_8).size}\r\n")
+        response.headers.forEach { (k, v) -> writer.write("$k: $v\r\n") }
+        writer.write("\r\n")
+        writer.write(response.body)
+        writer.flush()
+    }
+
+    private fun reasonPhrase(status: Int): String = when (status) {
+        200 -> "OK"
+        202 -> "Accepted"
+        400 -> "Bad Request"
+        404 -> "Not Found"
+        405 -> "Method Not Allowed"
+        500 -> "Internal Server Error"
+        else -> "Error"
+    }
+}
+
+private class HttpRequest(
+    val method: String,
+    val path: String,
+    val headers: Map<String, String>,
+    val body: String,
+) {
+    fun header(name: String): String? = headers[name]
+}

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
@@ -33,22 +33,33 @@ import java.util.concurrent.CountDownLatch
 fun main(args: Array<String>) {
     var project = System.getenv("CODEASSIST_MCP_PROJECT")
     var autoAccept = false
+    var httpPort: Int? = null
     var i = 0
     while (i < args.size) {
         when (args[i]) {
             "--project" -> project = args.getOrNull(++i) ?: error("--project requires a directory argument")
             "--auto-accept" -> autoAccept = true
+            "--http" -> {
+                val next = args.getOrNull(i + 1)
+                httpPort = next?.toIntOrNull() ?: CodeAssistMcpServer.DEFAULT_HTTP_PORT
+                if (next?.toIntOrNull() != null) i++
+            }
             "--help", "-h" -> {
                 println(
                     """
-                    |Usage: agent-mcp [--project <dir>] [--auto-accept]
+                    |Usage: agent-mcp [--project <dir>] [--auto-accept] [--http [<port>]]
                     |
                     |  --project <dir>  Project root to serve (default: current directory, or
                     |                   ${'$'}CODEASSIST_MCP_PROJECT).
                     |  --auto-accept    Authorize mutating tools (writes, deletes, HTTP requests) without
                     |                   prompting. Off by default: they are refused.
+                    |  --http [<port>]  Serve over HTTP (Streamable HTTP, request-response mode) instead of
+                    |                   stdio. Defaults to port ${'$'}{CodeAssistMcpServer.DEFAULT_HTTP_PORT}.
+                    |                   Useful for the standalone binary with an adb forward + a remote MCP
+                    |                   server; the IDE's in-app server uses the same code path.
                     |
-                    |Serves the Model Context Protocol over stdin/stdout (stdio transport).
+                    |Serves the Model Context Protocol over stdin/stdout (stdio transport), or over HTTP
+                    |when --http is given.
                     """.trimMargin(),
                 )
                 return
@@ -63,6 +74,15 @@ fun main(args: Array<String>) {
 
     val workspace = FileSystemAgentWorkspace(root)
     val gate = if (autoAccept) AllowAllGate else ReadOnlyGate
+
+    if (httpPort != null) {
+        val server = CodeAssistMcpServer.startHttpServer(workspace, port = httpPort, gate = gate)
+        System.err.println("CodeAssist MCP server ready over HTTP (project: $root, port: ${server.port})")
+        System.err.println("Mutating tools: ${if (autoAccept) "auto-accepted" else "denied"}.")
+        Runtime.getRuntime().addShutdownHook(Thread { server.close() })
+        SHUTDOWN_LATCH.await()
+        return
+    }
 
     // MCP output MUST be the only thing on stdout; anything else a client parses as a protocol message.
     System.err.println("CodeAssist MCP server ready (project: $root)")

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
@@ -7,6 +7,7 @@ import dev.ide.agent.WriteRequest
 import io.modelcontextprotocol.json.McpJsonDefaults
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 
@@ -34,6 +35,7 @@ fun main(args: Array<String>) {
     var project = System.getenv("CODEASSIST_MCP_PROJECT")
     var autoAccept = false
     var httpPort: Int? = null
+    var ftpPort: Int? = null
     var i = 0
     while (i < args.size) {
         when (args[i]) {
@@ -44,10 +46,15 @@ fun main(args: Array<String>) {
                 httpPort = next?.toIntOrNull() ?: CodeAssistMcpServer.DEFAULT_HTTP_PORT
                 if (next?.toIntOrNull() != null) i++
             }
+            "--ftp" -> {
+                val next = args.getOrNull(i + 1)
+                ftpPort = next?.toIntOrNull() ?: CodeAssistMcpServer.DEFAULT_FTP_PORT
+                if (next?.toIntOrNull() != null) i++
+            }
             "--help", "-h" -> {
                 println(
                     """
-                    |Usage: agent-mcp [--project <dir>] [--auto-accept] [--http [<port>]]
+                    |Usage: agent-mcp [--project <dir>] [--auto-accept] [--http [<port>]] [--ftp [<port>]]
                     |
                     |  --project <dir>  Project root to serve (default: current directory, or
                     |                   ${'$'}CODEASSIST_MCP_PROJECT).
@@ -57,6 +64,9 @@ fun main(args: Array<String>) {
                     |                   stdio. Defaults to port ${'$'}{CodeAssistMcpServer.DEFAULT_HTTP_PORT}.
                     |                   Useful for the standalone binary with an adb forward + a remote MCP
                     |                   server; the IDE's in-app server uses the same code path.
+                    |  --ftp [<port>]   Also serve an anonymous local FTP asset server (defaults to port
+                    |                   ${'$'}{CodeAssistMcpServer.DEFAULT_FTP_PORT}) rooted at <project>/assets.
+                    |                   Uploads land directly in the workspace for the agent to consume.
                     |
                     |Serves the Model Context Protocol over stdin/stdout (stdio transport), or over HTTP
                     |when --http is given.
@@ -75,11 +85,18 @@ fun main(args: Array<String>) {
     val workspace = FileSystemAgentWorkspace(root)
     val gate = if (autoAccept) AllowAllGate else ReadOnlyGate
 
-    if (httpPort != null) {
-        val server = CodeAssistMcpServer.startHttpServer(workspace, port = httpPort, gate = gate)
-        System.err.println("CodeAssist MCP server ready over HTTP (project: $root, port: ${server.port})")
-        System.err.println("Mutating tools: ${if (autoAccept) "auto-accepted" else "denied"}.")
-        Runtime.getRuntime().addShutdownHook(Thread { server.close() })
+    if (httpPort != null || ftpPort != null) {
+        val servers = mutableListOf<AutoCloseable>()
+        if (httpPort != null) {
+            val server = CodeAssistMcpServer.startHttpServer(workspace, port = httpPort, gate = gate)
+            System.err.println("CodeAssist MCP server ready over HTTP (project: $root, port: ${server.port})")
+            System.err.println("Mutating tools: ${if (autoAccept) "auto-accepted" else "denied"}.")
+            servers += server
+        }
+        if (ftpPort != null) {
+            servers += startFtpServer(root, ftpPort)
+        }
+        Runtime.getRuntime().addShutdownHook(Thread { servers.forEach { it.close() } })
         SHUTDOWN_LATCH.await()
         return
     }
@@ -104,6 +121,14 @@ fun main(args: Array<String>) {
 private object ReadOnlyGate : AgentPermissionGate {
     override val mode: PermissionMode get() = PermissionMode.PLAN_ONLY
     override suspend fun authorize(request: WriteRequest): Boolean = false
+}
+
+/** Starts the FTP asset server rooted at `<project>/assets` and logs where uploads land. */
+private fun startFtpServer(root: Path, port: Int): FtpServer {
+    val assets = root.resolve("assets")
+    val server = CodeAssistMcpServer.startFtpServer(assets, port)
+    System.err.println("FTP asset server ready on 127.0.0.1:${server.boundPort} (uploads → $assets)")
+    return server
 }
 
 private val SHUTDOWN_LATCH = CountDownLatch(1)

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/CodeAssistMcpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/CodeAssistMcpServerTest.kt
@@ -225,7 +225,7 @@ class CodeAssistMcpServerTest {
         result.content().joinToString("\n") { (it as McpSchema.TextContent).text() }
 
     /** An in-memory [AgentWorkspace] for the wire-level tests. */
-    private class FakeWorkspace(
+    internal class FakeWorkspace(
         val files: MutableMap<String, String> = mutableMapOf(),
         private val memory: String = "",
     ) : AgentWorkspace {
@@ -268,7 +268,7 @@ class CodeAssistMcpServerTest {
     }
 
     /** Refuses every mutating tool. */
-    private object DenyGate : AgentPermissionGate {
+    internal object DenyGate : AgentPermissionGate {
         override val mode: PermissionMode get() = PermissionMode.PLAN_ONLY
         override suspend fun authorize(request: WriteRequest): Boolean = false
     }

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
@@ -1,0 +1,153 @@
+package dev.ide.agent.mcp
+
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.net.Socket
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Drives [FtpServer] with a tiny raw-socket FTP client (same wire format curl/`ftplib` speak), covering the
+ * passive-mode asset round trip: STOR → SIZE → RETR → LIST → NLST → MDTM → MKD/CWD/DELE/RMD, plus the path
+ * traversal guard. Each test gets its own temp root and ephemeral port.
+ */
+class FtpServerTest {
+
+    private val tempDir: Path = Files.createTempDirectory("ftp-server-test")
+    private val server = FtpServer(tempDir, port = 0).start()
+    private val client = RawFtpClient(server.boundPort)
+
+    @Test
+    fun roundTrip() {
+        assertEquals(220, client.greetingCode)
+        assertEquals(331, client.cmd("USER anonymous"))
+        assertEquals(230, client.cmd("PASS anonymous@"))
+        assertEquals(200, client.cmd("TYPE I"))
+        assertEquals(200, client.cmd("STRU F"))
+        assertEquals(200, client.cmd("MODE S"))
+
+        // STOR (binary passthrough)
+        val payload = "hello world\n".toByteArray(Charsets.UTF_8)
+        client.dataCmd("STOR hello.txt", payload)
+        assertEquals(226, client.lastCode)
+        assertTrue(Files.readAllBytes(tempDir.resolve("hello.txt")).contentEquals(payload))
+
+        // SIZE
+        assertTrue(client.replyText("SIZE hello.txt").startsWith("213 ${payload.size}"))
+
+        // RETR round-trips the exact bytes
+        assertEquals(payload.toString(Charsets.UTF_8), client.dataText("RETR hello.txt"))
+        assertEquals(226, client.lastCode)
+
+        // LIST / NLST advertise the file
+        assertTrue(client.dataText("LIST").contains("hello.txt"))
+        assertTrue(client.dataText("NLST").contains("hello.txt"))
+
+        // MDTM
+        assertTrue(client.replyText("MDTM hello.txt").startsWith("213 "))
+
+        // Subdirectory navigation + nested upload
+        assertEquals(257, client.cmd("MKD sub"))
+        assertEquals(250, client.cmd("CWD sub"))
+        assertTrue(client.replyText("PWD").startsWith("257 \"/sub\""))
+        client.dataCmd("STOR other.txt", "x".toByteArray())
+        assertEquals(226, client.lastCode)
+        assertEquals(250, client.cmd("DELE other.txt"))
+        assertEquals(250, client.cmd("CDUP"))
+        assertEquals(250, client.cmd("RMD sub"))
+        assertEquals(250, client.cmd("DELE hello.txt"))
+        assertTrue(!Files.exists(tempDir.resolve("hello.txt")))
+
+        // QUIT
+        assertEquals(221, client.cmd("QUIT"))
+    }
+
+    @Test
+    fun rejectsPathTraversal() {
+        client.greetingCode
+        client.cmd("USER anonymous")
+        client.cmd("PASS x")
+        assertEquals(550, client.cmd("STOR ../escape.txt"))
+        assertTrue(!Files.exists(tempDir.parent.resolve("escape.txt")))
+    }
+
+    /** A tiny FTP control client (enough for USER/PASS/PASV/STOR/RETR/LIST/... over one socket). */
+    private class RawFtpClient(port: Int) : AutoCloseable {
+        private val socket = Socket("127.0.0.1", port)
+        private val reader = socket.getInputStream().bufferedReader(Charsets.US_ASCII)
+        private val writer = BufferedWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.US_ASCII))
+
+        val greetingCode: Int = readReply().take(3).toInt()
+
+        private var lastReply: String = ""
+
+        val lastCode: Int get() = lastReply.take(3).toInt()
+
+        /** Sends a command and returns the numeric reply code (last line for multi-line replies). */
+        fun cmd(line: String): Int {
+            writer.write("$line\r\n")
+            writer.flush()
+            lastReply = readReply()
+            return lastCode
+        }
+
+        /** Sends a command and returns the full reply text (for content assertions). */
+        fun replyText(line: String): String {
+            cmd(line)
+            return lastReply
+        }
+
+        /** Sends a PASV data command ([verbArg], e.g. `STOR x.txt`) and uploads [payload], returning the
+         *  completion code. */
+        fun dataCmd(verbArg: String, payload: ByteArray): Int {
+            val port = dataPort(cmdPASV())
+            val pre = readReply()
+            check(pre.startsWith("150")) { "expected 150 for $verbArg, got: $pre" }
+            Socket("127.0.0.1", port).use { it.getOutputStream().write(payload) }
+            lastReply = readReply()
+            return lastCode
+        }
+
+        /** Downloads the data for [verbArg] (e.g. `RETR x.txt`) and returns the raw bytes. */
+        fun dataText(verbArg: String): String {
+            val port = dataPort(cmdPASV())
+            val pre = readReply()
+            check(pre.startsWith("150")) { "expected 150 for $verbArg, got: $pre" }
+            val bytes = Socket("127.0.0.1", port).use { it.getInputStream().readBytes() }
+            lastReply = readReply()
+            return bytes.toString(Charsets.UTF_8)
+        }
+
+        private fun cmdPASV(): String {
+            writer.write("PASV\r\n")
+            writer.flush()
+            val reply = readReply()
+            check(reply.startsWith("227")) { "expected 227, got: $reply" }
+            return reply
+        }
+
+        private fun dataPort(pasvReply: String): Int {
+            val groups = Regex("\\((\\d+),(\\d+),(\\d+),(\\d+),(\\d+),(\\d+)\\)")
+                .find(pasvReply)?.groupValues?.drop(1)?.map { it.toInt() }
+                ?: throw IOException("no passive port in: $pasvReply")
+            return groups[4] * 256 + groups[5]
+        }
+
+        private fun readReply(): String {
+            val sb = StringBuilder()
+            while (true) {
+                val line = reader.readLine() ?: throw IOException("connection closed")
+                sb.append(line).append('\n')
+                // A multi-line reply continues while the 4th char is '-'; it ends on a plain "NNN ...".
+                if (line.length < 4 || line[3] != '-') break
+            }
+            return sb.toString().trim()
+        }
+
+        override fun close() = socket.close()
+    }
+}

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
@@ -77,7 +77,7 @@ class FtpServerTest {
 
     /** A tiny FTP control client (enough for USER/PASS/PASV/STOR/RETR/LIST/... over one socket). */
     private class RawFtpClient(port: Int) : AutoCloseable {
-        private val socket = Socket("127.0.0.1", port)
+        private val socket = Socket("127.0.0.1", port).apply { soTimeout = 10_000 }
         private val reader = socket.getInputStream().bufferedReader(Charsets.US_ASCII)
         private val writer = BufferedWriter(OutputStreamWriter(socket.getOutputStream(), Charsets.US_ASCII))
 
@@ -105,9 +105,11 @@ class FtpServerTest {
          *  completion code. */
         fun dataCmd(verbArg: String, payload: ByteArray): Int {
             val port = dataPort(cmdPASV())
+            writer.write("$verbArg\r\n")
+            writer.flush()
             val pre = readReply()
             check(pre.startsWith("150")) { "expected 150 for $verbArg, got: $pre" }
-            Socket("127.0.0.1", port).use { it.getOutputStream().write(payload) }
+            Socket("127.0.0.1", port).apply { soTimeout = 10_000 }.use { it.getOutputStream().write(payload) }
             lastReply = readReply()
             return lastCode
         }
@@ -115,9 +117,11 @@ class FtpServerTest {
         /** Downloads the data for [verbArg] (e.g. `RETR x.txt`) and returns the raw bytes. */
         fun dataText(verbArg: String): String {
             val port = dataPort(cmdPASV())
+            writer.write("$verbArg\r\n")
+            writer.flush()
             val pre = readReply()
             check(pre.startsWith("150")) { "expected 150 for $verbArg, got: $pre" }
-            val bytes = Socket("127.0.0.1", port).use { it.getInputStream().readBytes() }
+            val bytes = Socket("127.0.0.1", port).apply { soTimeout = 10_000 }.use { it.getInputStream().readBytes() }
             lastReply = readReply()
             return bytes.toString(Charsets.UTF_8)
         }

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/HttpMcpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/HttpMcpServerTest.kt
@@ -1,0 +1,138 @@
+package dev.ide.agent.mcp
+
+import dev.ide.agent.AllowAllGate
+import dev.ide.agent.SimpleToolRegistry
+import dev.ide.agent.impl.builtinTools
+import io.modelcontextprotocol.client.McpClient
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport
+import io.modelcontextprotocol.json.McpJsonDefaults
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end Streamable HTTP tests: the real SDK HTTP client (with its 405-on-GET fallback to
+ * request-response mode) talks to [HttpStreamableServerTransportProvider] over an in-process socket, so
+ * the whole wire path a remote opencode client will exercise is covered offline.
+ */
+class HttpMcpServerTest {
+
+    @Test
+    fun `streamable HTTP handshake and tool calls work end to end`() {
+        val fake = CodeAssistMcpServerTest.FakeWorkspace("src/Main.kt" to "fun main() { println(\"hi\") }")
+        val server = CodeAssistMcpServer.startHttpServer(
+            workspace = fake,
+            port = 0,
+            tools = SimpleToolRegistry(builtinTools(fake)),
+            gate = AllowAllGate,
+        )
+        val client = McpClient.sync(
+            HttpClientStreamableHttpTransport
+                .builder("http://127.0.0.1:${server.port}")
+                .jsonMapper(McpJsonDefaults.getMapper())
+                .build(),
+        ).build()
+
+        try {
+            val init = client.initialize()
+            assertEquals(CodeAssistMcpServer.DEFAULT_SERVER_NAME, init.serverInfo().name())
+
+            val toolNames = client.listTools().tools().map { it.name() }.toSet()
+            assertTrue("read_file" in toolNames)
+            assertTrue("edit_file" in toolNames)
+
+            val result = client.callTool(
+                McpSchema.CallToolRequest.builder("read_file")
+                    .arguments(mapOf("path" to "src/Main.kt"))
+                    .build(),
+            )
+            assertFalse(result.isError())
+            val text = result.content().joinToString("\n") { (it as McpSchema.TextContent).text() }
+            assertTrue("fun main" in text)
+
+            val edited = client.callTool(
+                McpSchema.CallToolRequest.builder("edit_file")
+                    .arguments(mapOf("path" to "src/Main.kt", "old_string" to "hi", "new_string" to "hey"))
+                    .build(),
+            )
+            assertFalse(edited.isError())
+            assertEquals("fun main() { println(\"hey\") }", fake.readNow("src/Main.kt"))
+        } finally {
+            client.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `second client gets its own session`() {
+        val fake = CodeAssistMcpServerTest.FakeWorkspace("a.txt" to "a")
+        val server = CodeAssistMcpServer.startHttpServer(fake, port = 0)
+
+        val first = newClient(server.port)
+        val second = newClient(server.port)
+        try {
+            first.initialize()
+            second.initialize()
+            assertTrue(first.listTools().tools().isNotEmpty())
+            assertTrue(second.listTools().tools().isNotEmpty())
+        } finally {
+            first.closeGracefully()
+            second.closeGracefully()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `raw HTTP wire format matches the streamable transport contract`() {
+        val fake = CodeAssistMcpServerTest.FakeWorkspace()
+        val server = CodeAssistMcpServer.startHttpServer(fake, port = 0)
+        val base = "http://127.0.0.1:${server.port}/mcp"
+        val http = java.net.http.HttpClient.newHttpClient()
+        try {
+            val get = http.send(
+                java.net.http.HttpRequest.newBuilder(java.net.URI.create(base))
+                    .header("Accept", "text/event-stream")
+                    .GET()
+                    .build(),
+                java.net.http.HttpResponse.BodyHandlers.ofString(),
+            )
+            assertEquals(405, get.statusCode(), "GET stream must be refused so clients fall back to request-response mode")
+
+            val initBody =
+                """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}"""
+            val init = http.send(post(base, initBody, null), java.net.http.HttpResponse.BodyHandlers.ofString())
+            assertEquals(200, init.statusCode())
+            val sessionId = init.headers().firstValue("mcp-session-id").orElseThrow()
+            assertTrue(init.body().contains("\"serverInfo\""))
+            assertTrue(init.body().contains("\"codeassist\""))
+
+            val toolsBody = """{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"""
+            val tools = http.send(post(base, toolsBody, sessionId), java.net.http.HttpResponse.BodyHandlers.ofString())
+            assertEquals(200, tools.statusCode())
+            assertTrue(tools.body().contains("\"read_file\""))
+
+            val missing = http.send(post(base, toolsBody, null), java.net.http.HttpResponse.BodyHandlers.ofString())
+            assertEquals(404, missing.statusCode(), "a request without a session id must be rejected, body: ${missing.body()}")
+        } finally {
+            server.close()
+        }
+    }
+
+    private fun post(url: String, body: String, sessionId: String?): java.net.http.HttpRequest {
+        val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(url))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .POST(java.net.http.HttpRequest.BodyPublishers.ofString(body))
+        if (sessionId != null) builder.header("Mcp-Session-Id", sessionId)
+        return builder.build()
+    }
+
+    private fun newClient(port: Int) = McpClient.sync(
+        HttpClientStreamableHttpTransport
+            .builder("http://127.0.0.1:$port")
+            .jsonMapper(McpJsonDefaults.getMapper())
+            .build(),
+    ).build()
+}

--- a/ide-core/build.gradle.kts
+++ b/ide-core/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(project(":deps-api"))
     implementation(project(":deps-impl")) // Maven dependency resolver (download/transitive/conflict)
     implementation(project(":agent-impl")) // the AI coding agent engine (providers, loop, tools)
+    implementation(project(":agent-mcp")) // the agent's MCP server (stdio standalone + in-app HTTP, see AgentBackend)
     implementation(project(":agent-ui")) // the agent's Compose UI plugin (AgentUiPlugin) — paired with AgentPlugin in BuiltInPlugins
     // Opt-in usage analytics. `api` because AnalyticsService appears in IdeServicesBackend's (public)
     // constructor signature, so a host wiring it (ide-android) needs the type on its compile classpath.

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
@@ -3,6 +3,7 @@ package dev.ide.core
 import dev.ide.agent.AgentEvent
 import dev.ide.agent.AgentEventSink
 import dev.ide.agent.AgentPermissionGate
+import dev.ide.agent.AllowAllGate
 import dev.ide.agent.PermissionMode
 import dev.ide.agent.ProviderConfig
 import dev.ide.agent.SimpleToolRegistry
@@ -12,6 +13,9 @@ import dev.ide.agent.impl.AgentProviders
 import dev.ide.agent.impl.OkHttpLlmTransport
 import dev.ide.agent.impl.SystemPrompt
 import dev.ide.agent.impl.builtinTools
+import dev.ide.agent.mcp.CodeAssistMcpServer
+import dev.ide.agent.mcp.HttpMcpServer
+import dev.ide.platform.log.Log
 import dev.ide.ui.backend.AgentService
 import dev.ide.ui.backend.UiAgentChatState
 import dev.ide.ui.backend.UiAgentConfig
@@ -52,6 +56,19 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     private val workspace = IdeAgentWorkspace(ctx)
     private val tools = SimpleToolRegistry(builtinTools(workspace))
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val log = Log.logger("ide.agent")
+
+    /** The in-app MCP-over-HTTP server, started when the "MCP server" AI setting is on. The server is
+     *  opt-in: enabling it is itself the permission to edit the open project, so its tools run under
+     *  [AllowAllGate] (a remote client cannot answer the interactive UI prompts). */
+    @Volatile
+    private var mcpServer: HttpMcpServer? = null
+
+    init {
+        if (prefBool("mcpServer", default = false)) {
+            mcpServer = startMcpServer()
+        }
+    }
 
     private val _chatState = MutableStateFlow(UiAgentChatState())
     override val chatState: StateFlow<UiAgentChatState> = _chatState.asStateFlow()
@@ -83,6 +100,19 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     private fun prefInt(key: String): Int? = pref(key)?.toIntOrNull()
 
     private fun prefBool(key: String, default: Boolean): Boolean = pref(key)?.toBooleanStrictOrNull() ?: default
+
+    /** Binds the MCP-over-HTTP server to the engine workspace; null when startup fails (e.g. port taken). */
+    private fun startMcpServer(): HttpMcpServer? = try {
+        CodeAssistMcpServer.startHttpServer(
+            workspace = workspace,
+            port = CodeAssistMcpServer.DEFAULT_HTTP_PORT,
+            tools = tools,
+            gate = AllowAllGate,
+        )
+    } catch (e: Exception) {
+        log.error("Failed to start the MCP server on port ${CodeAssistMcpServer.DEFAULT_HTTP_PORT}: ${e.message}", e)
+        null
+    }
 
     private fun modePref(): PermissionMode =
         runCatching { PermissionMode.valueOf(ctx.manager?.preference(MODE_PREF).orEmpty()) }
@@ -449,6 +479,9 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
         const val AI_PAGE = "ai"
         const val MODE_PREF = "agent.permissionMode"
         const val GATEWAY = "gateway"
+
+        /** The port the in-app MCP server listens on (see the "MCP server" AI setting). */
+        const val MCP_PORT = CodeAssistMcpServer.DEFAULT_HTTP_PORT
 
         /** The "leave it to the provider" reasoning-effort choice: nothing is sent on the request. */
         const val REASONING_EFFORT_DEFAULT = "default"

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
@@ -61,29 +61,6 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     private val transport = OkHttpLlmTransport()
     private val registry = AgentProviders.registry(transport)
     private val workspace = IdeAgentWorkspace(ctx)
-    private val tools = SimpleToolRegistry(builtinTools(workspace) + ftpControlTool)
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val log = Log.logger("ide.agent")
-
-    /** The in-app MCP-over-HTTP server, started when the "MCP server" AI setting is on. The server is
-     *  opt-in: enabling it is itself the permission to edit the open project, so its tools run under
-     *  [AllowAllGate] (a remote client cannot answer the interactive UI prompts). */
-    @Volatile
-    private var mcpServer: HttpMcpServer? = null
-
-    /** The local FTP asset server, started when the More-menu "FTP server" toggle (or the `ftp_server`
-     *  tool) is on. Anonymous and bound to 127.0.0.1 only; uploads land in `<project>/assets`. */
-    @Volatile
-    private var ftpServer: FtpServer? = null
-
-    init {
-        if (prefBool("mcpServer", default = false)) {
-            mcpServer = startMcpServer()
-        }
-        if (prefBool(FTP_PREF, default = false)) {
-            ftpServer = startFtpServer()
-        }
-    }
 
     /** The `ftp_server` tool: start, stop, or query the local FTP asset server. Advertised on the MCP
      *  server and to the in-app chat agent (which both share [tools]), so the feature is controllable from
@@ -113,6 +90,30 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
             } else {
                 ToolExecutionResult.ok("FTP asset server is stopped.")
             }
+        }
+    }
+
+    private val tools = SimpleToolRegistry(builtinTools(workspace) + ftpControlTool)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val log = Log.logger("ide.agent")
+
+    /** The in-app MCP-over-HTTP server, started when the "MCP server" AI setting is on. The server is
+     *  opt-in: enabling it is itself the permission to edit the open project, so its tools run under
+     *  [AllowAllGate] (a remote client cannot answer the interactive UI prompts). */
+    @Volatile
+    private var mcpServer: HttpMcpServer? = null
+
+    /** The local FTP asset server, started when the More-menu "FTP server" toggle (or the `ftp_server`
+     *  tool) is on. Anonymous and bound to 127.0.0.1 only; uploads land in `<project>/assets`. */
+    @Volatile
+    private var ftpServer: FtpServer? = null
+
+    init {
+        if (prefBool("mcpServer", default = false)) {
+            mcpServer = startMcpServer()
+        }
+        if (prefBool(FTP_PREF, default = false)) {
+            ftpServer = startFtpServer()
         }
     }
 

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
@@ -3,10 +3,14 @@ package dev.ide.core
 import dev.ide.agent.AgentEvent
 import dev.ide.agent.AgentEventSink
 import dev.ide.agent.AgentPermissionGate
+import dev.ide.agent.AgentTool
 import dev.ide.agent.AllowAllGate
 import dev.ide.agent.PermissionMode
 import dev.ide.agent.ProviderConfig
 import dev.ide.agent.SimpleToolRegistry
+import dev.ide.agent.ToolArgs
+import dev.ide.agent.ToolExecutionResult
+import dev.ide.agent.ToolSpec
 import dev.ide.agent.WriteRequest
 import dev.ide.agent.impl.AgentLoop
 import dev.ide.agent.impl.AgentProviders
@@ -14,7 +18,9 @@ import dev.ide.agent.impl.OkHttpLlmTransport
 import dev.ide.agent.impl.SystemPrompt
 import dev.ide.agent.impl.builtinTools
 import dev.ide.agent.mcp.CodeAssistMcpServer
+import dev.ide.agent.mcp.FtpServer
 import dev.ide.agent.mcp.HttpMcpServer
+import dev.ide.agent.toolSchema
 import dev.ide.platform.log.Log
 import dev.ide.ui.backend.AgentService
 import dev.ide.ui.backend.UiAgentChatState
@@ -39,6 +45,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.io.path.readText
@@ -54,7 +61,7 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     private val transport = OkHttpLlmTransport()
     private val registry = AgentProviders.registry(transport)
     private val workspace = IdeAgentWorkspace(ctx)
-    private val tools = SimpleToolRegistry(builtinTools(workspace))
+    private val tools = SimpleToolRegistry(builtinTools(workspace) + ftpControlTool)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val log = Log.logger("ide.agent")
 
@@ -64,9 +71,48 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     @Volatile
     private var mcpServer: HttpMcpServer? = null
 
+    /** The local FTP asset server, started when the More-menu "FTP server" toggle (or the `ftp_server`
+     *  tool) is on. Anonymous and bound to 127.0.0.1 only; uploads land in `<project>/assets`. */
+    @Volatile
+    private var ftpServer: FtpServer? = null
+
     init {
         if (prefBool("mcpServer", default = false)) {
             mcpServer = startMcpServer()
+        }
+        if (prefBool(FTP_PREF, default = false)) {
+            ftpServer = startFtpServer()
+        }
+    }
+
+    /** The `ftp_server` tool: start, stop, or query the local FTP asset server. Advertised on the MCP
+     *  server and to the in-app chat agent (which both share [tools]), so the feature is controllable from
+     *  a client as well as the More-menu toggle. Non-mutating: no project file changes. */
+    private val ftpControlTool = object : AgentTool {
+        override val spec = ToolSpec(
+            name = "ftp_server",
+            description = "Start, stop, or query the local FTP asset server (anonymous, bound to " +
+                "127.0.0.1:${CodeAssistMcpServer.DEFAULT_FTP_PORT}). When running, files uploaded over FTP " +
+                "land in the open project's assets/ folder, reachable from a PC with \"adb forward tcp:" +
+                CodeAssistMcpServer.DEFAULT_FTP_PORT + " tcp:" + CodeAssistMcpServer.DEFAULT_FTP_PORT + "\". " +
+                "action=status only reports the current state.",
+            parameters = toolSchema {
+                string("action", "start, stop, or status", enum = listOf("start", "stop", "status"))
+            },
+        )
+        override suspend fun execute(args: ToolArgs): ToolExecutionResult {
+            when (args.string("action")) {
+                "start" -> setFtpServerEnabled(true)
+                "stop" -> setFtpServerEnabled(false)
+            }
+            return if (ftpServer != null) {
+                ToolExecutionResult.ok(
+                    "FTP asset server is RUNNING on 127.0.0.1:${CodeAssistMcpServer.DEFAULT_FTP_PORT} " +
+                        "(uploads land in <project>/assets/).",
+                )
+            } else {
+                ToolExecutionResult.ok("FTP asset server is stopped.")
+            }
         }
     }
 
@@ -112,6 +158,32 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
     } catch (e: Exception) {
         log.error("Failed to start the MCP server on port ${CodeAssistMcpServer.DEFAULT_HTTP_PORT}: ${e.message}", e)
         null
+    }
+
+    /** Binds the FTP asset server to `<project>/assets` (created on start); null when no project is open or
+     *  startup fails (e.g. port taken). */
+    private fun startFtpServer(): FtpServer? = try {
+        val assets = ctx.servicesOrNull?.workspaceRoot?.resolve("assets")
+            ?: return null
+        Files.createDirectories(assets)
+        CodeAssistMcpServer.startFtpServer(assets, CodeAssistMcpServer.DEFAULT_FTP_PORT)
+    } catch (e: Exception) {
+        log.error("Failed to start the FTP server on port ${CodeAssistMcpServer.DEFAULT_FTP_PORT}: ${e.message}", e)
+        null
+    }
+
+    override fun ftpServerSupported(): Boolean = true
+
+    override fun ftpServerEnabled(): Boolean = ftpServer != null
+
+    override fun setFtpServerEnabled(enabled: Boolean) {
+        ctx.manager?.setPreference("settings.$AI_PAGE.$FTP_PREF", enabled.toString())
+        if (enabled) {
+            if (ftpServer == null) ftpServer = startFtpServer()
+        } else {
+            ftpServer?.close()
+            ftpServer = null
+        }
     }
 
     private fun modePref(): PermissionMode =
@@ -479,6 +551,9 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
         const val AI_PAGE = "ai"
         const val MODE_PREF = "agent.permissionMode"
         const val GATEWAY = "gateway"
+
+        /** The `settings.ai.*` pref backing the FTP asset server toggle (`ftpServer`). */
+        const val FTP_PREF = "ftpServer"
 
         /** The port the in-app MCP server listens on (see the "MCP server" AI setting). */
         const val MCP_PORT = CodeAssistMcpServer.DEFAULT_HTTP_PORT

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentPlugin.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentPlugin.kt
@@ -105,6 +105,16 @@ internal object AgentSettingsPage : SettingsPage {
                 "The web_fetch and http_request tools work regardless.",
             default = true,
         ),
+        SettingControl.Toggle(
+            key = "mcpServer",
+            title = "MCP server",
+            description = "Expose the agent's tools over MCP on port " + AgentBackend.MCP_PORT +
+                " (Streamable HTTP). Connect from a desktop client with \"adb forward tcp:" + AgentBackend.MCP_PORT +
+                " tcp:" + AgentBackend.MCP_PORT + "\" then add a remote MCP server at \"http://127.0.0.1:" +
+                AgentBackend.MCP_PORT + "/mcp\". Warning: any client that can reach the port can edit the open " +
+                "project, without further permission prompts. Applies on the next launch.",
+            default = false,
+        ),
         SettingControl.IntSlider(
             key = "maxTokens",
             title = "Max response tokens",

--- a/ide-ui-api/src/commonMain/kotlin/dev/ide/ui/backend/BackendServices.kt
+++ b/ide-ui-api/src/commonMain/kotlin/dev/ide/ui/backend/BackendServices.kt
@@ -1127,6 +1127,15 @@ interface AgentService {
     /** Answer a pending [permissionRequest]. */
     fun answerPermission(id: Int, decision: UiAgentPermissionDecision)
 
+    /** Whether the backend hosts the local FTP asset server (the More-menu toggle + `ftp_server` tool). */
+    fun ftpServerSupported(): Boolean = false
+
+    /** Whether the local FTP asset server is currently running. */
+    fun ftpServerEnabled(): Boolean = false
+
+    /** Start or stop the local FTP asset server (persisted under `settings.ai.ftpServer`). */
+    fun setFtpServerEnabled(enabled: Boolean) {}
+
     /** A no-op agent for backends that wire none. */
     object Unsupported : AgentService {
         override val chatState: StateFlow<UiAgentChatState> =

--- a/ide-ui/src/commonMain/composeResources/values/strings.xml
+++ b/ide-ui/src/commonMain/composeResources/values/strings.xml
@@ -161,6 +161,9 @@ We never collect your code, file or project names, which features you use, or an
     <string name="performance_analytics">Performance analytics</string>
     <string name="sharing_performance_data">Sharing anonymous performance data</string>
     <string name="not_sharing_performance_data">Not sharing performance data</string>
+    <string name="ftp_server">FTP server</string>
+    <string name="ftp_server_running">Running on 127.0.0.1:8021 · uploads go to assets/</string>
+    <string name="ftp_server_stopped">Stopped · local asset upload server</string>
     <string name="compatibility">Compatibility</string>
     <plurals name="recovered_projects">
         <item quantity="one">Recovered %1$d project from an older version</item>

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FtpServerToggleRow.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/FtpServerToggleRow.kt
@@ -1,0 +1,60 @@
+package dev.ide.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.ide.ui.generated.resources.Res
+import dev.ide.ui.generated.resources.ftp_server
+import dev.ide.ui.generated.resources.ftp_server_running
+import dev.ide.ui.generated.resources.ftp_server_stopped
+import dev.ide.ui.icons.CaIcons
+import org.jetbrains.compose.resources.stringResource
+
+/** A compact on/off row for the local FTP asset server, shown in the editor's More menu. */
+@Composable
+fun FtpServerToggleRow(
+    enabled: Boolean,
+    onChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .clickable(
+                remember { MutableInteractionSource() },
+                indication = null,
+            ) { onChange(!enabled) }
+            .padding(vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(CaIcons.folder, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        Column(Modifier.weight(1f)) {
+            Text(
+                stringResource(Res.string.ftp_server),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                if (enabled) stringResource(Res.string.ftp_server_running)
+                else stringResource(Res.string.ftp_server_stopped),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        PillToggle(enabled, onChange)
+    }
+}

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/PillToggle.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/PillToggle.kt
@@ -1,0 +1,41 @@
+package dev.ide.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.ide.ui.theme.Ca
+
+/** A small on-brand pill toggle (matches the module-settings switch), shared by the settings rows. */
+@Composable
+fun PillToggle(
+    on: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier
+            .size(width = 44.dp, height = 26.dp)
+            .background(
+                if (on) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHighest,
+                RoundedCornerShape(Ca.radius.pill),
+            )
+            .clickable(remember { MutableInteractionSource() }, indication = null) { onToggle(!on) }
+            .padding(3.dp),
+        contentAlignment = if (on) Alignment.CenterEnd else Alignment.CenterStart,
+    ) {
+        Box(
+            Modifier.size(20.dp)
+                .background(MaterialTheme.colorScheme.onPrimary, RoundedCornerShape(Ca.radius.pill))
+        )
+    }
+}

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorSheets.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorSheets.kt
@@ -30,6 +30,7 @@ import dev.ide.ui.backend.IdeBackend
 import dev.ide.ui.backend.UiActionPlaces
 import dev.ide.ui.components.AnalyticsToggleRow
 import dev.ide.ui.components.BottomSheet
+import dev.ide.ui.components.FtpServerToggleRow
 import dev.ide.ui.components.CommandPalette
 import dev.ide.ui.components.DropdownOverlay
 import dev.ide.ui.ext.UiPluginHost
@@ -151,6 +152,16 @@ internal fun MoreSheetContent(
             Box(Modifier.fillMaxWidth().padding(vertical = 8.dp).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
             Box(Modifier.padding(horizontal = 6.dp)) {
                 AnalyticsToggleRow(enabled = on, onChange = { on = it; backend.diagnostics.setAnalyticsConsent(it) })
+            }
+        }
+
+        // The local FTP asset server toggle sits below analytics; it's controllable from the app or via the
+        // `ftp_server` MCP tool (both flip the same `settings.ai.ftpServer` pref + live server state).
+        if (backend.agent.ftpServerSupported()) {
+            var on by remember { mutableStateOf(backend.agent.ftpServerEnabled()) }
+            Box(Modifier.fillMaxWidth().padding(vertical = 8.dp).height(1.dp).background(MaterialTheme.colorScheme.outlineVariant))
+            Box(Modifier.padding(horizontal = 6.dp)) {
+                FtpServerToggleRow(enabled = on, onChange = { on = it; backend.agent.setFtpServerEnabled(it) })
             }
         }
     }


### PR DESCRIPTION
## Summary
Extends the MCP server from #1482 (stdio) with an in-app Streamable HTTP transport plus an anonymous local FTP asset server, so the MCP agent can run remotely (e.g. over `adb forward`) and consume files uploaded into the workspace.

## Changes
- **agent-mcp**
  - `HttpMcpServer` — Streamable HTTP (request-response) transport for the MCP server
  - `FtpServer` — anonymous local FTP asset server rooted at `<project>/assets`, plus FTP protocol deadlock fix
  - `CodeAssistMcpServer.startHttpServer`/`startFtpServer` — the same code path the IDE uses
  - CLI: `--http [port]` (default 8765) and `--ftp [port]` flags for the standalone binary
  - tests: `HttpMcpServerTest`, `FtpServerTest` (round-trip), `CodeAssistMcpServerTest` update
- **ide-core**: `AgentBackend` hosts the in-app HTTP/FTP servers; `ftpControlTool` registered before tools-registry init; `AgentPlugin` wiring
- **ide-ui**: `FtpServerToggleRow` / `PillToggle` More-menu toggle, `BackendServices` plumbing, `strings.xml` entries

Default behavior is unchanged (stdio, mutating tools denied unless `--auto-accept`).