### PR TITLE
fix(agent-mcp): loopback-only HTTP server, byte-framed bodies, and a forwardable FTP data port

### DIFF
--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/CodeAssistMcpServer.kt
@@ -43,7 +43,11 @@ object CodeAssistMcpServer {
     /** Default port for the in-IDE MCP-over-HTTP server (`adb forward tcp:8765 tcp:8765`). */
     const val DEFAULT_HTTP_PORT = 8765
 
-    /** Default port for the local FTP asset server (`adb forward tcp:8021 tcp:8021`). */
+    /**
+     * Default control port for the local FTP asset server. Passive transfers take the next port up, so
+     * driving it from a PC means forwarding both: `adb forward tcp:8021 tcp:8021` and
+     * `adb forward tcp:8022 tcp:8022`.
+     */
     const val DEFAULT_FTP_PORT = 8021
 
     /**

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/FtpServer.kt
@@ -29,10 +29,18 @@ import java.util.concurrent.atomic.AtomicBoolean
  * daemon accept thread, one daemon thread per control connection, and a short-lived passive data socket
  * bound to 127.0.0.1 for each transfer. `TYPE A` is accepted but transfers raw bytes like `TYPE I` (the
  * use-case is binary assets, where ASCII line-ending rewriting would corrupt the payload).
+ *
+ * Passive mode needs a second port, and a passive port picked at random is a port a desktop client cannot
+ * reach: `adb forward` forwards the ports it is told about, one at a time. So each transfer claims
+ * [passivePort] (the control port plus one by default) and only falls back to an ephemeral port when that
+ * one is busy, which is what makes `adb forward tcp:8021 tcp:8021` plus `adb forward tcp:8022 tcp:8022`
+ * enough to drive the server from a PC. A second concurrent client takes the fallback and stays on-device.
  */
 class FtpServer(
     root: Path,
     private val port: Int = CodeAssistMcpServer.DEFAULT_FTP_PORT,
+    /** The port passive transfers prefer; see the class doc for why it is fixed rather than ephemeral. */
+    private val passivePort: Int = if (port == 0) 0 else port + 1,
 ) : AutoCloseable {
     private val root: Path = root.toAbsolutePath().normalize()
     private val lock = Any()
@@ -106,14 +114,19 @@ class FtpServer(
         private var passive: ServerSocket? = null
 
         fun run() {
-            reply(220, "CodeAssist FTP asset server ready.")
-            while (true) {
-                val line = reader.readLine() ?: break
-                if (line.isBlank()) continue
-                val sp = line.indexOf(' ')
-                val verb = (if (sp > 0) line.substring(0, sp) else line).uppercase(Locale.ROOT)
-                val arg = if (sp > 0) line.substring(sp + 1).trim() else ""
-                if (!dispatch(verb, arg)) break
+            try {
+                reply(220, "CodeAssist FTP asset server ready.")
+                while (true) {
+                    val line = reader.readLine() ?: break
+                    if (line.isBlank()) continue
+                    val sp = line.indexOf(' ')
+                    val verb = (if (sp > 0) line.substring(0, sp) else line).uppercase(Locale.ROOT)
+                    val arg = if (sp > 0) line.substring(sp + 1).trim() else ""
+                    if (!dispatch(verb, arg)) break
+                }
+            } finally {
+                // A PASV nobody ever used still holds a listening port; the session owns it, so it frees it.
+                closeData()
             }
         }
 
@@ -297,8 +310,9 @@ class FtpServer(
         }
 
         private fun pasv(): Boolean {
+            // Free the previous listener first: it holds the fixed data port the new one wants.
+            closeData()
             val s = passiveSocket()
-            passive?.close()
             passive = s
             val p = s.localPort
             reply(227, "Entering Passive Mode (127,0,0,1,${p ushr 8},${p and 0xFF})")
@@ -306,18 +320,33 @@ class FtpServer(
         }
 
         private fun epsv(): Boolean {
+            closeData()
             val s = passiveSocket()
-            passive?.close()
             passive = s
             reply(229, "Entering Extended Passive Mode (|||${s.localPort}|)")
             return true
         }
 
+        /** Binds the data listener on [passivePort], or on an ephemeral port when that one is taken. */
         private fun passiveSocket(): ServerSocket {
+            tryBind(passivePort)?.let { return it }
             val s = ServerSocket()
             s.reuseAddress = true
             s.bind(InetSocketAddress("127.0.0.1", 0))
             return s
+        }
+
+        /** Binds a data listener on [port], or null when something already holds it. */
+        private fun tryBind(port: Int): ServerSocket? {
+            val s = ServerSocket()
+            s.reuseAddress = true
+            return try {
+                s.bind(InetSocketAddress("127.0.0.1", port))
+                s
+            } catch (e: IOException) {
+                s.close()
+                null
+            }
         }
 
         /** Accepts the data connection for the current passive socket (15s window), or replies 425. */
@@ -327,6 +356,7 @@ class FtpServer(
             return try {
                 p.accept()
             } catch (e: IOException) {
+                closeData()
                 reply(425, "Can't open data connection.")
                 null
             }

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/HttpMcpServer.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/HttpMcpServer.kt
@@ -8,16 +8,17 @@ import io.modelcontextprotocol.spec.McpStreamableServerSession
 import io.modelcontextprotocol.spec.McpStreamableServerTransport
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider
 import reactor.core.publisher.Mono
-import java.io.BufferedReader
+import java.io.BufferedInputStream
 import java.io.BufferedWriter
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
-import java.io.InputStreamReader
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
@@ -25,8 +26,9 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * An [McpStreamableServerTransportProvider] that speaks MCP's Streamable HTTP transport over a plain
  * `java.net.ServerSocket` HTTP/1.1 server — no servlet container required, so it runs in-process in the IDE
- * (or any pure-JVM host) and is addressable from another machine, e.g. via `adb forward tcp:8765 tcp:8765`
- * followed by an opencode `remote` MCP server pointing at `http://127.0.0.1:8765/mcp`.
+ * (or any pure-JVM host). The listener is loopback-only; a desktop client reaches it through
+ * `adb forward tcp:8765 tcp:8765`, which dials the device's own 127.0.0.1, followed by an opencode
+ * `remote` MCP server pointing at `http://127.0.0.1:8765/mcp`.
  *
  * Sessions are created on the first `initialize` request and keyed by the `Mcp-Session-Id` the server
  * hands out; every later request/notification/response for a session is routed by that header, mirroring
@@ -201,7 +203,14 @@ internal class HttpResponse(
     val body: String = "",
 )
 
-/** Minimal HTTP/1.1 server: one thread per connection, `Connection: close`, no keep-alive. */
+/**
+ * Minimal HTTP/1.1 server: one thread per connection, `Connection: close`, no keep-alive.
+ *
+ * Bound to loopback only. The transport authenticates nobody and its tools can edit the open project, so
+ * the port must not be reachable off the device; `adb forward` needs nothing more than 127.0.0.1.
+ * [isLocal] then covers the one case loopback binding does not: a browser aimed at the port by a hostname
+ * the attacker rebinds to it.
+ */
 private class HttpServerSocket(
     private val provider: HttpStreamableServerTransportProvider,
 ) {
@@ -216,7 +225,7 @@ private class HttpServerSocket(
             check(serverSocket == null) { "HTTP server already bound to port $boundPort" }
             val server = ServerSocket()
             server.reuseAddress = true
-            server.bind(InetSocketAddress("0.0.0.0", port))
+            server.bind(InetSocketAddress(LOOPBACK, port))
             serverSocket = server
             acceptThread.start()
             return server.localPort
@@ -246,30 +255,60 @@ private class HttpServerSocket(
     private fun handle(client: Socket) {
         client.use {
             try {
+                // A peer that connects and then stalls would otherwise pin this thread for good.
+                it.soTimeout = READ_TIMEOUT_MS
                 val request = readRequest(it.getInputStream())
-                val response = when (request.method) {
-                    "POST" -> provider.handlePost(request.body, request.header("mcp-session-id"))
-                    "DELETE" -> provider.handleDelete(request.header("mcp-session-id"))
+                val response = when {
+                    !request.isLocal() -> HttpResponse(403, body = "Forbidden")
+                    request.method == "POST" -> provider.handlePost(request.body, request.header("mcp-session-id"))
+                    request.method == "DELETE" -> provider.handleDelete(request.header("mcp-session-id"))
                     else -> HttpResponse(405, body = "Method not allowed")
                 }
                 writeResponse(it.getOutputStream(), response)
+            } catch (e: RequestTooLargeException) {
+                runCatching { writeResponse(it.getOutputStream(), HttpResponse(413, body = "Payload too large")) }
             } catch (e: IOException) {
-                // client hung up; nothing to send
+                // client hung up, or the read timed out; nothing to send
             } catch (e: Exception) {
-                writeResponse(it.getOutputStream(), HttpResponse(500, body = "Internal error: ${e.message}"))
+                runCatching {
+                    writeResponse(it.getOutputStream(), HttpResponse(500, body = "Internal error: ${e.message}"))
+                }
             }
         }
     }
 
+    /**
+     * Whether the request came from this device. Loopback binding already keeps the network out, but a
+     * browser can be steered at 127.0.0.1 by a hostname the attacker rebinds to it, which is why the MCP
+     * Streamable HTTP transport asks servers to check these two headers. A native client (opencode, curl)
+     * sends no `Origin`, so only a present-and-foreign one is refused; a missing `Host` is likewise let
+     * through, since a browser always sends one.
+     */
+    private fun HttpRequest.isLocal(): Boolean {
+        val host = header("host")?.let {
+            if (it.startsWith("[")) it.substringAfter('[').substringBefore(']') else it.substringBefore(':')
+        }
+        if (host != null && host !in LOCAL_HOSTS) return false
+        val origin = header("origin") ?: return true
+        val originHost = runCatching { URI(origin).host }.getOrNull() ?: return false
+        return originHost.trim('[', ']') in LOCAL_HOSTS
+    }
+
+    /**
+     * Reads one request. The head is read byte-wise rather than through a `Reader` so the body can be taken
+     * as exactly `Content-Length` *bytes*: that header counts bytes, and decoding first left any body with
+     * a non-ASCII character (an emoji in an edit, an accented path) short by the difference and blocked the
+     * read until the socket timed out.
+     */
     private fun readRequest(input: InputStream): HttpRequest {
-        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
-        val requestLine = reader.readLine() ?: throw IOException("empty request")
+        val stream = BufferedInputStream(input)
+        val requestLine = readHeaderLine(stream) ?: throw IOException("empty request")
         val parts = requestLine.split(' ')
         val method = parts.getOrNull(0) ?: ""
         val path = parts.getOrNull(1) ?: "/"
         val headers = LinkedHashMap<String, String>()
         while (true) {
-            val line = reader.readLine() ?: break
+            val line = readHeaderLine(stream) ?: break
             if (line.isEmpty()) break
             val idx = line.indexOf(':')
             if (idx > 0) {
@@ -277,20 +316,37 @@ private class HttpServerSocket(
             }
         }
         val length = headers["content-length"]?.toIntOrNull() ?: 0
+        if (length > MAX_BODY_BYTES) throw RequestTooLargeException()
         val body = if (length > 0) {
-            val chars = CharArray(length)
+            val bytes = ByteArray(length)
             var read = 0
             while (read < length) {
-                val n = reader.read(chars, read, length - read)
+                val n = stream.read(bytes, read, length - read)
                 if (n < 0) break
                 read += n
             }
-            String(chars, 0, read)
+            String(bytes, 0, read, StandardCharsets.UTF_8)
         } else {
             ""
         }
         return HttpRequest(method, path, headers, body)
     }
+
+    /** Reads one CRLF- (or bare LF-) terminated head line as ISO-8859-1, HTTP's byte-per-char default. */
+    private fun readHeaderLine(input: InputStream): String? {
+        val line = ByteArrayOutputStream()
+        while (true) {
+            val b = input.read()
+            when {
+                b < 0 -> return if (line.size() == 0) null else decode(line)
+                b == '\n'.code -> return decode(line).removeSuffix("\r")
+                else -> line.write(b)
+            }
+        }
+    }
+
+    private fun decode(buffer: ByteArrayOutputStream): String =
+        String(buffer.toByteArray(), StandardCharsets.ISO_8859_1)
 
     private fun writeResponse(output: OutputStream, response: HttpResponse) {
         val writer = BufferedWriter(OutputStreamWriter(output, StandardCharsets.UTF_8))
@@ -308,12 +364,31 @@ private class HttpServerSocket(
         200 -> "OK"
         202 -> "Accepted"
         400 -> "Bad Request"
+        403 -> "Forbidden"
         404 -> "Not Found"
         405 -> "Method Not Allowed"
+        413 -> "Payload Too Large"
         500 -> "Internal Server Error"
         else -> "Error"
     }
+
+    private companion object {
+        /** The only address the listener binds: see the class doc for why it is not configurable. */
+        const val LOOPBACK = "127.0.0.1"
+
+        /** How long a connection may go without sending, so a stalled peer cannot hold its thread. */
+        const val READ_TIMEOUT_MS = 30_000
+
+        /** Ceiling on `Content-Length`, so a bogus header cannot allocate the IDE into an OOM. */
+        const val MAX_BODY_BYTES = 16 * 1024 * 1024
+
+        /** The hosts a request may claim and still count as local (see [isLocal]). */
+        val LOCAL_HOSTS = setOf("127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1")
+    }
 }
+
+/** Raised when a request declares a `Content-Length` past the server's body ceiling. */
+private class RequestTooLargeException : Exception()
 
 private class HttpRequest(
     val method: String,

--- a/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
+++ b/agent-mcp/src/main/kotlin/dev/ide/agent/mcp/Main.kt
@@ -67,6 +67,8 @@ fun main(args: Array<String>) {
                     |  --ftp [<port>]   Also serve an anonymous local FTP asset server (defaults to port
                     |                   ${'$'}{CodeAssistMcpServer.DEFAULT_FTP_PORT}) rooted at <project>/assets.
                     |                   Uploads land directly in the workspace for the agent to consume.
+                    |                   Passive transfers use the next port up, so an adb forward needs
+                    |                   both that port and the one after it.
                     |
                     |Serves the Model Context Protocol over stdin/stdout (stdio transport), or over HTTP
                     |when --http is given.

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/FtpServerTest.kt
@@ -6,6 +6,7 @@ import java.io.OutputStreamWriter
 import java.net.Socket
 import java.nio.file.Files
 import java.nio.file.Path
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -64,6 +65,30 @@ class FtpServerTest {
 
         // QUIT
         assertEquals(221, client.cmd("QUIT"))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        client.close()
+        server.close()
+    }
+
+    @Test
+    fun `passive transfers prefer the configured data port so an adb forward can reach them`() {
+        // A port nobody holds: bound to learn its number, then released. The point of the fixed port is
+        // that a client can forward it ahead of time, which an ephemeral one makes impossible.
+        val dataPort = java.net.ServerSocket(0).use { it.localPort }
+        FtpServer(tempDir, port = 0, passivePort = dataPort).start().use { fixed ->
+            RawFtpClient(fixed.boundPort).use { c ->
+                c.greetingCode
+                c.cmd("USER anonymous")
+                c.cmd("PASS x")
+                assertEquals(dataPort, c.passivePort())
+                // Stable across transfers: the previous listener is released before the next one binds,
+                // so the second PASV does not find the port taken and fall back to an ephemeral one.
+                assertEquals(dataPort, c.passivePort())
+            }
+        }
     }
 
     @Test
@@ -125,6 +150,9 @@ class FtpServerTest {
             lastReply = readReply()
             return bytes.toString(Charsets.UTF_8)
         }
+
+        /** The port the server advertises for the next passive transfer. */
+        fun passivePort(): Int = dataPort(cmdPASV())
 
         private fun cmdPASV(): String {
             writer.write("PASV\r\n")

--- a/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/HttpMcpServerTest.kt
+++ b/agent-mcp/src/test/kotlin/dev/ide/agent/mcp/HttpMcpServerTest.kt
@@ -120,13 +120,96 @@ class HttpMcpServerTest {
         }
     }
 
-    private fun post(url: String, body: String, sessionId: String?): java.net.http.HttpRequest {
+    @Test
+    fun `a body with non-ASCII text is framed by bytes, not chars`() {
+        val fake = CodeAssistMcpServerTest.FakeWorkspace("a.kt" to "val greeting = \"hi\"")
+        val server = CodeAssistMcpServer.startHttpServer(fake, port = 0)
+        val http = java.net.http.HttpClient.newHttpClient()
+        try {
+            val base = "http://127.0.0.1:${server.port}/mcp"
+            val session = initialize(http, base)
+            // Content-Length counts bytes, and this payload runs well ahead of its char count, so a
+            // char-counted read would still be waiting for the difference when the client gave up.
+            val call =
+                """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"edit_file","arguments":{"path":"a.kt","old_string":"hi","new_string":"héllo 🎉 こんにちは"}}}"""
+            val response = http.send(post(base, call, session), java.net.http.HttpResponse.BodyHandlers.ofString())
+
+            assertEquals(200, response.statusCode())
+            assertEquals("val greeting = \"héllo 🎉 こんにちは\"", fake.readNow("a.kt"))
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `a foreign Origin is refused so a rebound hostname cannot drive the server`() {
+        val server = CodeAssistMcpServer.startHttpServer(CodeAssistMcpServerTest.FakeWorkspace(), port = 0)
+        val http = java.net.http.HttpClient.newHttpClient()
+        try {
+            val base = "http://127.0.0.1:${server.port}/mcp"
+            val foreign = http.send(
+                post(base, INIT_BODY, null, origin = "http://evil.example"),
+                java.net.http.HttpResponse.BodyHandlers.ofString(),
+            )
+            assertEquals(403, foreign.statusCode(), "a page on another origin must not reach the tools")
+
+            val local = http.send(
+                post(base, INIT_BODY, null, origin = "http://127.0.0.1:5173"),
+                java.net.http.HttpResponse.BodyHandlers.ofString(),
+            )
+            assertEquals(200, local.statusCode(), "a loopback origin is the local client and stays allowed")
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `an oversized Content-Length is refused instead of allocated`() {
+        val server = CodeAssistMcpServer.startHttpServer(CodeAssistMcpServerTest.FakeWorkspace(), port = 0)
+        try {
+            java.net.Socket("127.0.0.1", server.port).use { socket ->
+                socket.soTimeout = 20_000
+                socket.getOutputStream().write(
+                    "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 2000000000\r\n\r\n"
+                        .toByteArray(Charsets.US_ASCII),
+                )
+                socket.getOutputStream().flush()
+                val status = socket.getInputStream().bufferedReader(Charsets.ISO_8859_1).readLine()
+                assertTrue(status.orEmpty().startsWith("HTTP/1.1 413"), "expected 413, got: $status")
+            }
+        } finally {
+            server.close()
+        }
+    }
+
+    private fun post(
+        url: String,
+        body: String,
+        sessionId: String?,
+        origin: String? = null,
+    ): java.net.http.HttpRequest {
         val builder = java.net.http.HttpRequest.newBuilder(java.net.URI.create(url))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json, text/event-stream")
+            // A deadline, so a framing regression fails the test instead of hanging CI on a read that
+            // will never be satisfied.
+            .timeout(java.time.Duration.ofSeconds(20))
             .POST(java.net.http.HttpRequest.BodyPublishers.ofString(body))
         if (sessionId != null) builder.header("Mcp-Session-Id", sessionId)
+        if (origin != null) builder.header("Origin", origin)
         return builder.build()
+    }
+
+    /** Runs the initialize handshake over raw HTTP and returns the session id the server handed out. */
+    private fun initialize(http: java.net.http.HttpClient, base: String): String {
+        val response = http.send(post(base, INIT_BODY, null), java.net.http.HttpResponse.BodyHandlers.ofString())
+        assertEquals(200, response.statusCode())
+        return response.headers().firstValue("mcp-session-id").orElseThrow()
+    }
+
+    private companion object {
+        const val INIT_BODY =
+            """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}"""
     }
 
     private fun newClient(port: Int) = McpClient.sync(

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
@@ -70,8 +70,11 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
             name = "ftp_server",
             description = "Start, stop, or query the local FTP asset server (anonymous, bound to " +
                 "127.0.0.1:${CodeAssistMcpServer.DEFAULT_FTP_PORT}). When running, files uploaded over FTP " +
-                "land in the open project's assets/ folder, reachable from a PC with \"adb forward tcp:" +
-                CodeAssistMcpServer.DEFAULT_FTP_PORT + " tcp:" + CodeAssistMcpServer.DEFAULT_FTP_PORT + "\". " +
+                "land in the open project's assets/ folder. To reach it from a PC, forward the control port " +
+                "and the passive port above it: \"adb forward tcp:" + CodeAssistMcpServer.DEFAULT_FTP_PORT +
+                " tcp:" + CodeAssistMcpServer.DEFAULT_FTP_PORT + "\" and \"adb forward tcp:" +
+                (CodeAssistMcpServer.DEFAULT_FTP_PORT + 1) + " tcp:" + (CodeAssistMcpServer.DEFAULT_FTP_PORT + 1) +
+                "\". Anyone else on the device can read and write those files too. " +
                 "action=status only reports the current state.",
             parameters = toolSchema {
                 string("action", "start, stop, or status", enum = listOf("start", "stop", "status"))

--- a/ide-ui/src/commonMain/composeResources/values/strings.xml
+++ b/ide-ui/src/commonMain/composeResources/values/strings.xml
@@ -162,7 +162,7 @@ We never collect your code, file or project names, which features you use, or an
     <string name="sharing_performance_data">Sharing anonymous performance data</string>
     <string name="not_sharing_performance_data">Not sharing performance data</string>
     <string name="ftp_server">FTP server</string>
-    <string name="ftp_server_running">Running on 127.0.0.1:8021 · uploads go to assets/</string>
+    <string name="ftp_server_running">Running on 127.0.0.1:8021 · uploads go to assets/, writable by any app on this device</string>
     <string name="ftp_server_stopped">Stopped · local asset upload server</string>
     <string name="compatibility">Compatibility</string>
     <plurals name="recovered_projects">


### PR DESCRIPTION
Follow-up to #1490, covering the three defects that are reachable as soon as a user turns either server on. Both features stay default-off, so nothing shipped is affected yet.

## The HTTP listener was on every interface

`HttpServerSocket.bind` used `0.0.0.0`. The transport authenticates nobody, and its tools read and write the open project, so a phone on shared Wi-Fi was offering that project to the network. `adb forward` dials the device's own loopback and never needed more, so the listener binds `127.0.0.1`.

Loopback alone does not cover a browser aimed at the port by a hostname the attacker rebinds to it, which is why the Streamable HTTP transport asks servers to inspect `Host` and `Origin`. A foreign `Origin` now gets 403; a native client (opencode, curl) sends none and is unaffected.

## `Content-Length` counts bytes, the body was read as chars

```kotlin
val chars = CharArray(length)
while (read < length) { val n = reader.read(chars, read, length - read); ... }
```

Any body carrying a non-ASCII character (an emoji in an edit, an accented path, CJK in a string literal) has fewer chars than bytes, so the loop kept reading past the end of the request and blocked on data that would never come. There was no socket timeout to end it, so the client hung and the thread leaked. The head is now read byte-wise so the body can be taken as exactly `Content-Length` bytes and decoded after.

Two things fell out of the same function: `length` was unbounded, so `Content-Length: 2000000000` allocated a 4 GB char array, and a peer that connected and stalled pinned its thread indefinitely. Both are now capped (16 MB, 413) and bounded (30s read deadline).

## FTP passive transfers could not be forwarded

`PASV` handed out a fresh ephemeral port per transfer, but `adb forward` forwards the ports it is told about. The control channel came up, then every `STOR`/`RETR`/`LIST` from a PC failed against a port nothing was listening on. The existing test only passed because it connects directly to the device-local port.

Transfers now claim the control port plus one, falling back to ephemeral only when it is busy, so `adb forward tcp:8021 tcp:8021` plus `adb forward tcp:8022 tcp:8022` is enough. The previous listener had to start being released *before* the next one binds, or it is the thing holding the fixed port. A session now also frees a `PASV` nobody used, rather than leaking the listener until the process exits.

## Docs and warning text

The `adb forward` instructions in the `ftp_server` tool description, the `--ftp` CLI help, and `DEFAULT_FTP_PORT` now mention both ports. The More-menu subtitle says that anything on the device can write the uploaded files, matching the warning the MCP setting already carries.

## Tests

Three new HTTP tests (non-ASCII body, foreign `Origin`, oversized `Content-Length`) and one FTP test (the data port is fixed and stable across transfers). Each was run against the pre-fix code and fails there: 3/6 HTTP failures, and the FTP test catches the bind-ordering half specifically. `:agent-mcp:test` is 20/20 green, `:ide-core` and `:ide-ui` compile.

Still open from the review of #1490, deliberately left for a second pass: the MCP server has no stop path, the FTP root goes stale across a project switch, and `ftp_control` is classed as non-mutating so it bypasses the permission gate.