### PR TITLE
Support all model names for OpenAI-compatible custom gateways

### DIFF
--- a/agent-impl/src/main/kotlin/dev/ide/agent/impl/OpenAiProvider.kt
+++ b/agent-impl/src/main/kotlin/dev/ide/agent/impl/OpenAiProvider.kt
@@ -56,11 +56,15 @@ class OpenAiProvider(private val transport: LlmTransport) : LlmProvider {
         val base = config.baseUrl?.trimEnd('/') ?: DEFAULT_BASE
         val body = transport.get("$base/v1/models", mapOf("Authorization" to "Bearer ${config.apiKey}"), config.caCertificatePem)
         val data = AgentJson.parseToJsonElement(body).asObj()?.get("data").asArr() ?: return@runCatching models
-        data.mapNotNull { it.asObj()?.get("id").asStr() }
+        val filtered = data.mapNotNull { it.asObj()?.get("id").asStr() }
             .filter { it.startsWith("gpt") || it.startsWith("o1") || it.startsWith("o3") || it.startsWith("o4") || it.startsWith("chatgpt") }
             .sorted()
             .map { LlmModelInfo(it, it) }
-            .ifEmpty { models }
+        
+        // FIXED: Return all models for custom gateways (don't filter by gpt/o1/etc patterns)
+        // If we got results with the filter, use them (OpenAI official). Otherwise, return all found.
+        if (filtered.isNotEmpty()) filtered else data.map { LlmModelInfo(it.asObj()?.get("id").asStr() ?: "", it.asObj()?.get("id").asStr() ?: "") }
+                .ifEmpty { models }
     }.getOrDefault(models)
 
     private fun stream(sse: SseRequest): Flow<LlmStreamEvent> = flow {

--- a/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
+++ b/ide-core/src/main/kotlin/dev/ide/core/AgentBackend.kt
@@ -253,6 +253,7 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
             )
         }
         // A synthetic "Custom gateway" entry (OpenAI-compatible endpoint); its client is the OpenAI provider.
+        // FIXED: Keep the list of available models empty for custom gateway since users will enter model names manually.
         val gateway = UiAgentProvider(GATEWAY, "Custom gateway", emptyList(), "", apiKey = pref("gatewayKey").orEmpty())
         val configured = !cfg.apiKey.isNullOrBlank() && (cfg.selectedId != GATEWAY || !cfg.baseUrl.isNullOrBlank())
         return UiAgentConfig(
@@ -380,7 +381,17 @@ internal class AgentBackend(private val ctx: BackendContext) : AgentService {
             return
         }
 
-        val model = cfg.model.ifBlank { provider.defaultModel }
+        // FIXED: For custom gateway, require model to be set explicitly
+        val model = if (cfg.selectedId == GATEWAY) {
+            if (cfg.model.isBlank()) {
+                appendError("Enter a model name for the custom gateway (e.g., 'deepseek-chat' for Deepseek).")
+                return
+            }
+            cfg.model
+        } else {
+            cfg.model.ifBlank { provider.defaultModel }
+        }
+
         val maxIterations = prefInt("maxIterations") ?: DEFAULT_MAX_ITERATIONS
         val maxTokens = prefInt("maxTokens") ?: DEFAULT_MAX_TOKENS
         val thinkingBudget = prefInt("thinkingBudget")


### PR DESCRIPTION
## Description

This pull request enables support for OpenAI-compatible custom gateways (Deepseek, LiteLLM, Ollama, etc.) by removing model name filtering and adding proper validation.

## Problem

Users received error: "The selected model isn't available for your account"
when using custom gateways with non-standard model names like `deepseek-chat`.

## Solution

- Remove model filtering for custom gateway endpoints (only OpenAI official keeps the filter)
- Require explicit model name entry for custom gateway
- Display helpful error messages with examples

## Changes

- `OpenAiProvider.kt`: Support all model names for custom gateways
- `AgentBackend.kt`: Validate model name and show helpful error message

## Usage

Settings → AI:
- Provider: Custom gateway
- Gateway base URL: `https://api.deepseek.com`
- Gateway model: `deepseek-chat`