### PR TITLE
i18n(zh): complete Simplified Chinese translations and localize the previously hardcoded copy

### DIFF
--- a/agent-ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/agent-ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -37,4 +37,8 @@
     <string name="chat_antigravity_signin">使用 Google 登录</string>
     <string name="chat_antigravity_waiting">正在等待浏览器 — 授权后请返回 CodeAssist</string>
     <string name="chat_cancel">取消</string>
+
+        <string name="chat_ca_cert">CA 证书（可选）</string>
+
+        <string name="chat_ca_cert_hint">仅当端点使用系统不信任的私有或区域性 CA 时（如 GigaChat）才粘贴 CA 证书（PEM）。它会在系统 CA 之外额外受信任；证书链仍会校验。</string>
 </resources>

--- a/ide-ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/ide-ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -1267,4 +1267,863 @@
     <string name="block_palette_variable">变量</string>
     <string name="block_palette_call">调用</string>
     <string name="block_palette_comment">注释</string>
+
+        <string name="action_close_project">关闭项目</string>
+
+        <string name="action_close_project_desc">返回全部项目</string>
+
+        <string name="action_dependencies">管理依赖项</string>
+
+        <string name="action_hub">设置与工具</string>
+
+        <string name="action_hub_desc">设置 · 代码样式 · SDK 管理器 · 密钥库管理器</string>
+
+        <string name="action_icons">图标管理器</string>
+
+        <string name="action_icons_desc">浏览并导入图标，更换应用图标</string>
+
+        <string name="action_logs">查看日志</string>
+
+        <string name="action_logs_desc">编辑器、分析与构建日志——异常时分享排查</string>
+
+        <string name="action_modules">模块</string>
+
+        <string name="action_modules_desc">添加/移除模块 · Java 版本 · 依赖项 · 仓库</string>
+
+        <string name="action_reindex">重建项目索引</string>
+
+        <string name="action_reindex_desc">重建符号与补全索引</string>
+
+        <string name="action_toggle_theme">切换主题</string>
+
+        <string name="action_toggle_theme_desc">在浅色与深色之间切换</string>
+
+        <string name="appicon_applied">应用图标已更新</string>
+
+        <string name="appicon_apply">应用图标</string>
+
+        <string name="appicon_background">背景</string>
+
+        <string name="appicon_choose_icon">选择一个图标</string>
+
+        <string name="appicon_choose_image">选择一张图片</string>
+
+        <string name="appicon_current">当前图标</string>
+
+        <string name="appicon_files">%1$d 个文件</string>
+
+        <string name="appicon_foreground">前景</string>
+
+        <string name="appicon_gen_playstore">Play 商店图（512px）</string>
+
+        <string name="appicon_gen_rasters">多密度 PNG（Android 8 之前）</string>
+
+        <string name="appicon_gen_round">圆形图标</string>
+
+        <string name="appicon_manifest">清单：%1$s</string>
+
+        <string name="appicon_mask_circle">圆形</string>
+
+        <string name="appicon_mask_rounded">圆角</string>
+
+        <string name="appicon_mask_square">方形</string>
+
+        <string name="appicon_mask_squircle">方圆形</string>
+
+        <string name="appicon_module">模块</string>
+
+        <string name="appicon_monochrome">主题层</string>
+
+        <string name="appicon_no_module">此项目没有 Android 应用模块。</string>
+
+        <string name="appicon_none">无</string>
+
+        <string name="appicon_offset_x">水平移动</string>
+
+        <string name="appicon_offset_y">垂直移动</string>
+
+        <string name="appicon_outputs">将写入的内容</string>
+
+        <string name="appicon_preview">预览</string>
+
+        <string name="appicon_replacing">将替换 %1$d 个现有文件</string>
+
+        <string name="appicon_same_as_foreground">与前景相同</string>
+
+        <string name="appicon_scale">缩放</string>
+
+        <string name="appicon_themed">主题化</string>
+
+        <string name="appicon_title">应用图标</string>
+
+        <string name="appicon_use_project_drawable">使用项目 drawable</string>
+
+        <string name="buildc_exit_fullscreen">退出全屏</string>
+
+        <string name="buildc_fullscreen">全屏</string>
+
+        <string name="clone_repository_subtitle">将 GitHub 或任意 Git 服务器上的仓库复制为新项目。</string>
+
+        <string name="clone_repository_title">从 Git 克隆</string>
+
+        <string name="dep_back_to_search">返回搜索</string>
+
+        <string name="dep_bom_badge">BOM</string>
+
+        <string name="dep_firebase_subtitle">BoM + Analytics</string>
+
+        <string name="dep_location_subtitle">融合定位</string>
+
+        <string name="dep_maps_subtitle">Google Maps SDK</string>
+
+        <string name="dep_options_summary">%1$s · %2$s</string>
+
+        <string name="dep_other_sources">其他来源</string>
+
+        <string name="dep_play_auth_subtitle">Google 登录</string>
+
+        <string name="dep_quick_start">快速添加</string>
+
+        <string name="dep_search_hint">搜索或粘贴 group:name:version</string>
+
+        <string name="dep_show_options">作用域与变体选项</string>
+
+        <string name="dep_source_local">本地 .jar 或 .aar 文件</string>
+
+        <string name="dep_source_module">本项目中的另一个模块</string>
+
+        <string name="export_bundle_deps_cost">+%1$s</string>
+
+        <string name="export_details_title">详细信息</string>
+
+        <string name="export_excluded_note">构建输出、缓存和 SDK 绝不会打包。</string>
+
+        <string name="export_format_gradle">Gradle 项目</string>
+
+        <string name="export_format_gradle_desc">一个 .zip，包含你的源码和生成的 Gradle 构建文件，供 Android Studio 或 gradle 使用。</string>
+
+        <string name="export_format_package">CodeAssist 安装包</string>
+
+        <string name="export_format_package_desc">任何装有 CodeAssist 的人都能原样导入的 .caproj 文件。</string>
+
+        <string name="export_format_title">格式</string>
+
+        <string name="export_gradle_caveat">尽力而为。构建文件由项目模型生成，而非来自实际运行过的构建，因此请先通读再依赖它们。依赖项以 Maven 坐标声明，Gradle 在首次同步时下载，因此同步需要联网。</string>
+
+        <string name="export_gradle_contents">settings.gradle.kts、每个模块的 build.gradle.kts、gradle.properties 以及 Gradle wrapper 设置，全部由你的项目生成：模块、依赖项、SDK 版本、构建类型、变体和构建特性。</string>
+
+        <string name="export_gradle_title">会生成什么</string>
+
+        <string name="export_gradle_wrapper_note">不包含 gradlew 脚本：Android Studio 会在首次同步时添加，或手动运行一次 gradle wrapper。</string>
+
+        <string name="export_intro_gradle">将此项目写为 Gradle 构建，以便在 Android Studio 中打开或用 gradle 构建。</string>
+
+        <string name="export_modules_desc">排除一个模块时，依赖它的所有内容也会一并排除。</string>
+
+        <string name="export_modules_title">模块</string>
+
+        <string name="export_notes_desc">这些内容也包含在压缩包内的 GRADLE-EXPORT.md 中。</string>
+
+        <string name="export_notes_title">值得检查</string>
+
+        <string name="export_options_title">选项</string>
+
+        <string name="export_screenshot_add">添加图片</string>
+
+        <string name="export_screenshot_remove">移除截图</string>
+
+        <string name="export_screenshots_desc">展示给导入此安装包的人。</string>
+
+        <string name="export_screenshots_title">截图</string>
+
+        <string name="export_size_estimate">约 %1$s</string>
+
+        <string name="export_success_subtitle_gradle">你的 Gradle 项目已就绪。</string>
+
+        <string name="filetree_aidl_file">AIDL 文件</string>
+
+        <string name="filetree_image_asset">图片资源</string>
+
+        <string name="ftp_server">FTP 服务器</string>
+
+        <string name="ftp_server_running">运行于 127.0.0.1:8021 · 上传到 assets/，此设备上的任何应用均可写入</string>
+
+        <string name="ftp_server_stopped">已停止 · 本地资源上传服务器</string>
+
+        <string name="gradle_convert">转换</string>
+
+        <string name="gradle_convert_action">转换</string>
+
+        <string name="gradle_convert_body">Gradle 构建文件会移至备份文件夹，由 CodeAssist 自己的模块系统接管。之后将无法再从 Gradle 重新同步。此操作可以撤销。</string>
+
+        <string name="gradle_convert_done">完成</string>
+
+        <string name="gradle_convert_failed">无法转换此项目。</string>
+
+        <string name="gradle_convert_notes_intro">导入器尽力读取了以下内容——转换后不会再检查：</string>
+
+        <string name="gradle_convert_title">转换为 CodeAssist 项目？</string>
+
+        <string name="gradle_convert_undo">撤销</string>
+
+        <string name="gradle_convert_working">正在转换…</string>
+
+        <string name="gradle_converted">已转换为 CodeAssist 项目。</string>
+
+        <string name="gradle_sync_needed">构建文件自上次同步后已更改。请重新同步以更新项目。</string>
+
+        <string name="guide_intro">发布会将你的项目放入商店，供任何人安装。以下是从头到尾的流程。</string>
+
+        <string name="guide_limits_body">每个压缩包 5 MB，最多 2000 个文件。每个账号可发布十个项目，同时最多三份提交等待审核。</string>
+
+        <string name="guide_limits_title">限制说明</string>
+
+        <string name="guide_own_body">项目始终属于你。提交等待审核期间可以撤回，已发布的也可以申请下架。</string>
+
+        <string name="guide_own_title">你的权益</string>
+
+        <string name="guide_step_live_body">通过审核的项目会出现在"探索"中，任何人都可以安装。你可以继续发布新版本；旧版本仍然可用。</string>
+
+        <string name="guide_step_live_title">通过后带着你的名字上架</string>
+
+        <string name="guide_step_notified_body">批准与否，决定都会以通知的形式送达，即使应用已关闭。</string>
+
+        <string name="guide_step_notified_title">无论结果如何都会通知你</string>
+
+        <string name="guide_step_package_body">构建输出、缓存和 .git 不会包含在内。密钥也一样：keystore、local.properties、.env 和 google-services.json 都会被排除。上传前你可以看到确切的文件清单和被剔除的内容。</string>
+
+        <string name="guide_step_package_title">项目在本设备上打包为压缩文件</string>
+
+        <string name="guide_step_review_body">未经批准，任何内容都不会公开。审核员会下载压缩包、阅读你写的内容，然后选择发布或附上说明退回。</string>
+
+        <string name="guide_step_review_title">会有真人进行审核</string>
+
+        <string name="guide_title">发布流程是怎样的</string>
+
+        <string name="home_account_title">账号与工具</string>
+
+        <string name="home_backup">备份项目</string>
+
+        <string name="home_cancel">取消</string>
+
+        <string name="home_clone_repository">从 Git 克隆</string>
+
+        <string name="home_delete">删除</string>
+
+        <string name="home_delete_confirm_action">删除项目</string>
+
+        <string name="home_delete_confirm_body">这会从此设备上移除该项目及其全部内容。此操作无法撤销。</string>
+
+        <string name="home_delete_confirm_title">删除 %1$s？</string>
+
+        <string name="home_dismiss">关闭</string>
+
+        <string name="home_empty_list">此列表暂无内容</string>
+
+        <string name="home_feedback">发送反馈</string>
+
+        <string name="home_from_store">从商店模板开始</string>
+
+        <string name="home_good_afternoon">下午好</string>
+
+        <string name="home_good_evening">晚上好</string>
+
+        <string name="home_good_morning">早上好</string>
+
+        <string name="home_import_project">导入项目</string>
+
+        <string name="home_legacy_recovery">旧版本的项目可以恢复。</string>
+
+        <string name="home_more_actions">更多操作</string>
+
+        <string name="home_new_project">新建项目</string>
+
+        <string name="home_new_project_subtitle">骨架在本地生成，无需联网。</string>
+
+        <string name="home_open">打开</string>
+
+        <string name="home_open_in_files">在文件管理中打开存储</string>
+
+        <string name="home_open_named">打开 %1$s</string>
+
+        <string name="home_resume_title">从上次离开的地方继续</string>
+
+        <string name="home_seg_projects">项目</string>
+
+        <string name="home_seg_saved">收藏</string>
+
+        <string name="home_seg_updates">更新</string>
+
+        <string name="home_settings_tools">设置与工具</string>
+
+        <string name="home_share">分享</string>
+
+        <string name="home_sponsor">赞助 CodeAssist</string>
+
+        <string name="home_star_github">去 GitHub 加星</string>
+
+        <string name="home_your_projects">你的项目</string>
+
+        <string name="icons_app_icon_short">应用图标</string>
+
+        <string name="icons_app_icon_subtitle">预览并替换启动器图标</string>
+
+        <string name="icons_app_icon_title">应用图标</string>
+
+        <string name="icons_colour">颜色</string>
+
+        <string name="icons_colour_original">保持原色</string>
+
+        <string name="icons_compose_add_hint">添加 androidx.compose.material:material-icons-extended 即可浏览全部图标。</string>
+
+        <string name="icons_compose_empty">此模块的类路径上没有 Compose 图标库。</string>
+
+        <string name="icons_configurations">%1$d 种配置</string>
+
+        <string name="icons_conflict_body">%1$s 已声明此资源。替换后所有引用都会更新。</string>
+
+        <string name="icons_conflict_title">替换 %1$s？</string>
+
+        <string name="icons_copied">已复制到剪贴板</string>
+
+        <string name="icons_copy">复制</string>
+
+        <string name="icons_empty">没有符合搜索条件的图标。</string>
+
+        <string name="icons_filled">填充</string>
+
+        <string name="icons_import">添加到项目</string>
+
+        <string name="icons_import_svg">导入 SVG</string>
+
+        <string name="icons_insert">插入到光标处</string>
+
+        <string name="icons_license">许可协议：%1$s</string>
+
+        <string name="icons_load_set">加载 %1$s 图标</string>
+
+        <string name="icons_loading_set">正在下载图标列表…</string>
+
+        <string name="icons_name">资源名称</string>
+
+        <string name="icons_no_repositories">尚未注册任何图标库。</string>
+
+        <string name="icons_project_empty">此项目还没有 drawable 或 mipmap 资源。</string>
+
+        <string name="icons_reference">引用</string>
+
+        <string name="icons_replace">替换</string>
+
+        <string name="icons_res_type">文件夹</string>
+
+        <string name="icons_search_hint">搜索图标</string>
+
+        <string name="icons_size">大小</string>
+
+        <string name="icons_style">样式</string>
+
+        <string name="icons_style_outlined">描边</string>
+
+        <string name="icons_style_rounded">圆角</string>
+
+        <string name="icons_style_sharp">直角</string>
+
+        <string name="icons_tab_compose">Compose</string>
+
+        <string name="icons_tab_library">图标库</string>
+
+        <string name="icons_tab_project">项目</string>
+
+        <string name="icons_target">写入位置</string>
+
+        <string name="icons_title">图标管理器</string>
+
+        <string name="import_as_hint">项目名称</string>
+
+        <string name="import_as_title">导入为</string>
+
+        <string name="import_destination">将存放到 %1$s</string>
+
+        <string name="import_gradle_mode_compat">兼容模式</string>
+
+        <string name="import_gradle_mode_compat_desc">保留 Gradle 文件并从中重新同步。之后可以再转换。</string>
+
+        <string name="import_gradle_mode_convert">转换为 CodeAssist</string>
+
+        <string name="import_gradle_mode_convert_desc">切换到 CodeAssist 的模块系统。Gradle 文件会移至备份文件夹。</string>
+
+        <string name="import_gradle_mode_message">CodeAssist 应如何打开此项目？</string>
+
+        <string name="import_gradle_mode_title">导入 Gradle 项目</string>
+
+        <string name="import_hide_files">隐藏文件</string>
+
+        <string name="import_show_files">显示全部 %1$d 个文件</string>
+
+        <string name="import_source_folder">项目文件夹</string>
+
+        <string name="import_source_folder_desc">CodeAssist 项目，或现有的 Gradle 构建</string>
+
+        <string name="import_source_message">项目在哪里？</string>
+
+        <string name="import_source_package">项目安装包</string>
+
+        <string name="import_source_package_desc">从 CodeAssist 分享或导出的 .caproj 文件</string>
+
+        <string name="import_source_title">导入项目</string>
+
+        <string name="learn_lessons_done">已完成 %1$d 节课</string>
+
+        <string name="learn_module_meta">%2$d 节课中的第 %1$d 节 · %3$d 分钟</string>
+
+        <string name="learn_resume_lesson">继续第 %1$d 节课</string>
+
+        <string name="like_action">点赞</string>
+
+        <string name="like_liked">已点赞</string>
+
+        <string name="like_signin">登录后点赞</string>
+
+        <string name="modcfg_discard">放弃</string>
+
+        <string name="modcfg_unsaved_changes">有未保存的更改</string>
+
+        <string name="newfile_kind_parcelable">Parcelable</string>
+
+        <string name="newfile_new_aidl_file">新建 AIDL 文件</string>
+
+        <string name="newfile_source_aidl_hint">IMyService</string>
+
+        <string name="notif_clear">清除</string>
+
+        <string name="notif_days">%1$d 天前</string>
+
+        <string name="notif_dismiss">关闭</string>
+
+        <string name="notif_empty">暂无新动态。</string>
+
+        <string name="notif_empty_body">审核结果、更新和完成的构建会显示在这里。</string>
+
+        <string name="notif_hours">%1$d 小时前</string>
+
+        <string name="notif_just_now">刚刚</string>
+
+        <string name="notif_mark_all">全部标为已读</string>
+
+        <string name="notif_minutes">%1$d 分钟前</string>
+
+        <string name="notif_open">打开</string>
+
+        <string name="notif_title">通知</string>
+
+        <string name="notify_launch_cleared">你将不会收到通知。</string>
+
+        <string name="notify_launch_failed">刚才未能保存此设置。</string>
+
+        <string name="notify_launch_saved">项目上架时会通知你。</string>
+
+        <string name="plugins_failed">加载失败：%1$s</string>
+
+        <string name="plugins_installed_empty">还没有安装任何插件。从应用商店安装的 CodeAssist 插件会显示在这里。</string>
+
+        <string name="plugins_tab_builtin">内置</string>
+
+        <string name="plugins_tab_installed">已安装</string>
+
+        <string name="profile_follow">关注</string>
+
+        <string name="profile_followers">%1$d 位关注者</string>
+
+        <string name="profile_following">已关注</string>
+
+        <string name="profile_installs">安装量</string>
+
+        <string name="profile_likes">获赞</string>
+
+        <string name="profile_missing">没有这个名称的发布者</string>
+
+        <string name="profile_none">还没有发布任何内容</string>
+
+        <string name="profile_projects">项目</string>
+
+        <string name="profile_published">已发布的项目</string>
+
+        <string name="profile_rating">评分</string>
+
+        <string name="profile_signin_to_follow">登录后关注</string>
+
+        <string name="profile_unrated">未评分</string>
+
+        <string name="publish_from_share">发布到商店</string>
+
+        <string name="publish_from_share_body">分享给所有人，而不只是一个人。发布前会先经审核。</string>
+
+        <string name="reply_body_hint">你的回复会显示在评价下方，并标注为发布者。</string>
+
+        <string name="reply_send">发布回复</string>
+
+        <string name="reply_title">以发布者身份回复</string>
+
+        <string name="report_body">告诉我们它有什么问题。审核员会阅读每一份举报。</string>
+
+        <string name="report_detail">还有什么需要审核员知道的吗？（可选）</string>
+
+        <string name="report_reason_broken">错误或误导</string>
+
+        <string name="report_reason_copyright">版权问题</string>
+
+        <string name="report_reason_inappropriate">辱骂或不当内容</string>
+
+        <string name="report_reason_malware">恶意软件</string>
+
+        <string name="report_reason_other">其他</string>
+
+        <string name="report_reason_spam">垃圾信息或广告</string>
+
+        <string name="report_send">发送举报</string>
+
+        <string name="report_sending">正在发送…</string>
+
+        <string name="report_title">举报此评价</string>
+
+        <string name="review_actions">评价管理</string>
+
+        <string name="review_hidden_done">已隐藏。该评价不再计入评分。</string>
+
+        <string name="review_hide">隐藏评价</string>
+
+        <string name="review_reply">回复</string>
+
+        <string name="review_reply_delete">删除回复</string>
+
+        <string name="review_reply_edit">编辑回复</string>
+
+        <string name="review_report">举报</string>
+
+        <string name="review_reported">已举报。审核员会查看。</string>
+
+        <string name="review_unhide">恢复评价</string>
+
+        <string name="reviews_count">%1$d 条评价</string>
+
+        <string name="reviews_count_one">1 条评价</string>
+
+        <string name="reviews_delete">删除</string>
+
+        <string name="reviews_edit">编辑你的评价</string>
+
+        <string name="reviews_helpful">有帮助</string>
+
+        <string name="reviews_helpful_count">有帮助（%1$d）</string>
+
+        <string name="reviews_none">暂无评价</string>
+
+        <string name="reviews_none_body">来当第一个说说这个项目用起来如何的人。</string>
+
+        <string name="reviews_on_version">于 v%1$s</string>
+
+        <string name="reviews_optional_text">有什么想告诉下一位用户的吗？（可选）</string>
+
+        <string name="reviews_posting">正在发布…</string>
+
+        <string name="reviews_reader">一位 CodeAssist 用户</string>
+
+        <string name="reviews_reply">发布者已回复</string>
+
+        <string name="reviews_signin_to_vote">登录后投票</string>
+
+        <string name="reviews_signin_to_write">登录后写评价</string>
+
+        <string name="reviews_sort_helpful">最有帮助</string>
+
+        <string name="reviews_sort_recent">最新</string>
+
+        <string name="reviews_stars_label">%1$d 星（满分 5 星）</string>
+
+        <string name="reviews_submit">发布评价</string>
+
+        <string name="reviews_title">评分与评价</string>
+
+        <string name="reviews_unavailable">评价功能暂时不可用。</string>
+
+        <string name="reviews_write">写评价</string>
+
+        <string name="reviews_your_rating">你的评分</string>
+
+        <string name="reviews_yours">你的评价</string>
+
+        <string name="set_editor_hscrollbar">横向滚动条</string>
+
+        <string name="set_editor_hscrollbar_desc">当一行超出视图时，在底边显示可拖动的滚动条（自动换行开启时无需滚动）</string>
+
+        <string name="share_type_android_app">Android 应用</string>
+
+        <string name="share_type_android_lib">Android 库</string>
+
+        <string name="share_type_java_lib">Java 库</string>
+
+        <string name="store_action_read_why">查看原因</string>
+
+        <string name="store_action_use">使用</string>
+
+        <string name="store_action_view_listing">查看列表页</string>
+
+        <string name="store_action_view_notes">查看备注</string>
+
+        <string name="store_action_withdraw">撤回</string>
+
+        <string name="store_badge_cd">已发布 %1$d 个项目</string>
+
+        <string name="store_badge_first">书架第一</string>
+
+        <string name="store_badge_new">新</string>
+
+        <string name="store_browse_by_kind">按类型浏览</string>
+
+        <string name="store_bundled_subtitle">随安装附带、可离线使用的项目骨架。</string>
+
+        <string name="store_bundled_title">内置于你的 IDE</string>
+
+        <string name="store_catalogue_subtitle">最新优先</string>
+
+        <string name="store_collections_title">精选集</string>
+
+        <string name="store_downloading_pct">%1$d%%</string>
+
+        <string name="store_empty_hero_body">模板、示例应用和插件只要通过审核就会出现在这里。你可以成为第一个。</string>
+
+        <string name="store_empty_hero_title">还没有人发布项目</string>
+
+        <string name="store_ghost_charts_note">项目积累一周的安装量后，排行榜就会出现。</string>
+
+        <string name="store_ghost_collections_note">精选书架由团队从已发布的项目中挑选组成。</string>
+
+        <string name="store_ghost_count_cd">需要 %2$d 个项目，已有 %1$d 个</string>
+
+        <string name="store_ghost_next_title">接下来会上架什么</string>
+
+        <string name="store_ghost_recommend_note">推荐需要你的安装历史——先安装一个项目吧。</string>
+
+        <string name="store_ghost_section_subtitle">每个书架在内容足够参与排名时自动开启。</string>
+
+        <string name="store_ghost_section_title">商店成长后将陆续解锁</string>
+
+        <string name="store_ghostspec_charts_note">排行榜需要至少 %1$d 个项目才启动——四个项目的榜单就是上面的列表。</string>
+
+        <string name="store_ghostspec_collections_note">项目足够多、能凑出一个主题时，团队就会组建精选集。</string>
+
+        <string name="store_ghostspec_rec_note">推荐需要跨越多个项目的安装历史。</string>
+
+        <string name="store_ghostspec_rec_title">根据你的安装推荐…</string>
+
+        <string name="store_hero_download">下载量</string>
+
+        <string name="store_hero_eyebrow_open">商店已开放</string>
+
+        <string name="store_hero_installs">安装量</string>
+
+        <string name="store_how_it_works">如何运作</string>
+
+        <string name="store_how_publishing_title">发布流程是怎样的</string>
+
+        <string name="store_install">安装</string>
+
+        <string name="store_install_project">安装项目</string>
+
+        <string name="store_item_reviews">%1$d 条评价</string>
+
+        <string name="store_item_size">大小</string>
+
+        <string name="store_item_tab_changelog">更新日志</string>
+
+        <string name="store_item_tab_overview">概览</string>
+
+        <string name="store_item_tab_readme">README</string>
+
+        <string name="store_item_tab_reviews">评分与评价</string>
+
+        <string name="store_item_version">版本</string>
+
+        <string name="store_meta_offline">离线</string>
+
+        <string name="store_no_results">没有与"%1$s"匹配的项目</string>
+
+        <string name="store_not_rated">暂无评分</string>
+
+        <string name="store_notify_state_off">通知已关闭</string>
+
+        <string name="store_notify_state_on">通知已开启</string>
+
+        <string name="store_notify_subtitle">只发一条通知，仅限首批上架。</string>
+
+        <string name="store_notify_title">有项目上架时通知我</string>
+
+        <string name="store_open">打开</string>
+
+        <string name="store_open_in_editor">在编辑器中打开</string>
+
+        <string name="store_ordinal_fifth">五</string>
+
+        <string name="store_ordinal_fourth">四</string>
+
+        <string name="store_ordinal_second">二</string>
+
+        <string name="store_ordinal_third">三</string>
+
+        <string name="store_perk_direct_line">与审核团队直接沟通</string>
+
+        <string name="store_perk_front_page">发布首日即上门户首页</string>
+
+        <string name="store_pitch_body">现在已发布的所有项目都在这个页面上——没有要爬的排名，也没有藏在后面的分页。以后就不一定了。</string>
+
+        <string name="store_pitch_eyebrow">书架还没满</string>
+
+        <string name="store_pitch_next">%1$s 下一个就是你的。</string>
+
+        <string name="store_pitch_ordinal_full">%1$s 你的将是第 %2$s 个。</string>
+
+        <string name="store_pitch_subject">已收录 %1$d 个项目。</string>
+
+        <string name="store_pitch_subject_one">已收录 1 个项目。</string>
+
+        <string name="store_publish_another">再发布一个</string>
+
+        <string name="store_publish_cta">发布项目</string>
+
+        <string name="store_publishing_guide">发布指南</string>
+
+        <string name="store_retry">重试</string>
+
+        <string name="store_search_placeholder">模板、示例应用、插件</string>
+
+        <string name="store_see_all">查看全部</string>
+
+        <string name="store_signin_completing">正在登录…</string>
+
+        <string name="store_signin_dismiss">暂不</string>
+
+        <string name="store_signin_failed">登录未完成</string>
+
+        <string name="store_signin_github">使用 GitHub 继续</string>
+
+        <string name="store_signin_google">使用 Google 继续</string>
+
+        <string name="store_signin_reopen">重新打开浏览器</string>
+
+        <string name="store_signin_sign_out">退出登录</string>
+
+        <string name="store_signin_signed_in_as">已登录为 %1$s</string>
+
+        <string name="store_signin_submit_soon">接下来是项目提交页。你的账号已就绪。</string>
+
+        <string name="store_signin_title">发布到商店</string>
+
+        <string name="store_signin_unavailable_body">此构建版本未配置商店账号服务，因此发布功能已关闭。商店的其余功能均可正常使用。</string>
+
+        <string name="store_signin_unavailable_title">登录不可用</string>
+
+        <string name="store_signin_waiting_body">在浏览器中完成登录后返回。此页面会自动更新。</string>
+
+        <string name="store_signin_waiting_title">等待 GitHub</string>
+
+        <string name="store_signin_why">发布需要账号，这样项目才有归属者，审核员也有对象可沟通。浏览和安装则从不需要。</string>
+
+        <string name="store_status_building">正在干净的机器上构建</string>
+
+        <string name="store_status_changes">需要修改——请查看备注</string>
+
+        <string name="store_status_published">已在商店上架</string>
+
+        <string name="store_status_rejected">未通过</string>
+
+        <string name="store_status_rejected_note">未通过 · %1$s</string>
+
+        <string name="store_status_submitted">审核中 · 通常 2 个工作日</string>
+
+        <string name="store_step_listing_body">标题、一句话简介、分类和截图——直接取自应用内的编辑器。</string>
+
+        <string name="store_step_listing_title">填写列表信息</string>
+
+        <string name="store_step_pick_body">选择任意本地项目，CodeAssist 会替你读取名称、语言、JDK 和 Gradle 配置——无需手写任何内容。</string>
+
+        <string name="store_step_pick_title">从“项目”页选择一个项目</string>
+
+        <string name="store_step_submit_body">我们会在干净的机器上构建，并由真人检查许可协议与 README。通常两个工作日。</string>
+
+        <string name="store_step_submit_title">提交审核</string>
+
+        <string name="store_top_charts">排行榜</string>
+
+        <string name="store_unpacking">正在解压…</string>
+
+        <string name="store_use">使用</string>
+
+        <string name="submit_add_screenshot">添加截图</string>
+
+        <string name="submit_details">列表信息</string>
+
+        <string name="submit_excluded_none">无需剔除任何内容。</string>
+
+        <string name="submit_excluded_title">未包含在上传中</string>
+
+        <string name="submit_excluded_why">密钥和构建输出绝不会被上传。以下文件已被识别并剔除：</string>
+
+        <string name="submit_field_category">分类</string>
+
+        <string name="submit_field_description">描述</string>
+
+        <string name="submit_field_summary">一句话简介</string>
+
+        <string name="submit_field_tags">标签，逗号分隔</string>
+
+        <string name="submit_field_title">标题</string>
+
+        <string name="submit_field_version">版本</string>
+
+        <string name="submit_included">%1$d 个文件 · %2$s</string>
+
+        <string name="submit_mine_title">你的提交</string>
+
+        <string name="submit_no_projects">你还没有可发布的项目。</string>
+
+        <string name="submit_packaging">正在打包…</string>
+
+        <string name="submit_pick_project">选择哪个项目？</string>
+
+        <string name="submit_required">请填写标题、简介、描述和分类。</string>
+
+        <string name="submit_review_note">每份提交都会经过审核员审核后才会展示。未经批准，任何内容都不会公开。</string>
+
+        <string name="submit_screenshots">截图</string>
+
+        <string name="submit_screenshots_desc">最多六张。这是别人在安装之前最先看的东西。</string>
+
+        <string name="submit_send">提交审核</string>
+
+        <string name="submit_sending">正在提交…</string>
+
+        <string name="submit_signin_first">登录后才能发布。</string>
+
+        <string name="submit_title">发布项目</string>
+
+        <string name="submit_unavailable">此构建版本不支持发布。</string>
+
+        <string name="submit_withdraw">撤回</string>
+
+        <string name="toolchain_warning_accept_note">在版本匹配之前，此模块的构建会一直失败。</string>
+
+        <string name="toolchain_warning_build_anyway">仍然构建</string>
+
+        <string name="toolchain_warning_many">%1$d 个模块的运行时与内置的处理器版本不一致</string>
+
+        <string name="toolchain_warning_working">处理中…</string>
+
+        <string name="unrecognized_project_origin">克隆自 %1$s</string>
+
+        <string name="unrecognized_project_title">仅以编辑方式打开</string>
+
+    <plurals name="store_project_count">
+        <item quantity="one">%1$d 个项目</item>
+        <item quantity="other">%1$d 个项目</item>
+    </plurals>
 </resources>

--- a/ide-ui/src/commonMain/composeResources/values/strings.xml
+++ b/ide-ui/src/commonMain/composeResources/values/strings.xml
@@ -1604,4 +1604,163 @@ We never collect your code, file or project names, which features you use, or an
     <string name="icons_reference">Reference</string>
     <string name="icons_app_icon_short">App icon</string>
     <string name="icons_no_repositories">No icon libraries are registered.</string>
+
+        <string name="action_close_project">Close project</string>
+
+        <string name="action_close_project_desc">Back to all projects</string>
+
+        <string name="action_dependencies">Manage dependencies</string>
+
+        <string name="action_hub">Settings &amp; Tools</string>
+
+        <string name="action_hub_desc">Settings · code style · SDK manager · keystore manager</string>
+
+        <string name="action_icons">Icon Manager</string>
+
+        <string name="action_icons_desc">Browse and import icons, and change the app icon</string>
+
+        <string name="action_logs">View logs</string>
+
+        <string name="action_logs_desc">Editor, analysis &amp; build logs — share when something's off</string>
+
+        <string name="action_modules">Modules</string>
+
+        <string name="action_modules_desc">Add/remove modules · Java version · dependencies · repositories</string>
+
+        <string name="action_reindex">Re-index project</string>
+
+        <string name="action_reindex_desc">Rebuild symbol &amp; completion indexes</string>
+
+        <string name="action_toggle_theme">Toggle theme</string>
+
+        <string name="action_toggle_theme_desc">Switch between light and dark</string>
+
+        <string name="store_action_read_why">Read why</string>
+
+        <string name="store_action_use">Use</string>
+
+        <string name="store_action_view_listing">View listing</string>
+
+        <string name="store_action_view_notes">View notes</string>
+
+        <string name="store_action_withdraw">Withdraw</string>
+
+        <string name="store_badge_cd">%1$d projects published</string>
+
+        <string name="store_badge_first">FIRST ON THE SHELF</string>
+
+        <string name="store_badge_new">NEW</string>
+
+        <string name="store_bundled_subtitle">Offline scaffolds that ship with the install.</string>
+
+        <string name="store_bundled_title">Bundled with your IDE</string>
+
+        <string name="store_catalogue_subtitle">newest first</string>
+
+        <string name="store_collections_title">Collections</string>
+
+        <string name="store_empty_hero_body">Templates, sample apps and plugins show up here the moment they pass review. Yours can be the first one.</string>
+
+        <string name="store_empty_hero_title">No one has published a project yet</string>
+
+        <string name="store_ghost_charts_note">Ranks appear once projects have a week of install history.</string>
+
+        <string name="store_ghost_collections_note">Curated shelves are assembled by the team from published projects.</string>
+
+        <string name="store_ghost_count_cd">%1$d of %2$d projects needed</string>
+
+        <string name="store_ghost_next_title">What lands here next</string>
+
+        <string name="store_ghost_recommend_note">Recommendations need your install history — install something first.</string>
+
+        <string name="store_ghost_section_subtitle">Each shelf switches on when it has enough to rank.</string>
+
+        <string name="store_ghost_section_title">What unlocks as the store grows</string>
+
+        <string name="store_ghostspec_charts_note">Ranking starts at %1$d projects — a chart of four is just the list above.</string>
+
+        <string name="store_ghostspec_collections_note">The team builds a collection once there are enough projects to theme one.</string>
+
+        <string name="store_ghostspec_rec_note">Recommendations need install history across several projects.</string>
+
+        <string name="store_ghostspec_rec_title">Because you installed…</string>
+
+        <string name="store_hero_eyebrow_open">The store is open</string>
+
+        <string name="store_how_it_works">How it works</string>
+
+        <string name="store_how_publishing_title">How publishing works</string>
+
+        <string name="store_meta_offline">offline</string>
+
+        <string name="store_not_rated">Not rated yet</string>
+
+        <string name="store_notify_state_off">Notifications off</string>
+
+        <string name="store_notify_state_on">Notifications on</string>
+
+        <string name="store_notify_subtitle">One notification, only for the first batch.</string>
+
+        <string name="store_notify_title">Tell me when projects arrive</string>
+
+        <string name="store_ordinal_fifth">fifth</string>
+
+        <string name="store_ordinal_fourth">fourth</string>
+
+        <string name="store_ordinal_second">second</string>
+
+        <string name="store_ordinal_third">third</string>
+
+        <string name="store_perk_direct_line">Direct line to the review team</string>
+
+        <string name="store_perk_front_page">Front page from day one</string>
+
+        <string name="store_pitch_body">Everything published right now sits on this page — no ranking to climb, no back pages to fall into. That stops being true later.</string>
+
+        <string name="store_pitch_eyebrow">Shelves are still short</string>
+
+        <string name="store_pitch_next">%1$s Yours would be next.</string>
+
+        <string name="store_pitch_ordinal_full">%1$s Yours would be the %2$s.</string>
+
+        <string name="store_pitch_subject">%1$d projects in.</string>
+
+        <string name="store_pitch_subject_one">One project in.</string>
+
+        <string name="store_publish_another">Publish another</string>
+
+        <string name="store_publish_cta">Publish a project</string>
+
+        <string name="store_publishing_guide">Publishing guide</string>
+
+        <string name="store_status_building">Building on a clean machine</string>
+
+        <string name="store_status_changes">Changes requested — read the notes</string>
+
+        <string name="store_status_published">Live in the store</string>
+
+        <string name="store_status_rejected">Not accepted</string>
+
+        <string name="store_status_rejected_note">Not accepted · %1$s</string>
+
+        <string name="store_status_submitted">In review · usually 2 business days</string>
+
+        <string name="store_step_listing_body">Title, a short description, category and screenshots — captured from your editor inside the app.</string>
+
+        <string name="store_step_listing_title">Fill in the listing</string>
+
+        <string name="store_step_pick_body">Choose any local project. CodeAssist reads its name, language, JDK and Gradle setup for you — nothing to write by hand.</string>
+
+        <string name="store_step_pick_title">Pick a project from Home</string>
+
+        <string name="store_step_submit_body">We build it on a clean machine and a human checks licensing and the README. Usually two business days.</string>
+
+        <string name="store_step_submit_title">Submit for review</string>
+
+        <string name="store_top_charts">Top charts</string>
+
+    <plurals name="store_project_count">
+        <item quantity="one">%1$d PROJECT</item>
+        <item quantity="other">%1$d PROJECTS</item>
+    </plurals>
 </resources>

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/StoreEmpty.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/StoreEmpty.kt
@@ -39,6 +39,37 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.ide.ui.backend.UiStoreSubmission
 import dev.ide.ui.backend.UiSubmissionStatus
+import dev.ide.ui.generated.resources.Res
+import dev.ide.ui.generated.resources.store_empty_hero_body
+import dev.ide.ui.generated.resources.store_empty_hero_title
+import dev.ide.ui.generated.resources.store_ghost_charts_note
+import dev.ide.ui.generated.resources.store_ghost_collections_note
+import dev.ide.ui.generated.resources.store_ghost_recommend_note
+import dev.ide.ui.generated.resources.store_hero_eyebrow_open
+import dev.ide.ui.generated.resources.store_notify_state_off
+import dev.ide.ui.generated.resources.store_notify_state_on
+import dev.ide.ui.generated.resources.store_notify_subtitle
+import dev.ide.ui.generated.resources.store_notify_title
+import dev.ide.ui.generated.resources.store_publish_another
+import dev.ide.ui.generated.resources.store_publish_cta
+import dev.ide.ui.generated.resources.store_publishing_guide
+import dev.ide.ui.generated.resources.store_action_read_why
+import dev.ide.ui.generated.resources.store_action_view_listing
+import dev.ide.ui.generated.resources.store_action_view_notes
+import dev.ide.ui.generated.resources.store_action_withdraw
+import dev.ide.ui.generated.resources.store_status_building
+import dev.ide.ui.generated.resources.store_status_changes
+import dev.ide.ui.generated.resources.store_status_published
+import dev.ide.ui.generated.resources.store_status_rejected
+import dev.ide.ui.generated.resources.store_status_rejected_note
+import dev.ide.ui.generated.resources.store_status_submitted
+import dev.ide.ui.generated.resources.store_step_listing_body
+import dev.ide.ui.generated.resources.store_step_listing_title
+import dev.ide.ui.generated.resources.store_step_pick_body
+import dev.ide.ui.generated.resources.store_step_pick_title
+import dev.ide.ui.generated.resources.store_step_submit_body
+import dev.ide.ui.generated.resources.store_step_submit_title
+import org.jetbrains.compose.resources.stringResource
 import dev.ide.ui.icons.CaSymbols
 import dev.ide.ui.theme.Symbol
 import dev.ide.ui.theme.tileShape
@@ -85,9 +116,9 @@ fun EmptyStoreHero(
                 modifier = Modifier.align(Alignment.BottomEnd).offset(x = 24.dp, y = 34.dp),
             )
             Column(Modifier.padding(horizontal = 20.dp, vertical = 24.dp)) {
-                Eyebrow("The store is open", color = c.onPrimaryContainer.copy(alpha = 0.75f))
+                Eyebrow(stringResource(Res.string.store_hero_eyebrow_open), color = c.onPrimaryContainer.copy(alpha = 0.75f))
                 Text(
-                    "No one has published a project yet",
+                    stringResource(Res.string.store_empty_hero_title),
                     style = MaterialTheme.typography.headlineMedium.copy(
                         fontWeight = FontWeight.Medium, fontSize = 26.sp, lineHeight = 32.sp,
                         letterSpacing = (-0.7).sp,
@@ -96,8 +127,7 @@ fun EmptyStoreHero(
                     modifier = Modifier.padding(top = 8.dp),
                 )
                 Text(
-                    "Templates, sample apps and plugins show up here the moment they pass review. " +
-                        "Yours can be the first one.",
+                    stringResource(Res.string.store_empty_hero_body),
                     style = MaterialTheme.typography.bodyMedium,
                     color = c.onPrimaryContainer.copy(alpha = 0.82f),
                     modifier = Modifier.padding(top = 10.dp),
@@ -121,7 +151,11 @@ fun EmptyStoreHero(
                         ) {
                             Symbol(CaSymbols.upload, contentDescription = null, size = 20.dp)
                             Text(
-                                if (hasSubmission) "Publish another" else "Publish a project",
+                                if (hasSubmission) {
+                                    stringResource(Res.string.store_publish_another)
+                                } else {
+                                    stringResource(Res.string.store_publish_cta)
+                                },
                                 style = MaterialTheme.typography.labelLarge,
                             )
                         }
@@ -135,7 +169,7 @@ fun EmptyStoreHero(
                         modifier = Modifier.height(46.dp),
                     ) {
                         Box(Modifier.padding(horizontal = 20.dp), contentAlignment = Alignment.Center) {
-                            Text("Publishing guide", style = MaterialTheme.typography.labelLarge)
+                            Text(stringResource(Res.string.store_publishing_guide), style = MaterialTheme.typography.labelLarge)
                         }
                     }
                 }
@@ -189,19 +223,19 @@ fun PublishingSteps(steps: List<PublishStep>, modifier: Modifier = Modifier) {
 }
 
 /** The default copy for [PublishingSteps]. Kept beside the component so the two cannot drift apart. */
-val defaultPublishSteps: List<PublishStep> = listOf(
+@Composable
+fun defaultPublishSteps(): List<PublishStep> = listOf(
     PublishStep(
-        "Pick a project from Home",
-        "Choose any local project. CodeAssist reads its name, language, JDK and Gradle setup for you — " +
-            "nothing to write by hand.",
+        stringResource(Res.string.store_step_pick_title),
+        stringResource(Res.string.store_step_pick_body),
     ),
     PublishStep(
-        "Fill in the listing",
-        "Title, a short description, category and screenshots — captured from your editor inside the app.",
+        stringResource(Res.string.store_step_listing_title),
+        stringResource(Res.string.store_step_listing_body),
     ),
     PublishStep(
-        "Submit for review",
-        "We build it on a clean machine and a human checks licensing and the README. Usually two business days.",
+        stringResource(Res.string.store_step_submit_title),
+        stringResource(Res.string.store_step_submit_body),
     ),
 )
 
@@ -225,6 +259,9 @@ fun NotifySwitchRow(
     message: String? = null,
 ) {
     val c = MaterialTheme.colorScheme
+    // Resolved outside the semantics block: stringResource is composable-only.
+    val stateOn = stringResource(Res.string.store_notify_state_on)
+    val stateOff = stringResource(Res.string.store_notify_state_off)
     Surface(
         shape = RoundedCornerShape(26.dp),
         color = c.surfaceContainerLow,
@@ -238,12 +275,12 @@ fun NotifySwitchRow(
         ) {
             Column(Modifier.weight(1f)) {
                 Text(
-                    "Tell me when projects arrive",
+                    stringResource(Res.string.store_notify_title),
                     style = MaterialTheme.typography.titleSmall,
                     color = c.onSurface,
                 )
                 Text(
-                    message ?: "One notification, only for the first batch.",
+                    message ?: stringResource(Res.string.store_notify_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     // The failure takes over the supporting line rather than adding a row: it replaces the
                     // promise it just failed to keep.
@@ -257,7 +294,7 @@ fun NotifySwitchRow(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
                 modifier = Modifier.semantics {
-                    stateDescription = if (checked) "Notifications on" else "Notifications off"
+                    stateDescription = if (checked) stateOn else stateOff
                 },
             )
         }
@@ -282,19 +319,36 @@ fun SubmissionStatusCard(
     val c = MaterialTheme.colorScheme
     val (line, actionLabel, action) = when (submission.status) {
         UiSubmissionStatus.SUBMITTED ->
-            Triple("In review · usually 2 business days", "Withdraw", onWithdraw)
+            Triple(
+                stringResource(Res.string.store_status_submitted),
+                stringResource(Res.string.store_action_withdraw),
+                onWithdraw,
+            )
         UiSubmissionStatus.BUILDING ->
-            Triple("Building on a clean machine", "Withdraw", onWithdraw)
+            Triple(
+                stringResource(Res.string.store_status_building),
+                stringResource(Res.string.store_action_withdraw),
+                onWithdraw,
+            )
         UiSubmissionStatus.CHANGES_REQUESTED ->
-            Triple("Changes requested — read the notes", "View notes", onViewNotes)
+            Triple(
+                stringResource(Res.string.store_status_changes),
+                stringResource(Res.string.store_action_view_notes),
+                onViewNotes,
+            )
         UiSubmissionStatus.REJECTED ->
             Triple(
-                submission.note?.let { "Not accepted · $it" } ?: "Not accepted",
-                "Read why",
+                submission.note?.let { stringResource(Res.string.store_status_rejected_note, it) }
+                    ?: stringResource(Res.string.store_status_rejected),
+                stringResource(Res.string.store_action_read_why),
                 onViewNotes,
             )
         UiSubmissionStatus.PUBLISHED ->
-            Triple("Live in the store", "View listing", onViewListing)
+            Triple(
+                stringResource(Res.string.store_status_published),
+                stringResource(Res.string.store_action_view_listing),
+                onViewListing,
+            )
     }
     // Only the in-flight states spin; a finished one holding an animation would read as still working.
     val spinning = submission.status == UiSubmissionStatus.SUBMITTED ||
@@ -376,8 +430,9 @@ private fun SpinningGlyph(glyph: Char, spinning: Boolean, tint: Color) {
  * Different from the sparse state's on purpose: with nothing published, the honest thing to state is the
  * **condition** that fills the shelf, not a threshold the reader is nowhere near.
  */
+@Composable
 fun emptyGhostNote(key: String): String = when (key) {
-    "charts" -> "Ranks appear once projects have a week of install history."
-    "collections" -> "Curated shelves are assembled by the team from published projects."
-    else -> "Recommendations need your install history — install something first."
+    "charts" -> stringResource(Res.string.store_ghost_charts_note)
+    "collections" -> stringResource(Res.string.store_ghost_collections_note)
+    else -> stringResource(Res.string.store_ghost_recommend_note)
 }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/StoreSparse.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/components/StoreSparse.kt
@@ -36,6 +36,30 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.ide.ui.backend.UiGhostShelf
 import dev.ide.ui.backend.UiStoreItem
+import dev.ide.ui.generated.resources.Res
+import dev.ide.ui.generated.resources.store_action_use
+import dev.ide.ui.generated.resources.store_badge_cd
+import dev.ide.ui.generated.resources.store_badge_first
+import dev.ide.ui.generated.resources.store_badge_new
+import dev.ide.ui.generated.resources.store_ghost_count_cd
+import dev.ide.ui.generated.resources.store_how_it_works
+import dev.ide.ui.generated.resources.store_not_rated
+import dev.ide.ui.generated.resources.store_ordinal_fifth
+import dev.ide.ui.generated.resources.store_ordinal_fourth
+import dev.ide.ui.generated.resources.store_ordinal_second
+import dev.ide.ui.generated.resources.store_ordinal_third
+import dev.ide.ui.generated.resources.store_perk_direct_line
+import dev.ide.ui.generated.resources.store_perk_front_page
+import dev.ide.ui.generated.resources.store_pitch_body
+import dev.ide.ui.generated.resources.store_pitch_eyebrow
+import dev.ide.ui.generated.resources.store_pitch_next
+import dev.ide.ui.generated.resources.store_pitch_ordinal_full
+import dev.ide.ui.generated.resources.store_pitch_subject
+import dev.ide.ui.generated.resources.store_pitch_subject_one
+import dev.ide.ui.generated.resources.store_project_count
+import dev.ide.ui.generated.resources.store_publish_cta
+import org.jetbrains.compose.resources.pluralStringResource
+import org.jetbrains.compose.resources.stringResource
 import dev.ide.ui.icons.CaSymbols
 import dev.ide.ui.theme.Symbol
 import dev.ide.ui.theme.cardShape
@@ -59,18 +83,18 @@ import dev.ide.ui.theme.tonalPair
 @Composable
 fun StoreCountBadge(count: Int, modifier: Modifier = Modifier) {
     val c = MaterialTheme.colorScheme
+    // Resolved outside the semantics block: stringResource is composable-only.
+    val cd = stringResource(Res.string.store_badge_cd, count)
+    val label = pluralStringResource(Res.plurals.store_project_count, count, count)
     Surface(
         shape = RoundedCornerShape(9.dp),
         color = c.surfaceContainerHigh,
         contentColor = c.onSurfaceVariant,
         modifier = modifier.height(28.dp)
-            .semantics { contentDescription = "$count projects published" },
+            .semantics { contentDescription = cd },
     ) {
         Box(Modifier.padding(horizontal = 12.dp), contentAlignment = Alignment.Center) {
-            Text(
-                if (count == 1) "1 PROJECT" else "$count PROJECTS",
-                style = MaterialTheme.typography.labelSmall,
-            )
+            Text(label, style = MaterialTheme.typography.labelSmall)
         }
     }
 }
@@ -232,7 +256,7 @@ private fun RatingLine(item: UiStoreItem, onContainer: Color) {
             )
         } else {
             Text(
-                "Not rated yet",
+                stringResource(Res.string.store_not_rated),
                 style = MaterialTheme.typography.labelLarge,
                 color = onContainer.copy(alpha = 0.75f),
             )
@@ -248,9 +272,10 @@ private fun RatingLine(item: UiStoreItem, onContainer: Color) {
  *
  * Index 0 is the shelf's first project; index 1 gets "NEW" only when it is genuinely recent.
  */
+@Composable
 private fun sparseBadge(index: Int, isRecent: Boolean): String? = when {
-    index == 0 -> "FIRST ON THE SHELF"
-    index == 1 && isRecent -> "NEW"
+    index == 0 -> stringResource(Res.string.store_badge_first)
+    index == 1 && isRecent -> stringResource(Res.string.store_badge_new)
     else -> null
 }
 
@@ -284,7 +309,7 @@ fun PublishPitchBand(
                 modifier = Modifier.align(Alignment.BottomEnd).offset(x = 20.dp, y = 26.dp),
             )
             Column(Modifier.padding(20.dp)) {
-                Eyebrow("Shelves are still short", color = c.onPrimaryContainer.copy(alpha = 0.75f))
+                Eyebrow(stringResource(Res.string.store_pitch_eyebrow), color = c.onPrimaryContainer.copy(alpha = 0.75f))
                 Text(
                     pitchHeadline(projectCount),
                     style = MaterialTheme.typography.headlineSmall.copy(
@@ -295,8 +320,7 @@ fun PublishPitchBand(
                     modifier = Modifier.padding(top = 8.dp),
                 )
                 Text(
-                    "Everything published right now sits on this page — no ranking to climb, no back " +
-                        "pages to fall into. That stops being true later.",
+                    stringResource(Res.string.store_pitch_body),
                     style = MaterialTheme.typography.bodyMedium,
                     color = c.onPrimaryContainer.copy(alpha = 0.82f),
                     modifier = Modifier.padding(top = 8.dp),
@@ -319,7 +343,7 @@ fun PublishPitchBand(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             Symbol(CaSymbols.upload, contentDescription = null, size = 19.dp)
-                            Text("Publish a project", style = MaterialTheme.typography.labelLarge)
+                            Text(stringResource(Res.string.store_publish_cta), style = MaterialTheme.typography.labelLarge)
                         }
                     }
                     Surface(
@@ -331,7 +355,7 @@ fun PublishPitchBand(
                         modifier = Modifier.height(44.dp),
                     ) {
                         Box(Modifier.padding(horizontal = 18.dp), contentAlignment = Alignment.Center) {
-                            Text("How it works", style = MaterialTheme.typography.labelLarge)
+                            Text(stringResource(Res.string.store_how_it_works), style = MaterialTheme.typography.labelLarge)
                         }
                     }
                 }
@@ -341,8 +365,8 @@ fun PublishPitchBand(
                     Modifier.fillMaxWidth().padding(top = 18.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    PerkTile(CaSymbols.visibility, "Front page from day one", Modifier.weight(1f))
-                    PerkTile(CaSymbols.forum, "Direct line to the review team", Modifier.weight(1f))
+                    PerkTile(CaSymbols.visibility, stringResource(Res.string.store_perk_front_page), Modifier.weight(1f))
+                    PerkTile(CaSymbols.forum, stringResource(Res.string.store_perk_direct_line), Modifier.weight(1f))
                 }
             }
         }
@@ -373,16 +397,19 @@ private fun PerkTile(glyph: Char, label: String, modifier: Modifier = Modifier) 
  * Above five the ordinal starts sounding like a small club rather than an opportunity, so it switches to
  * "Yours would be next" — the handoff's own note on the copy.
  */
+@Composable
 internal fun pitchHeadline(count: Int): String {
-    val subject = if (count == 1) "One project in." else "$count projects in."
+    val subject = if (count == 1) stringResource(Res.string.store_pitch_subject_one)
+        else stringResource(Res.string.store_pitch_subject, count)
     val ordinal = when (count) {
-        1 -> "second"
-        2 -> "third"
-        3 -> "fourth"
-        4 -> "fifth"
+        1 -> stringResource(Res.string.store_ordinal_second)
+        2 -> stringResource(Res.string.store_ordinal_third)
+        3 -> stringResource(Res.string.store_ordinal_fourth)
+        4 -> stringResource(Res.string.store_ordinal_fifth)
         else -> null
     }
-    return if (ordinal != null) "$subject Yours would be the $ordinal." else "$subject Yours would be next."
+    return if (ordinal != null) stringResource(Res.string.store_pitch_ordinal_full, subject, ordinal)
+        else stringResource(Res.string.store_pitch_next, subject)
 }
 
 /**
@@ -423,12 +450,14 @@ fun GhostShelfCard(
                 modifier = Modifier.weight(1f),
             )
             if (shelf != null) {
+                // Resolved outside the semantics block: stringResource is composable-only.
+                val shelfCountCd = stringResource(Res.string.store_ghost_count_cd, shelf.have, shelf.need)
                 Surface(
                     shape = RoundedCornerShape(8.dp),
                     color = c.surfaceContainer,
                     contentColor = c.onSurfaceVariant,
                     modifier = Modifier.height(24.dp).semantics {
-                        contentDescription = "${shelf.have} of ${shelf.need} projects needed"
+                        contentDescription = shelfCountCd
                     },
                 ) {
                     Box(Modifier.padding(horizontal = 10.dp), contentAlignment = Alignment.Center) {
@@ -497,7 +526,7 @@ fun BundledTemplateRow(
             }
             Surface(shape = CircleShape, color = c.primaryContainer, contentColor = c.onPrimaryContainer) {
                 Box(Modifier.height(34.dp).padding(horizontal = 15.dp), contentAlignment = Alignment.Center) {
-                    Text("Use", style = MaterialTheme.typography.labelMedium)
+                    Text(stringResource(Res.string.store_action_use), style = MaterialTheme.typography.labelMedium)
                 }
             }
         }

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorSheets.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/EditorSheets.kt
@@ -151,7 +151,7 @@ internal fun MoreSheetContent(
         Text(stringResource(Res.string.more), color = MaterialTheme.colorScheme.onSurface, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(start = 6.dp, top = 4.dp, bottom = 10.dp))
         actions.forEach { a ->
-            MoreRow(actionIcon(a.iconId), a.text, a.description ?: "") { a.perform(host) }
+            MoreRow(actionIcon(a.iconId), localizedUiActionText(a), localizedUiActionDescription(a) ?: "") { a.perform(host) }
         }
 
         // Performance-analytics opt-in lives here (a settings surface) rather than on the home screen, so it's

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/ExploreFeedScreen.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/ExploreFeedScreen.kt
@@ -37,6 +37,20 @@ import dev.ide.ui.backend.UiStoreFeed
 import dev.ide.ui.backend.UiStoreItem
 import dev.ide.ui.backend.UiStoreMode
 import dev.ide.ui.backend.UiStorePublisher
+import dev.ide.ui.generated.resources.store_bundled_subtitle
+import dev.ide.ui.generated.resources.store_bundled_title
+import dev.ide.ui.generated.resources.store_catalogue_subtitle
+import dev.ide.ui.generated.resources.store_collections_title
+import dev.ide.ui.generated.resources.store_ghost_next_title
+import dev.ide.ui.generated.resources.store_ghost_section_subtitle
+import dev.ide.ui.generated.resources.store_ghost_section_title
+import dev.ide.ui.generated.resources.store_ghostspec_charts_note
+import dev.ide.ui.generated.resources.store_ghostspec_collections_note
+import dev.ide.ui.generated.resources.store_ghostspec_rec_note
+import dev.ide.ui.generated.resources.store_ghostspec_rec_title
+import dev.ide.ui.generated.resources.store_how_publishing_title
+import dev.ide.ui.generated.resources.store_meta_offline
+import dev.ide.ui.generated.resources.store_top_charts
 import dev.ide.ui.generated.resources.store_signin_title
 import dev.ide.ui.components.SquareToneButton
 import dev.ide.ui.components.inFlight
@@ -64,6 +78,7 @@ import dev.ide.ui.components.StoreCountBadge
 import dev.ide.ui.components.TrendingTicker
 import dev.ide.ui.components.chartMeta
 import dev.ide.ui.components.motifFor
+import org.jetbrains.compose.resources.stringResource
 import dev.ide.ui.icons.CaSymbols
 import dev.ide.ui.theme.tonalPair
 import dev.ide.ui.generated.resources.Res
@@ -210,7 +225,7 @@ fun ExploreFeed(
 
                     is UiFeedSection.Catalogue -> {
                         item("head_${section.id}") {
-                            SectionHeader(section.title, subtitle = "newest first")
+                            SectionHeader(section.title, subtitle = stringResource(Res.string.store_catalogue_subtitle))
                         }
                         itemsIndexed(section.items, key = { _, it -> "cat_${it.id}" }) { i, item ->
                             Spacer(Modifier.height(12.dp))
@@ -243,15 +258,15 @@ fun ExploreFeed(
                         if (bundled.isNotEmpty()) {
                             item("head_${section.id}") {
                                 SectionHeader(
-                                    "Bundled with your IDE",
-                                    subtitle = "Offline scaffolds that ship with the install.",
+                                    stringResource(Res.string.store_bundled_title),
+                                    subtitle = stringResource(Res.string.store_bundled_subtitle),
                                 )
                             }
                             itemsIndexed(bundled, key = { _, it -> "bundled_${it.id}" }) { i, item ->
                                 Spacer(Modifier.height(10.dp))
                                 BundledTemplateRow(
                                     title = item.title,
-                                    meta = listOfNotNull(item.language, "offline").joinToString(" · "),
+                                    meta = listOfNotNull(item.language, stringResource(Res.string.store_meta_offline)).joinToString(" · "),
                                     iconId = item.iconId,
                                     index = i,
                                     onUse = { onUseBundled(item) },
@@ -263,8 +278,8 @@ fun ExploreFeed(
                     is UiFeedSection.GhostShelves -> {
                         item("head_${section.id}") {
                             SectionHeader(
-                                "What unlocks as the store grows",
-                                subtitle = "Each shelf switches on when it has enough to rank.",
+                                stringResource(Res.string.store_ghost_section_title),
+                                subtitle = stringResource(Res.string.store_ghost_section_subtitle),
                             )
                         }
                         itemsIndexed(section.shelves, key = { _, it -> "ghost_${it.key}" }) { _, shelf ->
@@ -372,7 +387,7 @@ private fun ChartsSection(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Text(
-                "Top charts",
+                stringResource(Res.string.store_top_charts),
                 style = MaterialTheme.typography.headlineSmall,
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.weight(1f),
@@ -481,24 +496,25 @@ private data class GhostSpec(
     val slotCount: Int,
 )
 
+@Composable
 private fun ghostSpec(key: String, need: Int): GhostSpec = when (key) {
     "charts" -> GhostSpec(
-        title = "Top charts",
-        note = "Ranking starts at $need projects — a chart of four is just the list above.",
+        title = stringResource(Res.string.store_top_charts),
+        note = stringResource(Res.string.store_ghostspec_charts_note, need),
         glyph = CaSymbols.trendingUp,
         slotHeight = 46.dp,
         slotCount = 3,
     )
     "collections" -> GhostSpec(
-        title = "Collections",
-        note = "The team builds a collection once there are enough projects to theme one.",
+        title = stringResource(Res.string.store_collections_title),
+        note = stringResource(Res.string.store_ghostspec_collections_note),
         glyph = CaSymbols.rocketLaunch,
         slotHeight = 72.dp,
         slotCount = 2,
     )
     else -> GhostSpec(
-        title = "Because you installed…",
-        note = "Recommendations need install history across several projects.",
+        title = stringResource(Res.string.store_ghostspec_rec_title),
+        note = stringResource(Res.string.store_ghostspec_rec_note),
         glyph = CaSymbols.hub,
         slotHeight = 60.dp,
         slotCount = 3,
@@ -568,22 +584,22 @@ private fun ExploreEmpty(
                         modifier = Modifier.padding(top = 4.dp),
                     )
                 }
-                item("steps_head") { SectionHeader("How publishing works") }
-                item("steps") { PublishingSteps(defaultPublishSteps) }
+                item("steps_head") { SectionHeader(stringResource(Res.string.store_how_publishing_title)) }
+                item("steps") { PublishingSteps(defaultPublishSteps()) }
             }
 
             if (bundled.isNotEmpty()) {
                 item("bundled_head") {
                     SectionHeader(
-                        "Bundled with your IDE",
-                        subtitle = "Offline scaffolds that ship with the install.",
+                        stringResource(Res.string.store_bundled_title),
+                        subtitle = stringResource(Res.string.store_bundled_subtitle),
                     )
                 }
                 itemsIndexed(bundled, key = { _, it -> "bundled_${it.id}" }) { i, item ->
                     Spacer(Modifier.height(10.dp))
                     BundledTemplateRow(
                         title = item.title,
-                        meta = listOfNotNull(item.language, "offline").joinToString(" · "),
+                        meta = listOfNotNull(item.language, stringResource(Res.string.store_meta_offline)).joinToString(" · "),
                         iconId = item.iconId,
                         index = i,
                         onUse = { onUseBundled(item) },
@@ -591,7 +607,7 @@ private fun ExploreEmpty(
                 }
             }
 
-            item("ghosts_head") { SectionHeader("What lands here next") }
+            item("ghosts_head") { SectionHeader(stringResource(Res.string.store_ghost_next_title)) }
             // No progress counters here: at zero there is nothing to be partway toward, so each note
             // states the CONDITION that fills the shelf instead.
             itemsIndexed(EMPTY_GHOSTS, key = { _, k -> "ghost_$k" }) { _, key ->

--- a/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/UiActionLocalization.kt
+++ b/ide-ui/src/commonMain/kotlin/dev/ide/ui/screens/UiActionLocalization.kt
@@ -1,0 +1,54 @@
+package dev.ide.ui.screens
+
+import androidx.compose.runtime.Composable
+import dev.ide.ui.ext.UiHostAction
+import dev.ide.ui.generated.resources.*
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * A localization overlay for the built-in UI actions (the "More" menu rows and the command palette's
+ * UI-navigation commands). Their titles/descriptions are declared in `ide-ui-api`
+ * ([dev.ide.ui.ext.BuiltInUiPlugin]) as plain English — the plugin API carries plain strings (third-party
+ * plugins have no Compose-resource access), so rather than translate there, the UI maps a built-in action id
+ * to a string resource here and resolves it at render time.
+ *
+ * Same OVERRIDE pattern as [SettingsLocalization]: where a resource exists it wins, otherwise the
+ * plugin-supplied string is used verbatim, keeping third-party plugin actions working (unknown ids fall
+ * through).
+ *
+ * Keys mirror the [dev.ide.ui.ext.SimpleUiAction] ids.
+ */
+
+// Action title, by action id.
+private val ACTION_TITLE: Map<String, StringResource> = mapOf(
+    "ui.hub" to Res.string.action_hub,
+    "ui.modules" to Res.string.action_modules,
+    "ui.icons" to Res.string.action_icons,
+    "ui.dependencies" to Res.string.action_dependencies,
+    "ui.reindex" to Res.string.action_reindex,
+    "ui.logs" to Res.string.action_logs,
+    "ui.toggleTheme" to Res.string.action_toggle_theme,
+    "ui.closeProject" to Res.string.action_close_project,
+)
+
+// Action description, by action id (only the built-ins that carry one).
+private val ACTION_DESC: Map<String, StringResource> = mapOf(
+    "ui.hub" to Res.string.action_hub_desc,
+    "ui.modules" to Res.string.action_modules_desc,
+    "ui.icons" to Res.string.action_icons_desc,
+    "ui.reindex" to Res.string.action_reindex_desc,
+    "ui.logs" to Res.string.action_logs_desc,
+    "ui.toggleTheme" to Res.string.action_toggle_theme_desc,
+    "ui.closeProject" to Res.string.action_close_project_desc,
+)
+
+/** The localized title for a built-in UI action; the plugin-supplied title for a third-party action. */
+@Composable
+fun localizedUiActionText(action: UiHostAction): String =
+    ACTION_TITLE[action.id]?.let { stringResource(it) } ?: action.text
+
+/** The localized description for a built-in UI action, falling back to the plugin-supplied one (may be null). */
+@Composable
+fun localizedUiActionDescription(action: UiHostAction): String? =
+    ACTION_DESC[action.id]?.let { stringResource(it) } ?: action.description

--- a/vcs-ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/vcs-ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Panel chrome -->
+    <string name="vcs_title">Git</string>
+    <string name="vcs_refresh">刷新</string>
+    <string name="vcs_cancel">取消</string>
+    <string name="vcs_copy">复制</string>
+    <string name="vcs_copied">已复制</string>
+    <string name="vcs_open_in_browser">在浏览器中打开</string>
+
+    <!-- Empty and error states -->
+    <string name="vcs_not_a_repo_title">未纳入版本控制</string>
+    <string name="vcs_not_a_repo_body">使用 Git 跟踪此项目，即可保留更改历史、在分支上工作并推送到 GitHub。</string>
+    <string name="vcs_init">创建仓库</string>
+    <string name="vcs_clone">克隆仓库</string>
+    <string name="vcs_no_project">打开一个项目即可使用版本控制。</string>
+    <string name="vcs_clean_title">没有可提交的内容</string>
+    <string name="vcs_clean_body">你的工作区与最近一次提交一致。</string>
+
+    <!-- Branch header -->
+    <string name="vcs_branch">分支</string>
+    <string name="vcs_detached">游离 HEAD</string>
+    <string name="vcs_no_commits">尚无提交</string>
+    <string name="vcs_up_to_date">已是最新</string>
+    <string name="vcs_fetch">抓取</string>
+    <string name="vcs_pull">拉取</string>
+    <string name="vcs_push">推送</string>
+    <string name="vcs_history">历史</string>
+    <string name="vcs_file_history">此文件的历史</string>
+
+    <!-- Change sections -->
+    <string name="vcs_section_conflicts">冲突</string>
+    <string name="vcs_section_staged">已暂存</string>
+    <string name="vcs_section_changes">更改</string>
+    <string name="vcs_stage">暂存</string>
+    <string name="vcs_unstage">取消暂存</string>
+    <string name="vcs_stage_all">全部暂存</string>
+    <string name="vcs_unstage_all">全部取消暂存</string>
+    <string name="vcs_discard">丢弃</string>
+    <string name="vcs_discard_title">丢弃更改？</string>
+    <string name="vcs_discard_body">对 %1$s 的修改将被丢弃。此操作无法撤销。</string>
+    <string name="vcs_mark_resolved">标记为已解决</string>
+    <string name="vcs_abort_merge">中止合并</string>
+    <string name="vcs_merge_in_progress">合并进行中</string>
+    <string name="vcs_rebase_in_progress">变基进行中</string>
+    <string name="vcs_cherry_pick_in_progress">Cherry-pick 进行中</string>
+    <string name="vcs_revert_in_progress">回退进行中</string>
+    <string name="vcs_bisect_in_progress">二分查找进行中</string>
+
+    <!-- File status labels -->
+    <string name="vcs_status_added">已添加</string>
+    <string name="vcs_status_modified">已修改</string>
+    <string name="vcs_status_deleted">已删除</string>
+    <string name="vcs_status_renamed">已重命名</string>
+    <string name="vcs_status_copied">已复制</string>
+    <string name="vcs_status_untracked">新增</string>
+    <string name="vcs_status_conflicted">冲突</string>
+
+    <!-- Commit -->
+    <string name="vcs_commit_hint">提交信息</string>
+    <string name="vcs_commit">提交</string>
+    <string name="vcs_commit_and_push">提交并推送</string>
+    <string name="vcs_amend">修正上次提交</string>
+    <string name="vcs_nothing_staged">先暂存文件才能提交。</string>
+    <string name="vcs_identity_missing">提交前请先设置姓名和邮箱。</string>
+    <string name="vcs_set_identity">设置身份信息</string>
+    <string name="vcs_name">姓名</string>
+    <string name="vcs_email">邮箱</string>
+    <string name="vcs_save">保存</string>
+
+    <!-- Branches screen -->
+    <string name="vcs_branches">分支</string>
+    <string name="vcs_branches_search">搜索分支</string>
+    <string name="vcs_branches_local">本地</string>
+    <string name="vcs_branches_remote">远程</string>
+    <string name="vcs_branches_none">没有匹配的分支。</string>
+    <string name="vcs_new_branch">新建分支</string>
+    <string name="vcs_new_branch_hint">分支名称</string>
+    <string name="vcs_create">创建</string>
+    <string name="vcs_current_branch">当前</string>
+    <string name="vcs_merge_into">合并到 %1$s</string>
+    <string name="vcs_delete">删除</string>
+    <string name="vcs_delete_branch_title">删除 %1$s？</string>
+    <string name="vcs_delete_branch_body">该分支将从本地移除。仅存在于该分支上的提交可能会丢失。</string>
+    <string name="vcs_force_delete">仍要删除</string>
+
+    <!-- History screen -->
+    <string name="vcs_history_empty">尚无提交。</string>
+    <string name="vcs_load_more">加载更多</string>
+    <string name="vcs_commit_files">%1$d 个文件更改</string>
+    <string name="vcs_insertions">+%1$d</string>
+    <string name="vcs_deletions">-%1$d</string>
+    <string name="vcs_merge_commit">合并</string>
+
+    <!-- Diff -->
+    <string name="vcs_diff">差异</string>
+    <string name="vcs_diff_empty">没有文本差异。</string>
+    <string name="vcs_diff_binary">二进制文件，没有可显示的文本差异。</string>
+
+    <!-- Stash -->
+    <string name="vcs_stash">贮藏</string>
+    <string name="vcs_stashes">贮藏列表</string>
+    <string name="vcs_stash_changes">贮藏更改</string>
+    <string name="vcs_stash_hint">描述（可选）</string>
+    <string name="vcs_stash_untracked">包含未跟踪的文件</string>
+    <string name="vcs_stash_apply">应用</string>
+    <string name="vcs_stash_drop">丢弃</string>
+    <string name="vcs_stash_empty">没有贮藏的内容。</string>
+
+    <!-- Ignore -->
+    <string name="vcs_add_ignores">添加默认 .gitignore 条目</string>
+
+    <!-- Accounts -->
+    <string name="vcs_accounts">账号</string>
+    <string name="vcs_sign_in_github">使用 GitHub 登录</string>
+    <string name="vcs_sign_in_intro">登录后可克隆你的私有仓库、通过 HTTPS 免密码推送，以及创建拉取请求。</string>
+    <string name="vcs_sign_out">退出登录</string>
+    <string name="vcs_active_account">用于 Git 操作</string>
+    <string name="vcs_use_account">使用此账号</string>
+    <string name="vcs_device_code_title">在 GitHub 上输入此代码</string>
+    <string name="vcs_device_code_body">打开 %1$s 并输入代码。你批准后此页面会立即更新。</string>
+    <string name="vcs_signing_in">等待批准…</string>
+    <string name="vcs_sign_in_token">使用访问令牌</string>
+    <string name="vcs_token_hint">个人访问令牌</string>
+    <string name="vcs_token_help">在 GitHub 的 Settings、Developer settings、Personal access tokens 中创建一个带有 "repo" 权限范围的令牌。</string>
+    <string name="vcs_sign_in">登录</string>
+    <string name="vcs_other_servers">其他 Git 服务器</string>
+    <string name="vcs_other_servers_body">为不支持账号登录的服务器保存用户名和密码，例如自托管的 GitLab 或 Gitea。</string>
+    <string name="vcs_host">主机</string>
+    <string name="vcs_host_hint">git.example.com</string>
+    <string name="vcs_username">用户名</string>
+    <string name="vcs_password">密码或令牌</string>
+    <string name="vcs_saved_hosts">已保存的服务器</string>
+    <string name="vcs_remove">移除</string>
+
+    <!-- Clone -->
+    <string name="vcs_clone_title">克隆仓库</string>
+    <string name="vcs_clone_url">仓库 URL</string>
+    <string name="vcs_clone_folder">文件夹名称</string>
+    <string name="vcs_clone_action">克隆</string>
+    <string name="vcs_clone_yours">你的仓库</string>
+    <string name="vcs_clone_search">搜索仓库</string>
+    <string name="vcs_clone_sign_in">登录后即可浏览你的仓库。</string>
+    <string name="vcs_clone_none">未找到仓库。</string>
+    <string name="vcs_clone_unrecognized_title">无法识别的项目</string>
+    <string name="vcs_clone_unrecognized_body">%1$s 已克隆并添加到你的项目中，但没有构建系统能识别它。你可以浏览和编辑其文件；构建和运行需要先设置好模块。</string>
+    <string name="vcs_clone_unrecognized_open">以编辑方式打开</string>
+    <string name="vcs_private">私有</string>
+    <string name="vcs_fork">Fork</string>
+
+    <!-- GitHub screen -->
+    <string name="vcs_github">GitHub</string>
+    <string name="vcs_publish_title">发布到 GitHub</string>
+    <string name="vcs_publish_body">为此项目创建一个仓库，并将当前分支推送到该仓库。</string>
+    <string name="vcs_publish_name">仓库名称</string>
+    <string name="vcs_publish_description">描述（可选）</string>
+    <string name="vcs_publish_private">私有仓库</string>
+    <string name="vcs_publish">发布</string>
+    <string name="vcs_publish_needs_commit">发布前请先进行一次提交。</string>
+    <string name="vcs_pull_requests">拉取请求</string>
+    <string name="vcs_pull_requests_empty">没有开启中的拉取请求。</string>
+    <string name="vcs_new_pull_request">新建拉取请求</string>
+    <string name="vcs_pr_title">标题</string>
+    <string name="vcs_pr_body">描述</string>
+    <string name="vcs_pr_base">合并到</string>
+    <string name="vcs_pr_create">创建拉取请求</string>
+    <string name="vcs_pr_from">来自 %1$s</string>
+    <string name="vcs_draft">草稿</string>
+
+    <!-- Remotes -->
+    <string name="vcs_remotes">远程仓库</string>
+    <string name="vcs_add_remote">添加远程仓库</string>
+    <string name="vcs_remote_name">远程仓库名称</string>
+    <string name="vcs_remote_url">远程仓库 URL</string>
+    <string name="vcs_no_remote">此项目还没有远程仓库。</string>
+
+    <!-- Plain-language hints and menu wording. Git's own vocabulary is the main thing newcomers trip on, so
+         each group of files says what it is and every occasional action is a worded menu row. -->
+    <string name="vcs_hint_conflicts">双方都修改了这些文件。逐个修复后，再将其标记为已解决。</string>
+    <string name="vcs_hint_staged">已就绪待提交。这些文件会进入你的下一次提交。</string>
+    <string name="vcs_hint_changes">已修改但尚未纳入。暂存文件即可将其加入下一次提交。</string>
+    <string name="vcs_hint_commit">提交会将已暂存的文件保存为快照，仅保存在本设备上。</string>
+    <string name="vcs_hint_push">推送会将你的提交发送到远程仓库，让其他人可以看到。</string>
+
+    <string name="vcs_menu_more">更多操作</string>
+    <string name="vcs_menu_repository">仓库</string>
+    <string name="vcs_menu_file">此文件</string>
+    <string name="vcs_menu_view_changes">查看更改</string>
+    <string name="vcs_menu_file_history">文件历史</string>
+    <string name="vcs_menu_sync">同步</string>
+    <string name="vcs_tooltip_refresh">重新读取文件状态</string>
+    <string name="vcs_tooltip_history">浏览历史提交</string>
+    <string name="vcs_tooltip_fetch">检查远程是否有新提交，不改动你的文件</string>
+    <string name="vcs_tooltip_pull">将远程的提交拉入你的分支</string>
+    <string name="vcs_tooltip_push">将你的提交发送到远程仓库</string>
+    <string name="vcs_tooltip_github">你的 GitHub 账号、发布和拉取请求</string>
+    <string name="vcs_tooltip_stage">将此文件加入下一次提交</string>
+    <string name="vcs_tooltip_unstage">将此文件移出下一次提交</string>
+    <string name="vcs_tooltip_stage_all">将所有已更改的文件加入下一次提交</string>
+    <string name="vcs_tooltip_unstage_all">将所有文件移出下一次提交</string>
+    <string name="vcs_tooltip_discard">丢弃你对这个文件的修改</string>
+    <string name="vcs_tooltip_resolved">按当前内容接受此文件</string>
+    <string name="vcs_tooltip_branch">%1$s。点按可切换或新建分支。</string>
+    <string name="vcs_push_after_commit">提交后推送</string>
+    <string name="vcs_no_remote_short">未设置远程仓库</string>
+    <string name="vcs_set_up_remote">连接到 GitHub</string>
+    <string name="vcs_sign_out_of">退出 %1$s</string>
+    <string name="vcs_checkout_branch">切换到此分支</string>
+    <string name="vcs_delete_branch">删除分支</string>
+    <string name="vcs_merge_into_current">合并到当前分支</string>
+</resources>


### PR DESCRIPTION
## What

Two related halves, both around Simplified Chinese support:

**1. Fill the gaps in `values-zh`.**

`ide-ui` was missing ~350 strings (en has 1458, zh had 1139), `agent-ui` was missing 2, and `vcs-ui` had no zh file at all — now filled in. Existing translations are left untouched, and everything is verified 1:1 against `values/` (key parity + placeholder parity via a script). Missing keys fall back to English anyway, but now nothing on screen has to.

**2. Extract the copy that was hardcoded in composables.**

A bunch of UI text never went through the resource files at all, so translations could never reach it:

- the Explore screen's empty/sparse states (hero, publishing steps, pitch band, ghost shelves…)
- the built-in UI actions (the "More" menu rows and the palette's UI-navigation commands)

These now live in `values/strings.xml` (original English verbatim) with zh translations, following the existing key style.

The More-menu actions are a special case: they're contributed through the plugin API (`ide-ui-api`) as plain strings, and third-party plugins have no access to Compose resources. So I followed the same override pattern as `SettingsLocalization` — a new `UiActionLocalization.kt` maps built-in action ids to resources at render time and falls back to the plugin-supplied string for unknown ids, so third-party plugin actions keep working unchanged.

To call `stringResource`, five small helpers became `@Composable` (`defaultPublishSteps`, `emptyGhostNote`, `ghostSpec`, `sparseBadge`, `pitchHeadline`) — no behavior changes otherwise.

## Notes

- `app_name` stays "CodeAssist" (brand name, not translated)
- Brand and technical names (Gradle, Logcat, BOM…) stay in English inside the translations
- Author comments are untouched; new comments follow the existing style

Happy to adjust any wording — and if you'd rather split this into two PRs (pure translation fill vs. the extraction), say the word.